### PR TITLE
Fix team pages refresh

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - OrderedDictionary (1.2)
-  - TBAKit (1.1.3)
+  - TBAKit (1.1.4)
   - youtube-ios-player-helper (0.1.6)
 
 DEPENDENCIES:
@@ -10,7 +10,7 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   OrderedDictionary: 9cc5d69c5c5314ad696ed1839190724e83d534c7
-  TBAKit: d1382e28e66f5a88687a5c9fd1d0acfb3b6bfd85
+  TBAKit: 9cb2e72a66e3dcf283c6f7ff75b2a76ad336d721
   youtube-ios-player-helper: 21ab92db027c7ff86cb17a3843a3f6eafc8158d2
 
 COCOAPODS: 0.39.0

--- a/the-blue-alliance-ios/Team+Fetch.m
+++ b/the-blue-alliance-ios/Team+Fetch.m
@@ -32,7 +32,12 @@
             existingTeamsBlock = [existingTeamsBlock arrayByAddingObjectsFromArray:teams];
         }
         
-        if ([teams count] == 0) {
+        NSInteger maxTeamPage = [[NSUserDefaults standardUserDefaults] integerForKey:@"MaxTeamPage"];
+        
+        if ([teams count] == 0 && page >= maxTeamPage) {
+            [[NSUserDefaults standardUserDefaults] setInteger:page forKey:@"MaxTeamPage"];
+            [[NSUserDefaults standardUserDefaults] synchronize];
+            
             if (completion) {
                 completion(existingTeamsBlock, [existingTeamsBlock count], error);
             }


### PR DESCRIPTION
When paging through teams with the Last-Modified header, we won't get any data back if a page for the teams endpoint hasn't been modified. However, the only way for us to tell if we've hit a page that doesn't have any teams is if we get back no data (an empty page still gives us a 200 and a Last-Modified back). This is a simple fix, but we store the max page we see for the teams paging call, and make sure we always check up to at least that point.