### PR TITLE
[Closes #55] Setup initial background fetch for all teams

### DIFF
--- a/the-blue-alliance-ios/AppDelegate.m
+++ b/the-blue-alliance-ios/AppDelegate.m
@@ -11,7 +11,6 @@
 #import "TBAViewController.h"
 #import "TBANavigationController.h"
 #import "TBANavigationControllerDelegate.h"
-#import "Team+Fetch.h"
 #import "OpenInGoogleMapsController.h"
 
 @interface AppDelegate ()
@@ -33,9 +32,6 @@
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
         UITabBarController *rootTabBarController = [storyboard instantiateViewControllerWithIdentifier:@"RootTabBarController"];
         self.navigationDelegate = [[TBANavigationControllerDelegate alloc] init];
-     
-        // Refresh all our teams, if we don't have any
-        [self setupTeamsForPersistenceController:self.persistenceController];
         
         // Pass persistence controller to all navigation controllers
         for (TBANavigationController *nav in rootTabBarController.viewControllers) {
@@ -103,24 +99,6 @@
     [navigationBarAppearance setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor]}];
     [navigationBarAppearance setShadowImage:[[UIImage alloc] init]];
     [navigationBarAppearance setBackgroundImage:[[UIImage alloc] init] forBarMetrics:UIBarMetricsDefault];
-}
-
-#pragma mark - Private Methods
-
-- (void)setupTeamsForPersistenceController:(TBAPersistenceController *)persistenceController {
-    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:[Team entityName]];
-    
-    NSError *error;
-    NSUInteger count = [persistenceController.backgroundManagedObjectContext countForFetchRequest:fetchRequest error:&error];
-    if (error) {
-        NSLog(@"Error setting up teams: %@", error);
-    } else if (count == 0) {
-        [Team fetchAllTeamsWithTaskIdChange:^(NSUInteger newTaskId, NSArray *batchTeam) {
-            [persistenceController performChanges:^{
-                [Team insertTeamsWithModelTeams:batchTeam inManagedObjectContext:persistenceController.backgroundManagedObjectContext];
-            }];
-        } withCompletionBlock:nil];
-    }
 }
 
 @end

--- a/the-blue-alliance-ios/AppDelegate.m
+++ b/the-blue-alliance-ios/AppDelegate.m
@@ -11,6 +11,7 @@
 #import "TBAViewController.h"
 #import "TBANavigationController.h"
 #import "TBANavigationControllerDelegate.h"
+#import "Team+Fetch.h"
 #import "OpenInGoogleMapsController.h"
 
 @interface AppDelegate ()
@@ -27,12 +28,16 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [OpenInGoogleMapsController sharedInstance].callbackURL = [NSURL URLWithString:@"tba://"];
     [OpenInGoogleMapsController sharedInstance].fallbackStrategy = kGoogleMapsFallbackAppleMaps;
-
+    
     [self setPersistenceController:[[TBAPersistenceController alloc] initWithCallback:^{
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
         UITabBarController *rootTabBarController = [storyboard instantiateViewControllerWithIdentifier:@"RootTabBarController"];
         self.navigationDelegate = [[TBANavigationControllerDelegate alloc] init];
+     
+        // Refresh all our teams, if we don't have any
+        [self setupTeamsForPersistenceController:self.persistenceController];
         
+        // Pass persistence controller to all navigation controllers
         for (TBANavigationController *nav in rootTabBarController.viewControllers) {
             nav.delegate = self.navigationDelegate;
             nav.persistenceController = self.persistenceController;
@@ -98,6 +103,24 @@
     [navigationBarAppearance setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor]}];
     [navigationBarAppearance setShadowImage:[[UIImage alloc] init]];
     [navigationBarAppearance setBackgroundImage:[[UIImage alloc] init] forBarMetrics:UIBarMetricsDefault];
+}
+
+#pragma mark - Private Methods
+
+- (void)setupTeamsForPersistenceController:(TBAPersistenceController *)persistenceController {
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:[Team entityName]];
+    
+    NSError *error;
+    NSUInteger count = [persistenceController.backgroundManagedObjectContext countForFetchRequest:fetchRequest error:&error];
+    if (error) {
+        NSLog(@"Error setting up teams: %@", error);
+    } else if (count == 0) {
+        [Team fetchAllTeamsWithTaskIdChange:^(NSUInteger newTaskId, NSArray *batchTeam) {
+            [persistenceController performChanges:^{
+                [Team insertTeamsWithModelTeams:batchTeam inManagedObjectContext:persistenceController.backgroundManagedObjectContext];
+            }];
+        } withCompletionBlock:nil];
+    }
 }
 
 @end


### PR DESCRIPTION
After building a downloader that hooked in to inserts for stub team objects, I realized it was way more complicated than it needed to be, and making far too many network requests. I suggest we just attempt to refresh teams on initial launch to fix the current stub team states. We could also set a last fetched date in NSUserDefaults and if we see we haven't done a batch refresh in a certain period to keep things in sync.