### PR TITLE
Removes borders for 'winning' matches in 2015

### DIFF
--- a/the-blue-alliance-ios/TBAMatchTableViewCell.m
+++ b/the-blue-alliance-ios/TBAMatchTableViewCell.m
@@ -78,7 +78,7 @@
     }
 
     // Everyone is a winner in 2015 ╮ (. ❛ ᴗ ❛.) ╭
-    if (_match.event.year.integerValue == 2015) {
+    if (_match.event.year.integerValue == 2015 && _match.compLevel.integerValue != CompLevelFinal) {
         self.redContainerView.layer.borderWidth = 0.0f;
         self.blueContainerView.layer.borderWidth = 0.0f;
     } else if (_match.redScore > _match.blueScore) {

--- a/the-blue-alliance-ios/TBAMatchTableViewCell.m
+++ b/the-blue-alliance-ios/TBAMatchTableViewCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "TBAMatchTableViewCell.h"
+#import "Event.h"
 
 @interface TBAMatchTableViewCell ()
 
@@ -76,7 +77,11 @@
         self.blueScoreLabel.hidden = NO;
     }
 
-    if (_match.redScore > _match.blueScore) {
+    // Everyone is a winner in 2015 ╮ (. ❛ ᴗ ❛.) ╭
+    if (_match.event.year.integerValue == 2015) {
+        self.redContainerView.layer.borderWidth = 0.0f;
+        self.blueContainerView.layer.borderWidth = 0.0f;
+    } else if (_match.redScore > _match.blueScore) {
         self.redContainerView.layer.borderWidth = 2.0f;
         self.blueContainerView.layer.borderWidth = 0.0f;
     } else if (_match.blueScore > _match.redScore) {


### PR DESCRIPTION
Web/Android does the same thing - no "winners" in 2015 except for the finals