### PR TITLE
[closes #39] Auto select event week.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - OpenInGoogleMaps (0.1.0)
-  - TBAKit (1.1.2)
+  - TBAKit (1.1.3)
   - youtube-ios-player-helper (0.1.6)
 
 DEPENDENCIES:
@@ -10,7 +10,7 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   OpenInGoogleMaps: 60dd887d2e2b2149166a03bd6dab1d4478a7d3e8
-  TBAKit: 96f47ccc7268b9a7ece17b75e284818d7b7c7d80
+  TBAKit: d1382e28e66f5a88687a5c9fd1d0acfb3b6bfd85
   youtube-ios-player-helper: 21ab92db027c7ff86cb17a3843a3f6eafc8158d2
 
 COCOAPODS: 0.39.0

--- a/the-blue-alliance-ios/EventsViewController.m
+++ b/the-blue-alliance-ios/EventsViewController.m
@@ -36,11 +36,11 @@ static NSString *const EventViewControllerSegue  = @"EventViewControllerSegue";
 
 - (void)setWeeks:(NSArray<NSNumber *> *)weeks {
     _weeks = weeks;
-
+    
     if (weeks && !self.currentWeek) {
         self.currentWeek = self.currentYear.integerValue == [[NSCalendar currentCalendar] component:NSCalendarUnitYear fromDate:[NSDate date]] ?
         @([EventWeek eventOrderForDate:[NSDate date]]) :
-        @1;
+        @([EventWeek firstCompetitionWeekEventOrderForYear:self.currentYear.integerValue]);
         self.eventsViewController.week = self.currentWeek;
     }
 }

--- a/the-blue-alliance-ios/EventsViewController.m
+++ b/the-blue-alliance-ios/EventsViewController.m
@@ -36,9 +36,11 @@ static NSString *const EventViewControllerSegue  = @"EventViewControllerSegue";
 
 - (void)setWeeks:(NSArray<NSNumber *> *)weeks {
     _weeks = weeks;
-    
+
     if (weeks && !self.currentWeek) {
-        self.currentWeek = @([EventWeek eventOrderForDate:[NSDate date]]);
+        self.currentWeek = self.currentYear.integerValue == [[NSCalendar currentCalendar] component:NSCalendarUnitYear fromDate:[NSDate date]] ?
+        @([EventWeek eventOrderForDate:[NSDate date]]) :
+        @1;
         self.eventsViewController.week = self.currentWeek;
     }
 }

--- a/the-blue-alliance-ios/EventsViewController.m
+++ b/the-blue-alliance-ios/EventsViewController.m
@@ -117,7 +117,7 @@ static NSString *const EventViewControllerSegue  = @"EventViewControllerSegue";
 }
 
 - (IBAction)selectWeekButtonTapped:(id)sender {
-    if (!self.currentWeek) {
+    if (!self.weeks || self.weeks.count == 0 || !self.currentWeek) {
         return;
     }
     

--- a/the-blue-alliance-ios/EventsViewController.m
+++ b/the-blue-alliance-ios/EventsViewController.m
@@ -12,6 +12,7 @@
 #import "TBASelectYearViewController.h"
 #import "TBASelectViewController.h"
 #import "Event+Fetch.h"
+#import "Event.h"
 
 // TODO: Bring the events view to the current week, like the Android app
 
@@ -37,10 +38,8 @@ static NSString *const EventViewControllerSegue  = @"EventViewControllerSegue";
     _weeks = weeks;
     
     if (weeks && !self.currentWeek) {
-        NSNumber *week = weeks.firstObject;
-        
-        self.currentWeek = week;
-        self.eventsViewController.week = week;
+        self.currentWeek = @([EventWeek eventOrderForDate:[NSDate date]]);
+        self.eventsViewController.week = self.currentWeek;
     }
 }
 

--- a/the-blue-alliance-ios/Models/Event.h
+++ b/the-blue-alliance-ios/Models/Event.h
@@ -76,11 +76,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface EventWeek : NSObject
-+ (NSArray *)championshipWeeks;
-+ (NSArray *)firstCompitionWeeks;
++ (NSInteger)firstCompetitionWeekEventOrderForYear:(NSInteger)year;
++ (NSArray *)championshipCompetitionWeeks;
++ (NSArray *)firstCompetitionYearWeeks;
 + (NSInteger)eventOrderForDate:(NSDate *)date;
 + (NSInteger)competitionWeekForDate:(NSDate *)date;
-+ (NSInteger)championshipWeekForYear:(NSInteger)year;
++ (NSInteger)championshipCompetitionWeekForYear:(NSInteger)year;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/the-blue-alliance-ios/Models/Event.h
+++ b/the-blue-alliance-ios/Models/Event.h
@@ -75,4 +75,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface EventWeek : NSObject
++ (NSArray *)championshipWeeks;
++ (NSArray *)firstCompitionWeeks;
++ (NSInteger)eventOrderForDate:(NSDate *)date;
++ (NSInteger)competitionWeekForDate:(NSDate *)date;
++ (NSInteger)championshipWeekForYear:(NSInteger)year;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/the-blue-alliance-ios/Models/Event.m
+++ b/the-blue-alliance-ios/Models/Event.m
@@ -279,3 +279,68 @@
 }
 
 @end
