### PR TITLE
Keep previous subview colors in match cell during selection

### DIFF
--- a/the-blue-alliance-ios/Base.lproj/Main.storyboard
+++ b/the-blue-alliance-ios/Base.lproj/Main.storyboard
@@ -154,7 +154,7 @@
                     <navigationItem key="navigationItem" id="4pe-f2-zA2">
                         <nil key="title"/>
                         <view key="titleView" contentMode="scaleToFill" id="c4L-OJ-CrB">
-                            <rect key="frame" x="236" y="6" width="128" height="33"/>
+                            <rect key="frame" x="236" y="5.5" width="128" height="33"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Districts" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g76-Fu-X7s">
@@ -723,7 +723,7 @@
                     <navigationItem key="navigationItem" id="uzj-dD-tNd">
                         <nil key="title"/>
                         <view key="titleView" contentMode="scaleToFill" id="mcY-gS-Ww7">
-                            <rect key="frame" x="236" y="6" width="128" height="33"/>
+                            <rect key="frame" x="236" y="5.5" width="128" height="33"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Team 2337" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PdT-FR-3pi">
@@ -802,7 +802,7 @@
                     <navigationItem key="navigationItem" id="nwE-Me-WJo">
                         <nil key="title"/>
                         <view key="titleView" contentMode="scaleToFill" id="id9-ex-69K">
-                            <rect key="frame" x="236" y="6" width="128" height="33"/>
+                            <rect key="frame" x="236" y="5.5" width="128" height="33"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Events" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A1f-8v-Cv4">

--- a/the-blue-alliance-ios/TBAMatchTableViewCell.m
+++ b/the-blue-alliance-ios/TBAMatchTableViewCell.m
@@ -28,6 +28,8 @@
 
 @property (nonatomic, weak) IBOutlet UILabel *timeLabel;
 
+@property (nonatomic, strong) NSArray<UIView *> *coloredViews;
+
 @end
 
 @implementation TBAMatchTableViewCell
@@ -37,6 +39,49 @@
     
     self.redContainerView.layer.borderColor = [UIColor redColor].CGColor;
     self.blueContainerView.layer.borderColor = [UIColor blueColor].CGColor;
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    NSArray<UIColor *> *colors = [self storeBaseColorsForView:self.coloredViews];
+    [super setSelected:selected animated:animated];
+    
+    if (selected){
+        [self restoreBaseColors:colors forViews:self.coloredViews];
+    }
+}
+
+-(void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated{
+    NSArray<UIColor *> *colors = [self storeBaseColorsForView:self.coloredViews];
+    [super setHighlighted:highlighted animated:animated];
+    
+    if (highlighted){
+        [self restoreBaseColors:colors forViews:self.coloredViews];
+    }
+}
+
+- (NSArray<UIColor *> *)storeBaseColorsForView:(NSArray<UIView *> *)views {
+    NSMutableArray *colors = [[NSMutableArray alloc] init];
+    for (UIView *view in views) {
+        [colors addObject:view.backgroundColor];
+    }
+    return colors;
+}
+
+- (void)restoreBaseColors:(NSArray<UIColor *> *)colors forViews:(NSArray<UIView *> *)views {
+    if (colors.count != views.count) {
+        return;
+    }
+
+    for (int i = 0; i < colors.count; i++) {
+        UIView *view = views[i];
+        view.backgroundColor = colors[i];
+    }
+}
+
+#pragma mark - Properities
+
+- (NSArray<UIView *> *)coloredViews {
+    return @[self.redContainerView, self.redScoreLabel, self.blueContainerView, self.blueScoreLabel];
 }
 
 - (void)setMatch:(Match *)match {


### PR DESCRIPTION
Makes sure the subviews in the match cell have the same background color during the selection state (screenshot attached), as opposed to the grey color. The other solution here is to disable the selection state for the match cells. 
![simulator screen shot dec 29 2015 12 38 49 am](https://cloud.githubusercontent.com/assets/516458/12029973/c23144be-adc4-11e5-88b2-33c8777d99c4.png)
