### PR TITLE
Add myTBA unregister as syncronous action

### DIFF
--- a/tba-unit-tests/Operations/myTBA/MyTBASignOutOperation_Tests.swift
+++ b/tba-unit-tests/Operations/myTBA/MyTBASignOutOperation_Tests.swift
@@ -1,0 +1,58 @@
+import Firebase
+import TBAKit
+import XCTest
+@testable import The_Blue_Alliance
+
+class MyTBASignOutOperationTestCase: XCTestCase {
+
+    var myTBA: MockMyTBA!
+    var myTBASignOutOperation: MyTBASignOutOperation!
+
+    override func setUp() {
+        super.setUp()
+
+        myTBA = MockMyTBA()
+        myTBASignOutOperation = MyTBASignOutOperation(myTBA: myTBA, pushToken: "push_token")
+    }
+
+    override func tearDown() {
+        myTBA = nil
+        myTBASignOutOperation = nil
+
+        super.tearDown()
+    }
+
+    func test_execute() {
+        let expectation = XCTestExpectation(description: "Finish called")
+        myTBASignOutOperation.completionBlock = { [weak myTBASignOutOperation] in
+            XCTAssertNil(myTBASignOutOperation?.completionError)
+            expectation.fulfill()
+        }
+        myTBASignOutOperation.execute()
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_execute_error() {
+        let expectation = XCTestExpectation(description: "Finish called")
+        myTBA.unregisterError = NSError(domain: "com.zor.zach", code: 2337, userInfo: nil)
+        myTBASignOutOperation.completionBlock = { [weak myTBASignOutOperation] in
+            XCTAssertNotNil(myTBASignOutOperation?.completionError)
+            expectation.fulfill()
+        }
+        myTBASignOutOperation.execute()
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+}
+
+class MockMyTBA: MyTBA {
+
+    var unregisterError: Error?
+
+    // https://github.com/jrose-apple/swift-evolution/blob/overridable-members-in-extensions/proposals/nnnn-overridable-members-in-extensions.md
+    override func unregister(_ token: String, completion: @escaping (Error?) -> Void) -> URLSessionDataTask? {
+        completion(unregisterError)
+        return nil
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		92AAC69720967EC20076B977 /* MyTBAModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AAC69620967EC20076B977 /* MyTBAModel.swift */; };
 		92AAC69A209681400076B977 /* MyTBASubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AAC699209681400076B977 /* MyTBASubscription.swift */; };
 		92AF4D0C1E330790007E967D /* SelectNumberTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AF4D0B1E330790007E967D /* SelectNumberTableViewController.swift */; };
+		92B076F120FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B076F020FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift */; };
+		92B076F320FF948D00F9B2D7 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B076F220FF948D00F9B2D7 /* TestAppDelegate.swift */; };
 		92B0AA3B20CB837A0074FDF1 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B0AA3A20CB837A0074FDF1 /* main.swift */; };
 		92B5DAC61EE4CE7C00B0A8F3 /* EventTeamStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B5DAC51EE4CE7C00B0A8F3 /* EventTeamStat.swift */; };
 		92B7372F20996F25009A7784 /* MyTBAPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7372E20996F25009A7784 /* MyTBAPreferences.swift */; };
@@ -140,6 +142,7 @@
 		92F481F11E7DA04B00B4ED7E /* EventsContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F481F01E7DA04B00B4ED7E /* EventsContainerViewController.swift */; };
 		92F8E356209AAE890094213F /* PushService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F8E355209AAE890094213F /* PushService.swift */; };
 		92F8E358209AB3B50094213F /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F8E357209AB3B50094213F /* Provider.swift */; };
+		92FE68BB20D8A1E8004A1481 /* MyTBASignOutOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FE68BA20D8A1E8004A1481 /* MyTBASignOutOperation.swift */; };
 		92FF4A2E2099616B006B99F5 /* MyTBARegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FF4A2D2099616B006B99F5 /* MyTBARegister.swift */; };
 		92FFE51E1E770D010037E48C /* District.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FFE51D1E770D010037E48C /* District.swift */; };
 		92FFE5251E7C994B0037E48C /* EventTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 92FFE5241E7C994B0037E48C /* EventTableViewCell.xib */; };
