### PR TITLE
Remove try/catch to just try! so if we fail, we crash

### DIFF
--- a/the-blue-alliance-ios/Core Data/District.swift
+++ b/the-blue-alliance-ios/Core Data/District.swift
@@ -8,6 +8,7 @@ extension District: Managed {
         return "\(String(year)) \(abbreviation!.uppercased())"
     }
 
+    @discardableResult
     static func insert(with model: TBADistrict, in context: NSManagedObjectContext) -> District {
         let predicate = NSPredicate(format: "key == %@", model.key)
         return findOrCreate(in: context, matching: predicate, configure: { (district) in

--- a/the-blue-alliance-ios/Core Data/Event.swift
+++ b/the-blue-alliance-ios/Core Data/Event.swift
@@ -17,6 +17,7 @@ public enum EventType: Int {
 
 extension Event: Locatable, Managed {
 
+    @discardableResult
     static func insert(with model: TBAEvent, in context: NSManagedObjectContext) -> Event {
         let predicate = NSPredicate(format: "key == %@", model.key)
         return findOrCreate(in: context, matching: predicate) { (event) in

--- a/the-blue-alliance-ios/Core Data/EventStatus.swift
+++ b/the-blue-alliance-ios/Core Data/EventStatus.swift
@@ -4,6 +4,7 @@ import TBAKit
 
 extension EventStatus: Managed {
 
+    @discardableResult
     static func insert(with model: TBAEventStatus, team: Team, event: Event, in context: NSManagedObjectContext) -> EventStatus {
         let predicate = NSPredicate(format: "%K == %@ AND %K == %@",
                                     #keyPath(EventStatus.event), event, #keyPath(EventStatus.team), team)

--- a/the-blue-alliance-ios/Core Data/Favorite.swift
+++ b/the-blue-alliance-ios/Core Data/Favorite.swift
@@ -6,12 +6,13 @@ protocol MyTBAManaged: Managed {
     associatedtype MyType: NSManagedObject
     associatedtype RemoteType: MyTBAModel
 
-    static func insert(with model: RemoteType, in context: NSManagedObjectContext) -> MyType
+    @discardableResult static func insert(with model: RemoteType, in context: NSManagedObjectContext) -> MyType
     func toRemoteModel() -> RemoteType
 }
 
 extension Favorite: MyTBAManaged {
 
+    @discardableResult
     static func insert(with model: MyTBAFavorite, in context: NSManagedObjectContext) -> Favorite {
         let predicate = NSPredicate(format: "%K == %@ && %K == %@", #keyPath(Favorite.modelKey), model.modelKey, #keyPath(Favorite.modelType), model.modelType.rawValue)
         return findOrCreate(in: context, matching: predicate) { (favorite) in

--- a/the-blue-alliance-ios/Core Data/Match.swift
+++ b/the-blue-alliance-ios/Core Data/Match.swift
@@ -79,6 +79,7 @@ extension Match: Managed {
         return dateFormatter.string(from: date)
     }
 
+    @discardableResult
     static func insert(with model: TBAMatch, for event: Event, in context: NSManagedObjectContext) -> Match {
         let predicate = NSPredicate(format: "key == %@", model.key)
         return findOrCreate(in: context, matching: predicate) { (match) in

--- a/the-blue-alliance-ios/Core Data/NSManagedObjectContext+Extension.swift
+++ b/the-blue-alliance-ios/Core Data/NSManagedObjectContext+Extension.swift
@@ -9,28 +9,20 @@ extension NSManagedObjectContext {
         return obj
     }
 
-    public func saveOrRollback() -> Bool {
-        do {
-            try save()
-            return true
-        } catch {
-            print(error)
-            Crashlytics.sharedInstance().recordError(error)
-            rollback()
-            return false
-        }
+    public func saveContext() {
+        try! save()
     }
 
-    public func performSaveOrRollback() {
+    public func performSaveContext() {
         perform {
-            _ = self.saveOrRollback()
+            self.saveContext()
         }
     }
 
     public func performChanges(block: @escaping () -> Void) {
         perform {
             block()
-            _ = self.saveOrRollback()
+            self.saveContext()
         }
     }
 

--- a/the-blue-alliance-ios/Core Data/Subscription.swift
+++ b/the-blue-alliance-ios/Core Data/Subscription.swift
@@ -4,6 +4,7 @@ import TBAKit
 
 extension Subscription: MyTBAManaged {
 
+    @discardableResult
     static func insert(with model: MyTBASubscription, in context: NSManagedObjectContext) -> Subscription {
         let predicate = NSPredicate(format: "%K == %@ && %K == %@", #keyPath(Subscription.modelKey), model.modelKey, #keyPath(Subscription.modelType), model.modelType.rawValue)
         return findOrCreate(in: context, matching: predicate) { (subscription) in

--- a/the-blue-alliance-ios/Core Data/Team.swift
+++ b/the-blue-alliance-ios/Core Data/Team.swift
@@ -30,6 +30,7 @@ extension Team: Locatable, Managed {
         }
     }
 
+    @discardableResult
     static func insert(with model: TBATeam, in context: NSManagedObjectContext) -> Team {
         let predicate = NSPredicate(format: "key == %@", model.key)
         return findOrCreate(in: context, matching: predicate) { (team) in

--- a/the-blue-alliance-ios/Frameworks/MyTBAKit/MyTBA.swift
+++ b/the-blue-alliance-ios/Frameworks/MyTBAKit/MyTBA.swift
@@ -100,12 +100,8 @@ class MyTBA {
                 }
                 #endif
 
-                do {
-                    let response = try MyTBA.jsonDecoder.decode(T.self, from: data)
-                    completion(response, nil)
-                } catch {
-                    completion(nil, error)
-                }
+                let response = try! MyTBA.jsonDecoder.decode(T.self, from: data)
+                completion(response, nil)
             } else {
                 completion(nil, APIError.error("Unexpected response from myTBA API"))
             }

--- a/the-blue-alliance-ios/Services/PushService.swift
+++ b/the-blue-alliance-ios/Services/PushService.swift
@@ -38,7 +38,7 @@ class PushService: NSObject {
             // Not authenticated to MyTBA - save token for registration once we're auth'd
             pendingRegisterPushToken = token
         } else {
-            _ = myTBA.register(token) { (error) in
+            myTBA.register(token) { (error) in
                 if let error = error {
                     Crashlytics.sharedInstance().recordError(error)
                     DispatchQueue.main.async {

--- a/the-blue-alliance-ios/Services/TBABackgroundService.swift
+++ b/the-blue-alliance-ios/Services/TBABackgroundService.swift
@@ -25,14 +25,8 @@ class TBABackgroundService {
                     return
                 }
 
-                let team = Team.insert(with: modelTeam, in: context)
-                let success = context.saveOrRollback()
-
-                if success == true {
-                    completion(team, nil)
-                } else {
-                    completion(nil, BackgroundFetchError.message("Unable to save background team for \(key)"))
-                }
+                Team.insert(with: modelTeam, in: context)
+                context.saveContext()
             }
         }
     }
@@ -48,14 +42,8 @@ class TBABackgroundService {
                     return
                 }
 
-                let event = Event.insert(with: modelEvent, in: context)
-                let success = context.saveOrRollback()
-
-                if success == true {
-                    completion(event, nil)
-                } else {
-                    completion(nil, BackgroundFetchError.message("Unable to save background event for \(key)"))
-                }
+                Event.insert(with: modelEvent, in: context)
+                context.saveContext()
             }
         }
     }
@@ -99,14 +87,8 @@ class TBABackgroundService {
                     return
                 }
 
-                let match = Match.insert(with: modelMatch, for: event, in: context)
-                let success = context.saveOrRollback()
-
-                if success == true {
-                    completion(match, nil)
-                } else {
-                    completion(nil, BackgroundFetchError.message("Unable to save background match for \(key)"))
-                }
+                Match.insert(with: modelMatch, for: event, in: context)
+                context.saveContext()
             }
         }
     }

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/CollectionViewDataSource.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/CollectionViewDataSource.swift
@@ -45,7 +45,7 @@ class CollectionViewDataSource<Result: NSFetchRequestResult, Delegate: Collectio
     func reconfigureFetchRequest(_ configure: (NSFetchRequest<Result>) -> Void) {
         NSFetchedResultsController<NSFetchRequestResult>.deleteCache(withName: fetchedResultsController.cacheName)
         configure(fetchedResultsController.fetchRequest)
-        do { try fetchedResultsController.performFetch() } catch { fatalError("fetch request failed") }
+        try! fetchedResultsController.performFetch()
         DispatchQueue.main.async {
             self.collectionView.reloadData()
         }

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
@@ -52,7 +52,7 @@ class TableViewDataSource<Result: NSFetchRequestResult, Delegate: TableViewDataS
     func reconfigureFetchRequest(_ configure: (NSFetchRequest<Result>) -> Void) {
         NSFetchedResultsController<NSFetchRequestResult>.deleteCache(withName: fetchedResultsController.cacheName)
         configure(fetchedResultsController.fetchRequest)
-        do { try fetchedResultsController.performFetch() } catch { fatalError("fetch request failed") }
+        try! fetchedResultsController.performFetch()
         DispatchQueue.main.async {
             self.tableView.reloadData()
         }

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsTableViewController.swift
@@ -74,11 +74,11 @@ class DistrictRankingsTableViewController: TBATableViewController {
             self.persistentContainer?.performBackgroundTask({ (backgroundContext) in
                 backgroundContext.performAndWait {
                     events?.forEach({ (modelEvent) in
-                        _ = Event.insert(with: modelEvent, in: backgroundContext)
+                        Event.insert(with: modelEvent, in: backgroundContext)
                     })
                 }
-                let success = backgroundContext.saveOrRollback()
-                completion(success)
+                backgroundContext.saveContext()
+                completion(true)
             })
         })
     }
@@ -94,11 +94,11 @@ class DistrictRankingsTableViewController: TBATableViewController {
             self.persistentContainer?.performBackgroundTask({ (backgroundContext) in
                 backgroundContext.performAndWait {
                     teams?.forEach({ (modelTeam) in
-                        _ = Team.insert(with: modelTeam, in: backgroundContext)
+                        Team.insert(with: modelTeam, in: backgroundContext)
                     })
                 }
-                let success = backgroundContext.saveOrRollback()
-                completion(success)
+                backgroundContext.saveContext()
+                completion(true)
             })
         })
     }
@@ -120,8 +120,8 @@ class DistrictRankingsTableViewController: TBATableViewController {
                 })
                 backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
 
-                let success = backgroundContext.saveOrRollback()
-                completion(success)
+                backgroundContext.saveContext()
+                completion(true)
             })
         })
     }

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsTableViewController.swift
@@ -33,12 +33,10 @@ class DistrictsTableViewController: TBATableViewController {
 
             self.persistentContainer?.performBackgroundTask({ (backgroundContext) in
                 districts?.forEach({ (modelDistrict) in
-                    _ = District.insert(with: modelDistrict, in: backgroundContext)
+                    District.insert(with: modelDistrict, in: backgroundContext)
                 })
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh districts - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownTableViewController.swift
@@ -69,7 +69,7 @@ class DistrictBreakdownTableViewController: TBATableViewController, Observable {
                 let dispatchGroup = DispatchGroup()
                 for eventKey in eventlessKeys {
                     dispatchGroup.enter()
-                    _ = self.fetchEvent(eventKey: eventKey, completion: { (_) in
+                    self.fetchEvent(eventKey: eventKey, completion: { (_) in
                         dispatchGroup.leave()
                     })
                 }
@@ -83,15 +83,14 @@ class DistrictBreakdownTableViewController: TBATableViewController, Observable {
                 })
                 backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh team district breakdown - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: rankingsRequest!)
             })
         })
         addRequest(request: rankingsRequest!)
     }
 
+    @discardableResult
     func fetchEvent(eventKey: String, completion: @escaping (_ success: Bool) -> Void) -> URLSessionDataTask {
         return TBAKit.sharedKit.fetchEvent(key: eventKey, completion: { (modelEvent, error) in
             if error != nil {
@@ -104,7 +103,8 @@ class DistrictBreakdownTableViewController: TBATableViewController, Observable {
                 if let modelEvent = modelEvent {
                     backgroundTeam.addToEvents(Event.insert(with: modelEvent, in: backgroundContext))
                 }
-                completion(backgroundContext.saveOrRollback())
+                backgroundContext.saveContext()
+                completion(true)
             })
         })
     }

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryTableViewController.swift
@@ -59,9 +59,7 @@ class DistrictTeamSummaryTableViewController: TBATableViewController {
                 })
                 backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/EventAlliancesTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAlliancesTableViewController.swift
@@ -79,9 +79,7 @@ class EventAlliancesTableViewController: TBATableViewController {
                 })
                 backgroundEvent.alliances = Set(localAlliances ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event alliances - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: alliancesRequest!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
@@ -89,9 +89,7 @@ class EventAwardsTableViewController: TBATableViewController {
                 })
                 backgroundEvent.awards = Set(localAwards ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event awards - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
@@ -76,9 +76,7 @@ class EventDistrictPointsTableViewController: TBATableViewController {
                 })
                 backgroundEvent.points = Set(localPoints ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event district points - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/EventInfoTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventInfoTableViewController.swift
@@ -75,12 +75,10 @@ class EventInfoTableViewController: TBATableViewController, Observable {
 
             self.persistentContainer?.performBackgroundTask({ (backgroundContext) in
                 if let modelEvent = modelEvent {
-                    _ = Event.insert(with: modelEvent, in: backgroundContext)
+                    Event.insert(with: modelEvent, in: backgroundContext)
                 }
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/EventRankingsTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventRankingsTableViewController.swift
@@ -41,9 +41,7 @@ class EventRankingsTableViewController: TBATableViewController {
                 })
                 backgroundEvent.rankings = Set(localRankings ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event rankings - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: rankingsRequest!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/EventsTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsTableViewController.swift
@@ -70,12 +70,10 @@ class EventsTableViewController: TBATableViewController {
 
             self.persistentContainer?.performBackgroundTask({ (backgroundContext) in
                 events?.forEach({ (modelEvent) in
-                    _ = Event.insert(with: modelEvent, in: backgroundContext)
+                    Event.insert(with: modelEvent, in: backgroundContext)
                 })
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })
@@ -100,9 +98,7 @@ class EventsTableViewController: TBATableViewController {
                 })
                 backgroundTeam.addToEvents(Set(localEvents ?? []) as NSSet)
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })
@@ -127,9 +123,7 @@ class EventsTableViewController: TBATableViewController {
                 })
                 backgroundDistrict.events = Set(localEvents ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -150,9 +150,7 @@ class MatchBreakdownViewController: TBAViewController, Observable, ReactNative {
                     backgroundEvent.addToMatches(Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext))
                 }
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh match breakdown - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
@@ -197,9 +197,7 @@ class MatchInfoViewController: TBAViewController, Observable {
                     backgroundEvent.addToMatches(Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext))
                 }
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh match - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -42,9 +42,7 @@ class MatchesTableViewController: TBATableViewController {
                 })
                 backgroundEvent.matches = Set(localMatches ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event matches - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
@@ -125,10 +125,7 @@ class EventStatsViewController: TBAViewController, Observable, ReactNative {
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
                 backgroundEvent.insights = insights
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event stats - database error")
-                }
-
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsTableViewController.swift
@@ -62,9 +62,7 @@ class EventTeamStatsTableViewController: TBATableViewController {
                 })
                 backgroundEvent.stats = Set(localStats ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event team stats - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
@@ -71,7 +71,7 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
                         continue
                     }
 
-                    _ = T.insert(with: model, in: bgctx)
+                    T.insert(with: model, in: bgctx)
 
                     let predicate = NSPredicate(format: "key == %@", model.modelKey)
                     switch model.modelType {
@@ -104,9 +104,7 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
                     }
                 }
 
-                if !backgroundContext.saveOrRollback() {
-                    self?.showErrorAlert(with: "Unable to refresh \(modelName) - database error")
-                }
+                backgroundContext.saveContext()
                 self?.removeRequest(request: request!)
             })
         }

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
@@ -158,7 +158,7 @@ class MyTBAViewController: ContainerViewController, GIDSignInUIDelegate {
                 Crashlytics.sharedInstance().recordError(error)
             }
 
-            _ = persistentContainer.viewContext.saveOrRollback()
+            persistentContainer.viewContext.saveContext()
 
             DispatchQueue.main.async {
                 viewController.tableView.reloadData()

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamInfoTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamInfoTableViewController.swift
@@ -47,13 +47,10 @@ class TeamInfoTableViewController: TBATableViewController {
 
             self.persistentContainer?.performBackgroundTask({ (backgroundContext) in
                 if let modelTeam = modelTeam {
-                    _ = Team.insert(with: modelTeam, in: backgroundContext)
+                    Team.insert(with: modelTeam, in: backgroundContext)
                 }
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh team - database error")
-                }
-
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
@@ -65,9 +65,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
                     backgroundContext.delete($0)
                 }
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh team media - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamStatsTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamStatsTableViewController.swift
@@ -69,9 +69,7 @@ class TeamStatsTableViewController: TBATableViewController, Observable {
                 })
                 backgroundEvent.stats = Set(localStats ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh team stats - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryTableViewController.swift
@@ -174,12 +174,10 @@ class TeamSummaryTableViewController: TBATableViewController {
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
 
                 if let modelStatus = modelStatus {
-                    _ = EventStatus.insert(with: modelStatus, team: backgroundTeam, event: backgroundEvent, in: backgroundContext)
+                    EventStatus.insert(with: modelStatus, team: backgroundTeam, event: backgroundEvent, in: backgroundContext)
                 }
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: teamStatusRequest!)
             })
         })
