### PR TITLE
Fix crash where already-registered myTBA would crash after 1 min

### DIFF
--- a/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBARegister.swift
+++ b/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBARegister.swift
@@ -45,7 +45,7 @@ extension MyTBA {
         }
 
         return callApi(method: method, bodyData: encodedRegistration, completion: { (registerResponse: MyTBARegisterResponse?, error: Error?) in
-            if let registerResponse = registerResponse, registerResponse.code != "200" {
+            if let registerResponse = registerResponse, let code = Int(registerResponse.code), code >= 400 {
                 completion(APIError.error(registerResponse.message))
             } else {
                 completion(error)


### PR DESCRIPTION
The register response returns a 304, which isn't a 200, and incorrectly tells the retry service for registering push notifications that it failed. After a minute, it retries, and attempts to register with it's retry service a second time and crashes.

This fixes by just casing the response code from a string to an int, and doing the same check we were doing before (>= 400 is an error)