@@ -268,6 +271,8 @@
 		92AAC69620967EC20076B977 /* MyTBAModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBAModel.swift; sourceTree = "<group>"; };
 		92AAC699209681400076B977 /* MyTBASubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBASubscription.swift; sourceTree = "<group>"; };
 		92AF4D0B1E330790007E967D /* SelectNumberTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectNumberTableViewController.swift; sourceTree = "<group>"; };
+		92B076F020FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBASignOutOperation_Tests.swift; sourceTree = "<group>"; };
+		92B076F220FF948D00F9B2D7 /* TestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
 		92B0AA3A20CB837A0074FDF1 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		92B5DAC51EE4CE7C00B0A8F3 /* EventTeamStat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTeamStat.swift; sourceTree = "<group>"; };
 		92B7372E20996F25009A7784 /* MyTBAPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBAPreferences.swift; sourceTree = "<group>"; };
@@ -300,6 +305,7 @@
 		92F481F01E7DA04B00B4ED7E /* EventsContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsContainerViewController.swift; sourceTree = "<group>"; };
 		92F8E355209AAE890094213F /* PushService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushService.swift; sourceTree = "<group>"; };
 		92F8E357209AB3B50094213F /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
+		92FE68BA20D8A1E8004A1481 /* MyTBASignOutOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBASignOutOperation.swift; sourceTree = "<group>"; };
 		92FF4A2D2099616B006B99F5 /* MyTBARegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBARegister.swift; sourceTree = "<group>"; };
 		92FFE51D1E770D010037E48C /* District.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = District.swift; sourceTree = "<group>"; };
 		92FFE5241E7C994B0037E48C /* EventTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EventTableViewCell.xib; sourceTree = "<group>"; };
@@ -517,6 +523,7 @@
 			children = (
 				9287014720CD8C4A0077D6DA /* TBAOperation.swift */,
 				92BB717920CE05770081F4E5 /* App Setup */,
+				92FE68B920D8A1CF004A1481 /* myTBA */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -547,6 +554,7 @@
 				92E6253F208EC23000DF58C0 /* the-blue-alliance-ios.entitlements */,
 				92B0AA3A20CB837A0074FDF1 /* main.swift */,
 				92942D951E2154DA008E79CA /* AppDelegate.swift */,
+				92B076F220FF948D00F9B2D7 /* TestAppDelegate.swift */,
 				923A0D7620D21D3800BF5E31 /* Launch Views */,
 				92942D9E1E2154DA008E79CA /* Assets.xcassets */,
 				92942DA31E2154DA008E79CA /* Info.plist */,
@@ -769,6 +777,14 @@
 			name = MyTBA;
 			sourceTree = "<group>";
 		};