@@ -200,9 +198,7 @@ class TeamSummaryTableViewController: TBATableViewController {
                 })
                 backgroundEvent.addToAwards(Set(localAwards ?? []) as NSSet)
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh event awards for \(self.team.key!) - database error")
-                }
+                backgroundContext.saveContext()
                 self.removeRequest(request: awardsRequest!)
             })
         })

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamViewController.swift
@@ -118,9 +118,7 @@ class TeamViewController: ContainerViewController, Observable {
                     backgroundTeam.yearsParticipated = years.sorted().reversed()
                 }
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh years participated - database error")
-                }
+                backgroundContext.saveContext()
             })
         })
     }

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsTableViewController.swift
@@ -59,10 +59,10 @@ class TeamsTableViewController: TBATableViewController {
 
             self.persistentContainer?.performBackgroundTask({ (backgroundContext) in
                 teams.forEach({ (modelTeam) in
-                    _ = Team.insert(with: modelTeam, in: backgroundContext)
+                    Team.insert(with: modelTeam, in: backgroundContext)
                 })
 
-                _ = backgroundContext.saveOrRollback()
+                backgroundContext.saveContext()
                 self.removeRequest(request: previousRequest!)
             })
         }) { (error) in
@@ -93,10 +93,7 @@ class TeamsTableViewController: TBATableViewController {
                 })
                 backgroundEvent.teams = Set(localTeams ?? []) as NSSet
 
-                if !backgroundContext.saveOrRollback() {
-                    self.showErrorAlert(with: "Unable to refresh teams - database error")
-                }
-
+                backgroundContext.saveContext()
                 self.removeRequest(request: request!)
             })
         })


### PR DESCRIPTION
This is a slightly different approach to TBA for iOS then I've been working with before. The app was built in a way in which if something is broken, the app will fail quietly. I think this is the wrong approach though. It will cause hard to track down bugs, and weird UX for users. If their DB isn't saving right, let's crash and fix the bug, as opposed to quietly rolling back the DB without letting the user know what went wrong.

We haven't seen crashes related to the removed try/catch yet, so I'm not too worried about these changes.