+
+@implementation EventWeek
+
++ (NSInteger)eventOrderForDate:(NSDate *)date {
+    NSInteger year = [[NSCalendar currentCalendar] component:NSCalendarUnitYear fromDate:date];
+    NSInteger week;
+
+    if ([self competitionWeekForDate:[NSDate date]] == [self championshipWeekForYear:year]) {
+        week = EventOrderChampionship;
+    } else if ([self competitionWeekForDate:[NSDate date]] > [self championshipWeekForYear:year]) {
+        week = EventOrderOffseason;
+    } else if ([[NSCalendar currentCalendar] component:NSCalendarUnitWeekOfYear fromDate:date] < [self firstCompetitionWeekForYear:year]) {
+        week = EventOrderPreseason;
+    } else {
+        week = [self competitionWeekForDate:date];
+    }
+
+    return week;
+}
+
++ (NSArray *)firstCompitionWeeks {
+    return  @[@6, @8, @8, @7, @12, @9, @9, @8,         // 1992 - 1999
+              @0, @8, @9, @9, @9, @9, @8, @8, @8, @8,  // 2000 - 2009
+              @9, @9, @8, @8, @8, @8, @8];             // 2010 -
+
+}
+
++ (NSInteger)firstCompetitionWeekForYear:(NSInteger)year {
+    NSInteger offset = year - 1992;
+    if ([self firstCompitionWeeks].count > offset) {
+        return offset >= [self firstCompitionWeeks].count || offset < 0 ?
+        [[[self firstCompitionWeeks] objectAtIndex:([self firstCompitionWeeks].count)] integerValue] :
+        [[[self firstCompitionWeeks] objectAtIndex:offset] integerValue];
+    } else {
+        return [[[self firstCompitionWeeks] objectAtIndex:([self firstCompitionWeeks].count)] integerValue];
+    }
+}
+
++ (NSInteger)competitionWeekForDate:(NSDate *)date {
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSInteger selectedWeek = [calendar component:NSCalendarUnitWeekOfYear fromDate:[calendar dateByAddingUnit:NSCalendarUnitWeekOfYear
+                                                                                                        value:-1
+                                                                                                       toDate:date
+                                                                                                      options:NSCalendarWrapComponents]];
+    NSInteger week = (selectedWeek - [self firstCompetitionWeekForYear:[calendar component:NSCalendarUnitYear fromDate:date]]);
+    return week < 0 ? 0 : week;
+}
+
+
++ (NSArray *)championshipWeeks {
+    return @[@1, @1, @1, @6, @4, @6, @5, @9,               // 1992 - 1999
+             @5, @6, @8, @6, @7, @8, @7, @7, @8, @8,       // 2000 - 2009
+             @7, @9, @9, @9, @9, @9, @10];                 // 2010 -
+}
+
++ (NSInteger)championshipWeekForYear:(NSInteger)year {
+    NSInteger offset = year - 1992;
+    if ([self championshipWeeks].count > offset) {
+        return [[[self championshipWeeks] objectAtIndex:(offset - 1)] integerValue];
+    } else {
+        return [[[self championshipWeeks] objectAtIndex:([self championshipWeeks].count - 1)] integerValue];
+    }
+}
+
+@end

--- a/the-blue-alliance-ios/Models/Event.m
+++ b/the-blue-alliance-ios/Models/Event.m
@@ -282,13 +282,28 @@
 
 @implementation EventWeek
 