+		92B076EF20FF8DDC00F9B2D7 /* myTBA */ = {
+			isa = PBXGroup;
+			children = (
+				92B076F020FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift */,
+			);
+			path = myTBA;
+			sourceTree = "<group>";
+		};
 		92BB717920CE05770081F4E5 /* App Setup */ = {
 			isa = PBXGroup;
 			children = (
@@ -784,6 +800,7 @@
 			children = (
 				92BB717B20CE116C0081F4E5 /* TBAOperation_Tests.swift */,
 				92BB717D20CE19E20081F4E5 /* App Setup */,
+				92B076EF20FF8DDC00F9B2D7 /* myTBA */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -864,6 +881,14 @@
 				92F8E357209AB3B50094213F /* Provider.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		92FE68B920D8A1CF004A1481 /* myTBA */ = {
+			isa = PBXGroup;
+			children = (
+				92FE68BA20D8A1E8004A1481 /* MyTBASignOutOperation.swift */,
+			);
+			path = myTBA;
 			sourceTree = "<group>";
 		};
 		92FFE5221E7C994B0037E48C /* View Elements */ = {
@@ -1181,6 +1206,7 @@
 				9272924D1EE4A0FC0027CE7C /* EventStatsViewController.swift in Sources */,
 				9223AC831EE7003C00F54F93 /* CollectionViewDataSource.swift in Sources */,
 				9274A3F81F3520B900FAADF0 /* TeamSummaryTableViewController.swift in Sources */,
+				92FE68BB20D8A1E8004A1481 /* MyTBASignOutOperation.swift in Sources */,
 				9287014620CD8C0B0077D6DA /* PersistentContainerOperation.swift in Sources */,
 				929BBB051EC55742006D3854 /* InfoTableViewCell.swift in Sources */,
 				92C9BD3120968FAC007FB9C8 /* Favorite.swift in Sources */,
@@ -1276,6 +1302,7 @@
 				1405237A1ED33E040072FB91 /* MatchesViewController.swift in Sources */,
 				9249206F20BB0455001CAC5E /* Date+TBA.swift in Sources */,
 				9223AC851EE7214A00F54F93 /* MediaView.swift in Sources */,
+				92B076F320FF948D00F9B2D7 /* TestAppDelegate.swift in Sources */,
 				926A8EEA20B9B6BB00A25563 /* EventStatusAlliance.swift in Sources */,
 				929F571A2092AAF000E5313A /* URL+Reachable.swift in Sources */,
 				9255EB6D209AC9760006A745 /* RetryService.swift in Sources */,
@@ -1288,6 +1315,7 @@
 			files = (
 				924459C620CB796B0007570D /* Event_Tests.swift in Sources */,
 				92BB718420CE1E310081F4E5 /* Test.xcdatamodeld in Sources */,
+				92B076F120FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift in Sources */,
 				924459C320CB796B0007570D /* Date+TBA_Tests.swift in Sources */,
 				92BB717F20CE19F40081F4E5 /* PersistentContainerOperation_Tests.swift in Sources */,
 				924459C520CB796B0007570D /* CoreDataTestCase.swift in Sources */,

--- a/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBAFavorite.swift
+++ b/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBAFavorite.swift
@@ -27,6 +27,7 @@ struct MyTBAFavorite: MyTBAModel, Codable {
 
 extension MyTBA {
 
+    @discardableResult
     func fetchFavorites(_ completion: @escaping (_ favorites: [MyTBAFavorite]?, _ error: Error?) -> Void) -> URLSessionDataTask {
         let method = "\(MyTBAFavorite.arrayKey)/list"
 
@@ -35,6 +36,7 @@ extension MyTBA {
         })
     }
 
+    @discardableResult
     func updateFavorite(_ favorite: MyTBAFavorite, completion: @escaping (_ favorites: MyTBAFavorite?, _ error: Error?) -> Void) -> URLSessionDataTask? {
         // Something in here
         return nil

--- a/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBARegister.swift
+++ b/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBARegister.swift
@@ -12,18 +12,20 @@ struct MyTBARegisterRequest: Codable {
 
 struct MyTBARegisterResponse: MyTBAResponse, Codable {
 
-    var code: Int
+    var code: String
     var message: String
 
 }
 
 extension MyTBA {
 
+    @discardableResult
     func register(_ token: String, completion: @escaping (_ error: Error?) -> Void) -> URLSessionDataTask? {
         return registerUnregister("register", token: token, completion: completion)
     }
 
-    func unregister(_ token: String, completion: @escaping (_ error: Error?) -> Void) -> URLSessionDataTask? {
+    @discardableResult
+    @objc func unregister(_ token: String, completion: @escaping (_ error: Error?) -> Void) -> URLSessionDataTask? {
         return registerUnregister("unregister", token: token, completion: completion)
     }
 
@@ -43,7 +45,7 @@ extension MyTBA {
         }
 
         return callApi(method: method, bodyData: encodedRegistration, completion: { (registerResponse: MyTBARegisterResponse?, error: Error?) in
-            if let registerResponse = registerResponse, registerResponse.code >= 400 {
+            if let registerResponse = registerResponse, registerResponse.code != "200" {
                 completion(APIError.error(registerResponse.message))
             } else {
                 completion(error)

--- a/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBASubscription.swift
+++ b/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBASubscription.swift
@@ -45,6 +45,7 @@ struct MyTBASubscription: MyTBAModel, Codable {
 
 extension MyTBA {
 
+    @discardableResult
     func fetchSubscriptions(_ completion: @escaping (_ subscriptions: [MyTBASubscription]?, _ error: Error?) -> Void) -> URLSessionDataTask {
         let method = "\(MyTBASubscription.arrayKey)/list"
 
@@ -53,6 +54,7 @@ extension MyTBA {
         })
     }
 
+    @discardableResult
     func updateSubscription(_ subscriptions: MyTBASubscription, completion: @escaping (_ subscription: MyTBASubscription?, _ error: Error?) -> Void) -> URLSessionDataTask? {
         return nil
     }

--- a/the-blue-alliance-ios/Frameworks/MyTBAKit/MyTBA.swift
+++ b/the-blue-alliance-ios/Frameworks/MyTBAKit/MyTBA.swift
@@ -15,6 +15,7 @@ public enum APIError: Error {
 }
 
 class MyTBA {
+
     public static let shared = MyTBA()
     private var authToken: String? {
         didSet {
@@ -42,18 +43,18 @@ class MyTBA {
 
         // Block gets called on init - ignore the init call
         var initCall = true
-        Auth.auth().addIDTokenDidChangeListener { [weak self] (_, user) in
+        Auth.auth().addIDTokenDidChangeListener { (_, user) in
             if initCall {
                 initCall = false
                 return
             }
 
             if let user = user {
-                user.getIDToken(completion: { [weak self] (token, _) in
-                    self?.authToken = token
+                user.getIDToken(completion: { (token, _) in
+                    self.authToken = token
                 })
             } else {
-                self?.authToken = nil
+                self.authToken = nil
             }
         }
     }
@@ -83,7 +84,7 @@ class MyTBA {
 
         #if DEBUG
         if let bodyData = bodyData, let dataString = try? JSONSerialization.jsonObject(with: bodyData, options: []) {
-            print("POST: \(dataString)")
+            print("POST \(method): \(dataString)")
         }
         #endif
 

--- a/the-blue-alliance-ios/Operations/myTBA/MyTBASignOutOperation.swift
+++ b/the-blue-alliance-ios/Operations/myTBA/MyTBASignOutOperation.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+class MyTBASignOutOperation: TBAOperation {
+
+    var myTBA: MyTBA
+    var pushToken: String
+
+    init(myTBA: MyTBA, pushToken: String) {
+        self.myTBA = myTBA
+        self.pushToken = pushToken
+
+        super.init()
+    }
+
+    override func execute() {
+        myTBA.unregister(pushToken) { (error) in
+            if let error = error {
+                self.completionError = error
+            }
+            self.finish()
+        }
+    }
+
+}

--- a/the-blue-alliance-ios/TestAppDelegate.swift
+++ b/the-blue-alliance-ios/TestAppDelegate.swift
@@ -1,0 +1,12 @@
+import Firebase
+import Foundation
+
+class TestAppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Setup our Firebase app - make sure this is called before other Firebase setup
+        FirebaseApp.configure()
+        return true
+    }
+
+}

--- a/the-blue-alliance-ios/main.swift
+++ b/the-blue-alliance-ios/main.swift
@@ -3,7 +3,7 @@ import UIKit
 
 // TODO: For UI testing, check command line args to see if we're UI testing and need our host app
 private func delegateClassName() -> String? {
-    return NSClassFromString("XCTestCase") == nil ? NSStringFromClass(AppDelegate.self) : nil
+    return NSClassFromString("XCTestCase") == nil ? NSStringFromClass(AppDelegate.self) : NSStringFromClass(TestAppDelegate.self)
 }
 
 let args = UnsafeMutableRawPointer(CommandLine.unsafeArgv).bindMemory(to: UnsafeMutablePointer<Int8>.self, capacity: Int(CommandLine.argc))


### PR DESCRIPTION
Making unregister a synchronous action via an action and an activity spinner, since signing out of Google makes it where myTBA is unauthenticated, and we need to be authenticated when we hit that unregister endpoint.  Closes #175