+// This class uses the NCCalendarUnit standard of calling week of the year a "Year Week".
+// A week into the competition season is called a "Competition Week".
+// 
+// Example: 'championshipYearWeekForYear' returns what week of the year championship falls on
+// based on what competition week it is.
+
+
++ (NSInteger)firstCompetitionWeekEventOrderForYear:(NSInteger)year {
+    if ([self championshipYearWeekForYear:year] == [self firstCompetitionWeekForYear:year]) {
+        return EventOrderChampionship;
+    } else {
+        return 1;
+    }
+}
+
 + (NSInteger)eventOrderForDate:(NSDate *)date {
     NSInteger year = [[NSCalendar currentCalendar] component:NSCalendarUnitYear fromDate:date];
     NSInteger week;
 
-    if ([self competitionWeekForDate:[NSDate date]] == [self championshipWeekForYear:year]) {
+    if ([self competitionWeekForDate:[NSDate date]] == [self championshipCompetitionWeekForYear:year]) {
         week = EventOrderChampionship;
-    } else if ([self competitionWeekForDate:[NSDate date]] > [self championshipWeekForYear:year]) {
+    } else if ([self competitionWeekForDate:[NSDate date]] > [self championshipCompetitionWeekForYear:year]) {
         week = EventOrderOffseason;
     } else if ([[NSCalendar currentCalendar] component:NSCalendarUnitWeekOfYear fromDate:date] < [self firstCompetitionWeekForYear:year]) {
         week = EventOrderPreseason;
@@ -299,7 +314,7 @@
     return week;
 }
 
-+ (NSArray *)firstCompitionWeeks {
++ (NSArray *)firstCompetitionYearWeeks {
     return  @[@6, @8, @8, @7, @12, @9, @9, @8,         // 1992 - 1999
               @0, @8, @9, @9, @9, @9, @8, @8, @8, @8,  // 2000 - 2009
               @9, @9, @8, @8, @8, @8, @8];             // 2010 -
@@ -308,12 +323,12 @@
 
 + (NSInteger)firstCompetitionWeekForYear:(NSInteger)year {
     NSInteger offset = year - 1992;
-    if ([self firstCompitionWeeks].count > offset) {
-        return offset >= [self firstCompitionWeeks].count || offset < 0 ?
-        [[[self firstCompitionWeeks] objectAtIndex:([self firstCompitionWeeks].count)] integerValue] :
-        [[[self firstCompitionWeeks] objectAtIndex:offset] integerValue];
+    if ([self firstCompetitionYearWeeks].count > offset) {
+        return offset >= [self firstCompetitionYearWeeks].count || offset < 0 ?
+        [[[self firstCompetitionYearWeeks] objectAtIndex:([self firstCompetitionYearWeeks].count)] integerValue] :
+        [[[self firstCompetitionYearWeeks] objectAtIndex:offset] integerValue];
     } else {
-        return [[[self firstCompitionWeeks] objectAtIndex:([self firstCompitionWeeks].count)] integerValue];
+        return [[[self firstCompetitionYearWeeks] objectAtIndex:([self firstCompetitionYearWeeks].count)] integerValue];
     }
 }
 
@@ -328,18 +343,24 @@
 }
 
 
-+ (NSArray *)championshipWeeks {
++ (NSArray *)championshipCompetitionWeeks {
     return @[@1, @1, @1, @6, @4, @6, @5, @9,               // 1992 - 1999
              @5, @6, @8, @6, @7, @8, @7, @7, @8, @8,       // 2000 - 2009
              @7, @9, @9, @9, @9, @9, @10];                 // 2010 -
 }
 
-+ (NSInteger)championshipWeekForYear:(NSInteger)year {
++ (NSInteger)championshipYearWeekForYear:(NSInteger)year {
+    return ([self championshipCompetitionWeekForYear:year] + [self firstCompetitionWeekForYear:year]) - 1;
+}
+
++ (NSInteger)championshipCompetitionWeekForYear:(NSInteger)year {
     NSInteger offset = year - 1992;
-    if ([self championshipWeeks].count > offset) {
-        return [[[self championshipWeeks] objectAtIndex:(offset - 1)] integerValue];
+    if (1995 >= year) {
+        return [[[self championshipCompetitionWeeks] objectAtIndex:offset] integerValue];
+    } else if ([self championshipCompetitionWeeks].count > offset) {
+        return [[[self championshipCompetitionWeeks] objectAtIndex:(offset - 1)] integerValue];
     } else {
-        return [[[self championshipWeeks] objectAtIndex:([self championshipWeeks].count - 1)] integerValue];
+        return [[[self championshipCompetitionWeeks] objectAtIndex:([self championshipCompetitionWeeks].count - 1)] integerValue];
     }
 }
 


### PR DESCRIPTION
Created an `EventWeek` class that holds a number of static methods (err class methods) that
determines what event week is for a given date. `EventViewController` uses this new class to
pre-select the current event week when first visiting event list.

Admittedly these methods are basically a complete rip off of what the android app has.
https://github.com/the-blue-alliance/the-blue-alliance-android/blob/c4948c3a560e3b73833197b92d24295027004afe/android/src/main/java/com/thebluealliance/androidclient/helpers/EventHelper.java#L98

https://github.com/the-blue-alliance/the-blue-alliance-android/blob/c4948c3a560e3b73833197b92d24295027004afe/android/src/main/java/com/thebluealliance/androidclient/helpers/EventHelper.java#L98