### PR TITLE
Initially refresh view controllers (part of #197)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -146,7 +146,7 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
-  - TBAKit (2.0.5)
+  - TBAKit (2.0.7)
   - yoga (0.57.1.React)
   - youtube-ios-player-helper (0.1.6)
   - ZIPFoundation (0.9.6)
@@ -244,7 +244,7 @@ SPEC CHECKSUMS:
   Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
   PureLayout: 4634d0b61e3b5021166e8ec7c18e9e0ca0720c8b
   React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
-  TBAKit: 43455b6f1defc5e5edd268e58ca94894ae3123e1
+  TBAKit: 13e66f7b1dde686f028785faf4e6514e817f8fe3
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
   youtube-ios-player-helper: 21ab92db027c7ff86cb17a3843a3f6eafc8158d2
   ZIPFoundation: 68c35eb2637c21abe56dc60b3277636443bc1501

--- a/tba-unit-tests/Frameworks/MyTBAKit/MyTBA_Tests.swift
+++ b/tba-unit-tests/Frameworks/MyTBAKit/MyTBA_Tests.swift
@@ -1,0 +1,13 @@
+import Foundation
+import XCTest
+@testable import The_Blue_Alliance
+
+class MyTBAError_TestCase: XCTestCase {
+
+    func test_errorMessage() {
+        let errorMessage = "Testing error message"
+        let error = MyTBAError.error(errorMessage)
+        XCTAssertEqual(error.localizedDescription, errorMessage)
+    }
+
+}

--- a/tba-unit-tests/Services/TBABackgroundService_Tests.swift
+++ b/tba-unit-tests/Services/TBABackgroundService_Tests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XCTest
+@testable import The_Blue_Alliance
+
+class BackgroundFetchError_TestCase: XCTestCase {
+
+    func test_errorMessage() {
+        let errorMessage = "Testing error message"
+        let error = BackgroundFetchError.message(errorMessage)
+        XCTAssertEqual(error.localizedDescription, errorMessage)
+    }
+
+    func test_error() {
+        let errorMessage = "Testing error message"
+        let nserror = NSError(domain: "com.the-blue-alliance.testing", code: 7332, userInfo: [NSLocalizedDescriptionKey: errorMessage])
+        let error = BackgroundFetchError.error(nserror)
+        XCTAssertEqual(error.localizedDescription, errorMessage)
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		923AEE87216583CA00EF50C8 /* Bundle+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE86216583CA00EF50C8 /* Bundle+Version.swift */; };
 		923AEE8A21658BC400EF50C8 /* Launch_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE8921658BC400EF50C8 /* Launch_UITests.swift */; };
 		923AEE8C21658C5800EF50C8 /* Bundle+Version_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE8B21658C5800EF50C8 /* Bundle+Version_Tests.swift */; };
+		923AEE952167012000EF50C8 /* TBABackgroundService_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE942167012000EF50C8 /* TBABackgroundService_Tests.swift */; };
+		923AEE99216703CB00EF50C8 /* MyTBA_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE98216703CB00EF50C8 /* MyTBA_Tests.swift */; };
 		924459C320CB796B0007570D /* Date+TBA_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924459BD20CB796A0007570D /* Date+TBA_Tests.swift */; };
 		924459C420CB796B0007570D /* Int16+Suffix_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924459BE20CB796A0007570D /* Int16+Suffix_Tests.swift */; };
 		924459C520CB796B0007570D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924459C020CB796B0007570D /* CoreDataTestCase.swift */; };
@@ -242,6 +244,8 @@
 		923AEE86216583CA00EF50C8 /* Bundle+Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Bundle+Version.swift"; path = "Extensions/Bundle+Version.swift"; sourceTree = "<group>"; };
 		923AEE8921658BC400EF50C8 /* Launch_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Launch_UITests.swift; sourceTree = "<group>"; };
 		923AEE8B21658C5800EF50C8 /* Bundle+Version_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Version_Tests.swift"; sourceTree = "<group>"; };
+		923AEE942167012000EF50C8 /* TBABackgroundService_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBABackgroundService_Tests.swift; sourceTree = "<group>"; };
+		923AEE98216703CB00EF50C8 /* MyTBA_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBA_Tests.swift; sourceTree = "<group>"; };
 		924459BD20CB796A0007570D /* Date+TBA_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+TBA_Tests.swift"; sourceTree = "<group>"; };
 		924459BE20CB796A0007570D /* Int16+Suffix_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int16+Suffix_Tests.swift"; sourceTree = "<group>"; };
 		924459C020CB796B0007570D /* CoreDataTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
@@ -539,6 +543,22 @@
 			path = "App Delegate";
 			sourceTree = "<group>";
 		};
+		923AEE962167038000EF50C8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				923AEE972167038B00EF50C8 /* MyTBAKit */,
+			);
+			path = Frameworks;
+			sourceTree = "<group>";
+		};
+		923AEE972167038B00EF50C8 /* MyTBAKit */ = {
+			isa = PBXGroup;
+			children = (
+				923AEE98216703CB00EF50C8 /* MyTBA_Tests.swift */,
+			);
+			path = MyTBAKit;
+			sourceTree = "<group>";
+		};
 		924459BC20CB796A0007570D /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -566,6 +586,7 @@
 				924459C720CB797E0007570D /* RetryService_Tests.swift */,
 				14B6726B21528D6600FDDAB2 /* RealtimeDatabaseService_Tests.swift */,
 				92564C6F216456800047917F /* Secrets_Tests.swift */,
+				923AEE942167012000EF50C8 /* TBABackgroundService_Tests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1034,6 +1055,7 @@
 				924459BC20CB796A0007570D /* Extensions */,
 				92BB8B60214F165A0035AF28 /* View Controllers */,
 				924459BF20CB796B0007570D /* Core Data */,
+				923AEE962167038000EF50C8 /* Frameworks */,
 				92D6483E20BE4CB8008F0DB3 /* Info.plist */,
 				92564C71216457060047917F /* TestSecrets.plist */,
 			);
@@ -1631,6 +1653,7 @@
 				924459C620CB796B0007570D /* Event_Tests.swift in Sources */,
 				14B6726C21528D6600FDDAB2 /* RealtimeDatabaseService_Tests.swift in Sources */,
 				92BB718420CE1E310081F4E5 /* Test.xcdatamodeld in Sources */,
+				923AEE99216703CB00EF50C8 /* MyTBA_Tests.swift in Sources */,
 				92B076F120FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift in Sources */,
 				924459C320CB796B0007570D /* Date+TBA_Tests.swift in Sources */,
 				923AEE8C21658C5800EF50C8 /* Bundle+Version_Tests.swift in Sources */,
@@ -1644,6 +1667,7 @@
 				92BB717C20CE116C0081F4E5 /* TBAOperation_Tests.swift in Sources */,
 				924459C420CB796B0007570D /* Int16+Suffix_Tests.swift in Sources */,
 				924459C820CB797E0007570D /* RetryService_Tests.swift in Sources */,
+				923AEE952167012000EF50C8 /* TBABackgroundService_Tests.swift in Sources */,
 				92BB8B62214F16710035AF28 /* SettingsViewController_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBARegister.swift
+++ b/the-blue-alliance-ios/Frameworks/MyTBAKit/Models/MyTBARegister.swift
@@ -31,7 +31,7 @@ extension MyTBA {
 
     private func registerUnregister(_ method: String, token: String, completion: @escaping (_ error: Error?) -> Void) -> URLSessionDataTask? {
         guard let uuid = UIDevice.current.identifierForVendor?.uuidString else {
-            completion(APIError.error("Unable to update myTBA registration - no UUID"))
+            completion(MyTBAError.error("Unable to update myTBA registration - no UUID"))
             return nil
         }
 
@@ -40,13 +40,13 @@ extension MyTBA {
                                                 name: UIDevice.current.name)
 
         guard let encodedRegistration = try? MyTBA.jsonEncoder.encode(registration) else {
-            completion(APIError.error("Unable to update myTBA registration - invalid data"))
+            completion(MyTBAError.error("Unable to update myTBA registration - invalid data"))
             return nil
         }
 
         return callApi(method: method, bodyData: encodedRegistration, completion: { (registerResponse: MyTBARegisterResponse?, error: Error?) in
             if let registerResponse = registerResponse, let code = Int(registerResponse.code), code >= 400 {
-                completion(APIError.error(registerResponse.message))
+                completion(MyTBAError.error(registerResponse.message))
             } else {
                 completion(error)
             }

--- a/the-blue-alliance-ios/Frameworks/MyTBAKit/MyTBA.swift
+++ b/the-blue-alliance-ios/Frameworks/MyTBAKit/MyTBA.swift
@@ -10,8 +10,18 @@ private struct Constants {
     }
 }
 
-public enum APIError: Error {
+public enum MyTBAError: Error {
     case error(String)
+}
+
+extension MyTBAError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .error(message: let message):
+            // TODO: This, unlike the name says, isn't localized
+            return message
+        }
+    }
 }
 
 class MyTBA {
@@ -103,7 +113,7 @@ class MyTBA {
                 let response = try! MyTBA.jsonDecoder.decode(T.self, from: data)
                 completion(response, nil)
             } else {
-                completion(nil, APIError.error("Unexpected response from myTBA API"))
+                completion(nil, MyTBAError.error("Unexpected response from myTBA API"))
             }
         }
         task.resume()

--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -111,7 +111,6 @@ extension Refreshable {
 
     func enableRefreshing() {
         let refreshControl = UIRefreshControl()
-        // TODO: THIS IS STILL FUCKING BROKEN
         refreshControl.addTarget(self, action: Selector(("refresh")), for: .valueChanged)
 
         self.refreshControl = refreshControl

--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -12,11 +12,17 @@ protocol Refreshable: AnyObject {
     var refreshControl: UIRefreshControl? { get set }
     var refreshView: UIScrollView { get }
 
-    func refresh()
-    func shouldNoDataRefresh() -> Bool
+    /**
+     Identifier that reflects type of data used during refresh, and if we've fetched it before - used to calculate if we should refresh
+     */
+    var initialRefreshKey: String? { get }
 
-    func enableRefreshing()
-    func disableRefreshing()
+    /**
+     If the data source for the given view controller is empty - used to calculate if we should refresh
+     */
+    var isDataSourceEmpty: Bool { get }
+
+    func refresh()
 }
 
 extension Refreshable {
@@ -27,7 +33,20 @@ extension Refreshable {
     }
 
     func shouldRefresh() -> Bool {
-        return shouldNoDataRefresh() && !isRefreshing
+        var hasRefreshed = true
+        if let initialRefreshKey = initialRefreshKey {
+            hasRefreshed = UserDefaults.standard.bool(forKey: initialRefreshKey)
+        }
+        return (!hasRefreshed || isDataSourceEmpty) && !isRefreshing
+    }
+
+    func markRefreshSuccessful() {
+        guard let initialRefreshKey = initialRefreshKey else {
+            return
+        }
+
+        UserDefaults.standard.set(true, forKey: initialRefreshKey)
+        UserDefaults.standard.synchronize()
     }
 
     // TODO: Add a method to add an observer on a single core data object for changes
@@ -88,6 +107,18 @@ extension Refreshable {
                 self.refreshControl?.endRefreshing()
             }
         }
+    }
+
+    func enableRefreshing() {
+        let refreshControl = UIRefreshControl()
+        // TODO: THIS IS STILL FUCKING BROKEN
+        refreshControl.addTarget(self, action: Selector(("refresh")), for: .valueChanged)
+
+        self.refreshControl = refreshControl
+    }
+
+    func disableRefreshing() {
+        refreshControl = nil
     }
 
 }

--- a/the-blue-alliance-ios/Services/TBABackgroundService.swift
+++ b/the-blue-alliance-ios/Services/TBABackgroundService.swift
@@ -2,10 +2,21 @@ import Foundation
 import TBAKit
 import CoreData
 
-// TODO: LocalizedError
-private enum BackgroundFetchError: Error {
+enum BackgroundFetchError: Error {
     case message(String)
     case error(Error)
+}
+
+extension BackgroundFetchError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .message(message: let message):
+            // TODO: This, unlike the name says, isn't localized
+            return message
+        case .error(error: let error):
+            return error.localizedDescription
+        }
+    }
 }
 
 // Manage background fetches of information, such as teams (used in a handful of places), events, and matches
@@ -15,7 +26,7 @@ class TBABackgroundService {
     // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/183
 
     static func backgroundFetchTeam(_ key: String, in context: NSManagedObjectContext, completion: @escaping (Team?, Error?) -> Void) {
-        _ = TBAKit.sharedKit.fetchTeam(key: key) { (modelTeam, error) in
+        TBAKit.sharedKit.fetchTeam(key: key) { (modelTeam, error) in
             if let error = error {
                 print("Error in background fetch of team \(key) - \(error.localizedDescription)")
                 completion(nil, BackgroundFetchError.error(error))
@@ -34,7 +45,7 @@ class TBABackgroundService {
     }
 
     static func backgroundFetchEvent(_ key: String, in context: NSManagedObjectContext, completion: @escaping (Event?, Error?) -> Void) {
-        _ = TBAKit.sharedKit.fetchEvent(key: key) { (modelEvent, error) in
+        TBAKit.sharedKit.fetchEvent(key: key) { (modelEvent, error) in
             if let error = error {
                 print("Error in background fetch of event \(key) - \(error.localizedDescription)")
                 completion(nil, BackgroundFetchError.error(error))
@@ -81,7 +92,7 @@ class TBABackgroundService {
     }
 
     private static func backgroundFetchMatch(_ key: String, for event: Event, in context: NSManagedObjectContext, completion: @escaping (Match?, Error?) -> Void) {
-        _ = TBAKit.sharedKit.fetchMatch(key: key) { (modelMatch, error) in
+        TBAKit.sharedKit.fetchMatch(key: key) { (modelMatch, error) in
             if let error = error {
                 print("Error in background fetch of match \(key) - \(error.localizedDescription)")
                 completion(nil, BackgroundFetchError.error(error))

--- a/the-blue-alliance-ios/View Controllers/Base/Container Controllers/ContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Container Controllers/ContainerViewController.swift
@@ -110,6 +110,7 @@ class ContainerViewController: UIViewController, Persistable, Alertable {
             addChild(viewController)
             containerView.addSubview(viewController.view)
             viewController.view.autoPinEdgesToSuperviewEdges()
+            viewController.enableRefreshing()
         }
 
         stackView.autoPinEdge(toSuperviewSafeArea: .top)

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/CollectionViewDataSource.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/CollectionViewDataSource.swift
@@ -9,6 +9,8 @@ protocol CollectionViewDataSourceDelegate: class {
     associatedtype Object: NSFetchRequestResult
     associatedtype Cell: UICollectionViewCell, Reusable
 
+    var collectionView: UICollectionView! { get }
+
     func configure(_ cell: Cell, for object: Object, at indexPath: IndexPath)
 
     func showNoDataView()
@@ -20,24 +22,19 @@ class CollectionViewDataSource<Result: NSFetchRequestResult, Delegate: Collectio
     typealias Object = Delegate.Object
     typealias Cell = Delegate.Cell
 
-    required init(collectionView: UICollectionView, fetchedResultsController: NSFetchedResultsController<Result>, delegate: Delegate) {
-        self.collectionView = collectionView
+    required init(fetchedResultsController: NSFetchedResultsController<Result>, delegate: Delegate) {
         self.fetchedResultsController = fetchedResultsController
         self.delegate = delegate
+
         super.init()
         fetchedResultsController.delegate = self
         try! fetchedResultsController.performFetch()
 
         DispatchQueue.main.async {
-            collectionView.registerReusableCell(Cell.self)
-            collectionView.dataSource = self
-            self.collectionView.reloadData()
+            delegate.collectionView.registerReusableCell(Cell.self)
+            delegate.collectionView.dataSource = self
+            delegate.collectionView.reloadData()
         }
-    }
-
-    var selectedObject: Object? {
-        guard let indexPath = collectionView.indexPathsForSelectedItems?.first else { return nil }
-        return object(at: indexPath)
     }
 
     func object(at indexPath: IndexPath) -> Object {
@@ -49,13 +46,12 @@ class CollectionViewDataSource<Result: NSFetchRequestResult, Delegate: Collectio
         configure(fetchedResultsController.fetchRequest)
         try! fetchedResultsController.performFetch()
         DispatchQueue.main.async {
-            self.collectionView.reloadData()
+            self.delegate.collectionView.reloadData()
         }
     }
 
     // MARK: Private
 
-    fileprivate let collectionView: UICollectionView
     public let fetchedResultsController: NSFetchedResultsController<Result>
     fileprivate weak var delegate: Delegate!
 
@@ -95,7 +91,7 @@ class CollectionViewDataSource<Result: NSFetchRequestResult, Delegate: Collectio
     // MARK: NSFetchedResultsControllerDelegate
 
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
-        collectionView.reloadData()
+        delegate.collectionView.reloadData()
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
@@ -8,6 +8,8 @@ protocol TableViewDataSourceDelegate: class {
     associatedtype Object
     associatedtype Cell: UITableViewCell, Reusable
 
+    var tableView: UITableView! { get }
+
     func configure(_ cell: Cell, for object: Object, at indexPath: IndexPath)
     func title(for section: Int) -> String?
 
@@ -28,8 +30,7 @@ class TableViewDataSource<Result: NSFetchRequestResult, Delegate: TableViewDataS
     typealias Object = Delegate.Object
     typealias Cell = Delegate.Cell
 
-    required init(tableView: UITableView, fetchedResultsController: NSFetchedResultsController<Result>, delegate: Delegate) {
-        self.tableView = tableView
+    required init(fetchedResultsController: NSFetchedResultsController<Result>, delegate: Delegate) {
         self.fetchedResultsController = fetchedResultsController
         self.delegate = delegate
 
@@ -39,15 +40,10 @@ class TableViewDataSource<Result: NSFetchRequestResult, Delegate: TableViewDataS
         try! fetchedResultsController.performFetch()
 
         DispatchQueue.main.async {
-            tableView.registerReusableCell(Cell.self)
-            tableView.dataSource = self
-            tableView.reloadData()
+            delegate.tableView.registerReusableCell(Cell.self)
+            delegate.tableView.dataSource = self
+            delegate.tableView.reloadData()
         }
-    }
-
-    var selectedObject: Object? {
-        guard let indexPath = tableView.indexPathForSelectedRow else { return nil }
-        return object(at: indexPath)
     }
 
     func object(at indexPath: IndexPath) -> Object {
@@ -59,13 +55,12 @@ class TableViewDataSource<Result: NSFetchRequestResult, Delegate: TableViewDataS
         configure(fetchedResultsController.fetchRequest)
         try! fetchedResultsController.performFetch()
         DispatchQueue.main.async {
-            self.tableView.reloadData()
+            self.delegate.tableView.reloadData()
         }
     }
 
     // MARK: Private
 
-    fileprivate let tableView: UITableView
     public let fetchedResultsController: NSFetchedResultsController<Result>
     fileprivate weak var delegate: Delegate!
 
@@ -108,7 +103,7 @@ class TableViewDataSource<Result: NSFetchRequestResult, Delegate: TableViewDataS
     // MARK: NSFetchedResultsControllerDelegate
 
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        tableView.reloadData()
+        delegate.tableView.reloadData()
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBACollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBACollectionViewController.swift
@@ -5,31 +5,23 @@ import CoreData
 class TBACollectionViewController: UICollectionViewController, DataController {
 
     var persistentContainer: NSPersistentContainer
-
-    var requests: [URLSessionDataTask] = []
-
-    var refreshView: UIScrollView {
-        return collectionView
-    }
     var noDataViewController: NoDataViewController?
 
-    var refreshControl: UIRefreshControl? = {
-        let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: #selector(refresh), for: .valueChanged)
-        return refreshControl
-    }()
+    var requestsArray: [URLSessionDataTask] = []
+
+    // MARK: - Init
 
     init(persistentContainer: NSPersistentContainer) {
         self.persistentContainer = persistentContainer
 
         super.init(collectionViewLayout: UICollectionViewFlowLayout())
-
-        enableRefreshing()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    // MARK: - View Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,20 +31,30 @@ class TBACollectionViewController: UICollectionViewController, DataController {
         collectionView.registerReusableCell(BasicCollectionViewCell.self)
     }
 
-    @objc func refresh() {
-        fatalError("Implement this downstream")
+}
+
+extension Refreshable where Self: TBACollectionViewController {
+
+    var requests: [URLSessionDataTask] {
+        get {
+            return requestsArray
+        }
+        set {
+            requestsArray = newValue
+        }
     }
 
-    func shouldNoDataRefresh() -> Bool {
-        fatalError("Implement this downstream")
+    var refreshControl: UIRefreshControl? {
+        get {
+            return collectionView.refreshControl
+        }
+        set {
+            collectionView.refreshControl = newValue
+        }
     }
 
-    func enableRefreshing() {
-        collectionView.refreshControl = refreshControl
-    }
-
-    func disableRefreshing() {
-        collectionView.refreshControl = nil
+    var refreshView: UIScrollView {
+        return collectionView
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBATableViewController.swift
@@ -5,25 +5,16 @@ import CoreData
 class TBATableViewController: UITableViewController, DataController {
 
     var persistentContainer: NSPersistentContainer
-
-    var requests: [URLSessionDataTask] = []
-    var refreshView: UIScrollView {
-        return tableView
-    }
     var noDataViewController: NoDataViewController?
 
-    private var _refreshControl: UIRefreshControl = {
-        let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: #selector(refresh), for: .valueChanged)
-        return refreshControl
-    }()
+    var requestsArray: [URLSessionDataTask] = []
+
+    // MARK: - Init
 
     init(style: UITableView.Style = .plain, persistentContainer: NSPersistentContainer) {
         self.persistentContainer = persistentContainer
 
         super.init(style: style)
-
-        enableRefreshing()
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -53,22 +44,30 @@ class TBATableViewController: UITableViewController, DataController {
         }
     }
 
-    // MARK: - Refreshable
+}
 
-    @objc func refresh() {
-        fatalError("Implement this downstream")
+extension Refreshable where Self: TBATableViewController {
+
+    var refreshControl: UIRefreshControl? {
+        get {
+            return tableView.refreshControl
+        }
+        set {
+            tableView.refreshControl = newValue
+        }
     }
 
-    func shouldNoDataRefresh() -> Bool {
-        fatalError("Implement this downstream")
+    var requests: [URLSessionDataTask] {
+        get {
+            return requestsArray
+        }
+        set {
+            requestsArray = newValue
+        }
     }
 
-    func enableRefreshing() {
-        tableView.refreshControl = _refreshControl
-    }
-
-    func disableRefreshing() {
-        tableView.refreshControl = nil
+    var refreshView: UIScrollView {
+        return tableView
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAViewController.swift
@@ -2,9 +2,14 @@ import Foundation
 import UIKit
 import CoreData
 
-typealias DataController = Persistable & Refreshable & Alertable & Stateful
+typealias DataController = Persistable & Alertable & Stateful
 
 class TBAViewController: UIViewController, DataController {
+
+    var persistentContainer: NSPersistentContainer
+    var noDataViewController: NoDataViewController?
+
+    var requestsArray: [URLSessionDataTask] = []
 
     let scrollView: UIScrollView = {
         let scrollView = UIScrollView(forAutoLayout: ())
@@ -13,36 +18,12 @@ class TBAViewController: UIViewController, DataController {
         return scrollView
     }()
 
-    // MARK: - Persistable
-
-    var persistentContainer: NSPersistentContainer
-
-    // MARK: - Refreshable
-
-    var requests: [URLSessionDataTask] = []
-
-    var refreshView: UIScrollView {
-        return scrollView
-    }
-
-    var refreshControl: UIRefreshControl? = {
-        let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: #selector(refresh), for: .valueChanged)
-        return refreshControl
-    }()
-
-    // MARK: - Stateful
-
-    var noDataViewController: NoDataViewController?
-
     // MARK: - Init
 
     init(persistentContainer: NSPersistentContainer) {
         self.persistentContainer = persistentContainer
 
         super.init(nibName: nil, bundle: nil)
-
-        enableRefreshing()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -59,25 +40,35 @@ class TBAViewController: UIViewController, DataController {
         scrollView.autoPinEdgesToSuperviewEdges()
     }
 
-    @objc func refresh() {
-        fatalError("Implement this downstream")
-    }
-
-    func shouldNoDataRefresh() -> Bool {
-        fatalError("Implement this downstream")
-    }
-
     // TODO: https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/133
     func reloadViewAfterRefresh() {
         fatalError("Implement this downstream")
     }
 
-    func enableRefreshing() {
-        scrollView.refreshControl = refreshControl
+}
+
+extension Refreshable where Self: TBAViewController {
+
+    var refreshControl: UIRefreshControl? {
+        get {
+            return scrollView.refreshControl
+        }
+        set {
+            scrollView.refreshControl = newValue
+        }
     }
 
-    func disableRefreshing() {
-        scrollView.refreshControl = nil
+    var requests: [URLSessionDataTask] {
+        get {
+            return requestsArray
+        }
+        set {
+            requestsArray = newValue
+        }
+    }
+
+    var refreshView: UIScrollView {
+        return scrollView
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
@@ -110,7 +110,7 @@ class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TB
         return delegate?.isDataSourceEmpty ?? false
     }
 
-    func refresh() {
+    @objc func refresh() {
         delegate?.refresh()
     }
 

--- a/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
@@ -8,22 +8,28 @@ protocol SelectTableViewControllerDelegate: AnyObject {
     func optionSelected(_ option: OptionType)
     func titleForOption(_ option: OptionType) -> String
 
+    var initialRefreshKey: String? { get }
+    var isDataSourceEmpty: Bool { get }
     func refresh()
-    func shouldNoDataRefresh() -> Bool
 }
 
 extension SelectTableViewControllerDelegate {
+
+    var initialRefreshKey: String? {
+        return nil
+    }
+
+    var isDataSourceEmpty: Bool {
+        return false
+    }
 
     func refresh() {
         // NOP
     }
 
-    func shouldNoDataRefresh() -> Bool {
-        return false
-    }
 }
 
-class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TBATableViewController {
+class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TBATableViewController, Refreshable {
 
     private let current: Delegate.OptionType?
     var options: [Delegate.OptionType]
@@ -36,8 +42,6 @@ class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TB
         self.willPush = willPush
 
         super.init(persistentContainer: persistentContainer)
-
-        disableRefreshing()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -49,6 +53,8 @@ class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TB
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        disableRefreshing()
 
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
         tableView.tableFooterView = UIView()
@@ -96,12 +102,16 @@ class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TB
 
     // MARK: - Refreshable
 
-    @objc override func refresh() {
-        delegate?.refresh()
+    var initialRefreshKey: String? {
+        return delegate?.initialRefreshKey
     }
 
-    override func shouldNoDataRefresh() -> Bool {
-        return delegate?.shouldNoDataRefresh() ?? false
+    var isDataSourceEmpty: Bool {
+        return delegate?.isDataSourceEmpty ?? false
+    }
+
+    func refresh() {
+        delegate?.refresh()
     }
 
     // MARK: - Private Methods

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
@@ -18,6 +18,10 @@ class DistrictEventsViewController: EventsViewController {
 
     // MARK: - Refreshable
 
+    override var initialRefreshKey: String? {
+        return "\(district.key!)_events"
+    }
+
     override func refresh() {
         removeNoDataView()
 
@@ -25,6 +29,8 @@ class DistrictEventsViewController: EventsViewController {
         request = TBAKit.sharedKit.fetchDistrictEvents(key: district.key!, completion: { (events, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh events - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
@@ -22,7 +22,7 @@ class DistrictEventsViewController: EventsViewController {
         return "\(district.key!)_events"
     }
 
-    override func refresh() {
+    @objc override func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
@@ -42,7 +42,7 @@ class DistrictRankingsViewController: TBATableViewController, Refreshable {
     }
 
     // TODO: Think about building a way to "chain" requests together for a refresh...
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         // First, fetch events

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
@@ -46,7 +46,7 @@ class DistrictsViewController: TBATableViewController, Refreshable {
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
@@ -54,7 +54,7 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Obse
         return sortedEventPoints.count == 0
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var rankingsRequest: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import CoreData
 import TBAKit
 
-class DistrictBreakdownViewController: TBATableViewController, Observable {
+class DistrictBreakdownViewController: TBATableViewController, Refreshable, Observable {
 
     private let ranking: DistrictRanking
     private let sortedEventPoints: [DistrictEventPoints]
@@ -43,9 +43,18 @@ class DistrictBreakdownViewController: TBATableViewController, Observable {
         tableView.registerReusableCell(ReverseSubtitleTableViewCell.self)
     }
 
-    // MARK: - Refreshing
+    // MARK: - Refreshable
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return "\(ranking.district!.key!)_breakdown"
+    }
+
+    var isDataSourceEmpty: Bool {
+        // This should never fire
+        return sortedEventPoints.count == 0
+    }
+
+    func refresh() {
         removeNoDataView()
 
         var rankingsRequest: URLSessionDataTask?
@@ -54,6 +63,8 @@ class DistrictBreakdownViewController: TBATableViewController, Observable {
                 self.showErrorAlert(with: "Unable to refresh team district breakdown - \(error.localizedDescription)")
                 self.removeRequest(request: rankingsRequest!)
                 return
+            } else {
+                self.markRefreshSuccessful()
             }
 
             // Might as well insert them all... we just need to only fetch
@@ -113,11 +124,6 @@ class DistrictBreakdownViewController: TBATableViewController, Observable {
                 completion(true)
             })
         })
-    }
-
-    override func shouldNoDataRefresh() -> Bool {
-        // This should never fire
-        return sortedEventPoints.count == 0
     }
 
     // MARK: Table View Data Source

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
@@ -60,7 +60,7 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable {
         return sortedEventPoints.count == 0
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
@@ -7,7 +7,7 @@ protocol DistrictTeamSummaryViewControllerDelegate: AnyObject {
     func eventPointsSelected(_ eventPoints: DistrictEventPoints)
 }
 
-class DistrictTeamSummaryViewController: TBATableViewController {
+class DistrictTeamSummaryViewController: TBATableViewController, Refreshable {
 
     private let ranking: DistrictRanking
 
@@ -52,13 +52,23 @@ class DistrictTeamSummaryViewController: TBATableViewController {
 
     // MARK: - Refresh
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return "\(ranking.district!.key!)_rankings"
+    }
+
+    var isDataSourceEmpty: Bool {
+        return sortedEventPoints.count == 0
+    }
+
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchDistrictRankings(key: ranking.district!.key!, completion: { (rankings, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh district rankings - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -75,10 +85,6 @@ class DistrictTeamSummaryViewController: TBATableViewController {
             })
         })
         addRequest(request: request!)
-    }
-
-    override func shouldNoDataRefresh() -> Bool {
-        return sortedEventPoints.count == 0
     }
 
     // MARK: - Table view data source

--- a/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
@@ -93,7 +93,7 @@ private class EventAlliancesViewController: TBATableViewController, Refreshable 
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var alliancesRequest: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
@@ -94,7 +94,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable {
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
@@ -48,19 +48,12 @@ protocol EventDistrictPointsViewControllerDelegate: AnyObject {
     func districtEventPointsSelected(_ districtEventPoints: DistrictEventPoints)
 }
 
-private class EventDistrictPointsViewController: TBATableViewController {
+private class EventDistrictPointsViewController: TBATableViewController, Refreshable {
 
     private let event: Event
 
     weak var delegate: EventDistrictPointsViewControllerDelegate?
-    private lazy var dataSource: TableViewDataSource<DistrictEventPoints, EventDistrictPointsViewController> = {
-        let fetchRequest: NSFetchRequest<DistrictEventPoints> = DistrictEventPoints.fetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "total", ascending: false)]
-        setupFetchRequest(fetchRequest)
-
-        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: nil, cacheName: nil)
-        return TableViewDataSource(tableView: tableView, fetchedResultsController: frc, delegate: self)
-    }()
+    private var dataSource: TableViewDataSource<DistrictEventPoints, EventDistrictPointsViewController>!
 
     // MARK: - Init
 
@@ -68,21 +61,36 @@ private class EventDistrictPointsViewController: TBATableViewController {
         self.event = event
 
         super.init(persistentContainer: persistentContainer)
+
+        setupDataSource()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Refreshing
+    // MARK: - Refreshable
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return "\(event.key!)_district_points"
+    }
+
+    var isDataSourceEmpty: Bool {
+        if let points = dataSource.fetchedResultsController.fetchedObjects, points.isEmpty {
+            return true
+        }
+        return false
+    }
+
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchEventDistrictPoints(key: event.key!, completion: { (eventPoints, _, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh event district points - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -100,13 +108,6 @@ private class EventDistrictPointsViewController: TBATableViewController {
         addRequest(request: request!)
     }
 
-    override func shouldNoDataRefresh() -> Bool {
-        if let points = dataSource.fetchedResultsController.fetchedObjects, points.isEmpty {
-            return true
-        }
-        return false
-    }
-
     // MARK: UITableView Delegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -115,6 +116,15 @@ private class EventDistrictPointsViewController: TBATableViewController {
     }
 
     // MARK: Table View Data Source
+
+    private func setupDataSource() {
+        let fetchRequest: NSFetchRequest<DistrictEventPoints> = DistrictEventPoints.fetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "total", ascending: false)]
+        setupFetchRequest(fetchRequest)
+
+        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: nil, cacheName: nil)
+        dataSource = TableViewDataSource(fetchedResultsController: frc, delegate: self)
+    }
 
     private func updateDataSource() {
         dataSource.reconfigureFetchRequest(setupFetchRequest(_:))

--- a/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
@@ -82,7 +82,7 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventInfoViewController.swift
@@ -32,7 +32,7 @@ private enum EventLinkRow: Int {
     case max
 }
 
-class EventInfoViewController: TBATableViewController, Observable {
+class EventInfoViewController: TBATableViewController, Refreshable, Observable {
 
     private let event: Event
     private let urlOpener: URLOpener
@@ -74,15 +74,25 @@ class EventInfoViewController: TBATableViewController, Observable {
         tableView.registerReusableCell(InfoTableViewCell.self)
     }
 
-    // MARK: - Refresh
+    // MARK: - Refreshable
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return event.key!
+    }
+
+    var isDataSourceEmpty: Bool {
+        return event.name == nil
+    }
+
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchEvent(key: event.key!, completion: { (modelEvent, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh event - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -95,10 +105,6 @@ class EventInfoViewController: TBATableViewController, Observable {
             })
         })
         addRequest(request: request!)
-    }
-
-    override func shouldNoDataRefresh() -> Bool {
-        return event.name == nil
     }
 
     // MARK: - Table view data source

--- a/the-blue-alliance-ios/View Controllers/Events/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventInfoViewController.swift
@@ -84,7 +84,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Observable {
         return event.name == nil
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
@@ -41,7 +41,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable {
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var rankingsRequest: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
@@ -7,19 +7,12 @@ protocol EventRankingsViewControllerDelegate: AnyObject {
     func rankingSelected(_ ranking: EventRanking)
 }
 
-class EventRankingsViewController: TBATableViewController {
+class EventRankingsViewController: TBATableViewController, Refreshable {
 
     private let event: Event
 
     weak var delegate: EventRankingsViewControllerDelegate?
-    private lazy var dataSource: TableViewDataSource<EventRanking, EventRankingsViewController> = {
-        let fetchRequest: NSFetchRequest<EventRanking> = EventRanking.fetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "rank", ascending: true)]
-        setupFetchRequest(fetchRequest)
-
-        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: nil, cacheName: nil)
-        return TableViewDataSource(tableView: tableView, fetchedResultsController: frc, delegate: self)
-    }()
+    private var dataSource: TableViewDataSource<EventRanking, EventRankingsViewController>!
 
     // MARK: - Init
 
@@ -27,21 +20,36 @@ class EventRankingsViewController: TBATableViewController {
         self.event = event
 
         super.init(persistentContainer: persistentContainer)
+
+        setupDataSource()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Refreshing
+    // MARK: - Refreshable
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return "\(event.key!)_rankings"
+    }
+
+    var isDataSourceEmpty: Bool {
+        if let rankings = dataSource.fetchedResultsController.fetchedObjects, rankings.isEmpty {
+            return true
+        }
+        return false
+    }
+
+    func refresh() {
         removeNoDataView()
 
         var rankingsRequest: URLSessionDataTask?
-        rankingsRequest = TBAKit.sharedKit.fetchEventRankings(key: self.event.key!, completion: { (rankings, sortOrder, _, error) in
+        rankingsRequest = TBAKit.sharedKit.fetchEventRankings(key: event.key!, completion: { (rankings, sortOrder, _, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh event rankings - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -61,13 +69,6 @@ class EventRankingsViewController: TBATableViewController {
         self.addRequest(request: rankingsRequest!)
     }
 
-    override func shouldNoDataRefresh() -> Bool {
-        if let rankings = dataSource.fetchedResultsController.fetchedObjects, rankings.isEmpty {
-            return true
-        }
-        return false
-    }
-
     // MARK: UITableView Delegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -76,6 +77,15 @@ class EventRankingsViewController: TBATableViewController {
     }
 
     // MARK: Table View Data Source
+
+    private func setupDataSource() {
+        let fetchRequest: NSFetchRequest<EventRanking> = EventRanking.fetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "rank", ascending: true)]
+        setupFetchRequest(fetchRequest)
+
+        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: nil, cacheName: nil)
+        dataSource = TableViewDataSource(fetchedResultsController: frc, delegate: self)
+    }
 
     private func updateDataSource() {
         dataSource.reconfigureFetchRequest(setupFetchRequest(_:))

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -4,7 +4,7 @@ import React
 import TBAKit
 import CoreData
 
-class MatchBreakdownViewController: TBAViewController, Observable, ReactNative {
+class MatchBreakdownViewController: TBAViewController, Refreshable, Observable, ReactNative {
 
     private let match: Match
 
@@ -123,19 +123,25 @@ class MatchBreakdownViewController: TBAViewController, Observable, ReactNative {
                 "compLevel": match.compLevel!]
     }
 
-    // MARK: Refresh
+    // MARK: - Refreshable
 
-    override func shouldNoDataRefresh() -> Bool {
+    var initialRefreshKey: String? {
+        return match.key!
+    }
+
+    var isDataSourceEmpty: Bool {
         return match.redBreakdown == nil || match.blueBreakdown == nil
     }
 
-    override func refresh() {
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchMatch(key: match.key!, { (modelMatch, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh match breakdown - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -153,7 +159,7 @@ class MatchBreakdownViewController: TBAViewController, Observable, ReactNative {
     }
 
     override func reloadViewAfterRefresh() {
-        if shouldNoDataRefresh() {
+        if isDataSourceEmpty {
             showNoDataView()
         } else {
             updateBreakdownView()

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -133,7 +133,7 @@ class MatchBreakdownViewController: TBAViewController, Refreshable, Observable, 
         return match.redBreakdown == nil || match.blueBreakdown == nil
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
@@ -186,7 +186,7 @@ class MatchInfoViewController: TBAViewController, Refreshable, Observable {
         return (match.videos?.count ?? 0) == 0
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
@@ -4,7 +4,7 @@ import CoreData
 import TBAKit
 import PureLayout
 
-class MatchInfoViewController: TBAViewController, Observable {
+class MatchInfoViewController: TBAViewController, Refreshable, Observable {
 
     private let match: Match
     private let team: Team?
@@ -176,19 +176,25 @@ class MatchInfoViewController: TBAViewController, Observable {
 
     // MARK: Refresh
 
-    override func shouldNoDataRefresh() -> Bool {
+    var initialRefreshKey: String? {
+        return match.key!
+    }
+
+    var isDataSourceEmpty: Bool {
         // TODO: Think about doing a quiet refresh in the background for match videos on initial load...
         // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/135
         return (match.videos?.count ?? 0) == 0
     }
 
-    override func refresh() {
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchMatch(key: match.key!, { (modelMatch, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh match - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchViewController.swift
@@ -23,7 +23,7 @@ class MatchContainerViewController: ContainerViewController {
             breakdownViewController = MatchBreakdownViewController(match: match, persistentContainer: persistentContainer)
         }
 
-        super.init(viewControllers: [infoViewController, breakdownViewController].compactMap({ $0 }),
+        super.init(viewControllers: [infoViewController, breakdownViewController].compactMap({ $0 }) as! [ContainableViewController],
                    segmentedControlTitles: titles,
                    persistentContainer: persistentContainer)
     }

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -7,22 +7,13 @@ protocol MatchesViewControllerDelegate: AnyObject {
     func matchSelected(_ match: Match)
 }
 
-class MatchesViewController: TBATableViewController {
+class MatchesViewController: TBATableViewController, Refreshable {
 
     private let event: Event
     private let team: Team?
 
     weak var delegate: MatchesViewControllerDelegate?
-    private lazy var dataSource: TableViewDataSource<Match, MatchesViewController> = {
-        let fetchRequest: NSFetchRequest<Match> = Match.fetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "compLevelInt", ascending: true),
-                                        NSSortDescriptor(key: "setNumber", ascending: true),
-                                        NSSortDescriptor(key: "matchNumber", ascending: true)]
-        setupFetchRequest(fetchRequest)
-
-        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: "compLevelInt", cacheName: nil)
-        return TableViewDataSource(tableView: tableView, fetchedResultsController: frc, delegate: self)
-    }()
+    private var dataSource: TableViewDataSource<Match, MatchesViewController>!
 
     // MARK: - Init
 
@@ -31,21 +22,36 @@ class MatchesViewController: TBATableViewController {
         self.team = team
 
         super.init(persistentContainer: persistentContainer)
+
+        setupDataSource()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Refreshing
+    // MARK: - Refreshable
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return "\(event.key!)_matches"
+    }
+
+    var isDataSourceEmpty: Bool {
+        if let matches = dataSource.fetchedResultsController.fetchedObjects, matches.isEmpty {
+            return true
+        }
+        return false
+    }
+
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchEventMatches(key: event.key!, completion: { (matches, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh event matches - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -63,14 +69,18 @@ class MatchesViewController: TBATableViewController {
         addRequest(request: request!)
     }
 
-    override func shouldNoDataRefresh() -> Bool {
-        if let matches = dataSource.fetchedResultsController.fetchedObjects, matches.isEmpty {
-            return true
-        }
-        return false
-    }
-
     // MARK: Table View Data Source
+
+    private func setupDataSource() {
+        let fetchRequest: NSFetchRequest<Match> = Match.fetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "compLevelInt", ascending: true),
+                                        NSSortDescriptor(key: "setNumber", ascending: true),
+                                        NSSortDescriptor(key: "matchNumber", ascending: true)]
+        setupFetchRequest(fetchRequest)
+
+        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: "compLevelInt", cacheName: nil)
+        dataSource = TableViewDataSource(fetchedResultsController: frc, delegate: self)
+    }
 
     private func updateDataSource() {
         dataSource.reconfigureFetchRequest(setupFetchRequest(_:))

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -43,7 +43,7 @@ class MatchesViewController: TBATableViewController, Refreshable {
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
@@ -111,7 +111,7 @@ class EventStatsViewController: TBAViewController, Refreshable, Observable, Reac
         return qual == nil || playoff == nil
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
@@ -4,7 +4,7 @@ import TBAKit
 import UIKit
 import React
 
-class EventStatsViewController: TBAViewController, Observable, ReactNative {
+class EventStatsViewController: TBAViewController, Refreshable, Observable, ReactNative {
 
     private let event: Event
 
@@ -95,9 +95,13 @@ class EventStatsViewController: TBAViewController, Observable, ReactNative {
         showNoDataView(with: "No stats for event")
     }
 
-    // MARK: Refresh
+    // MARK: - Refreshable
 
-    override func shouldNoDataRefresh() -> Bool {
+    var initialRefreshKey: String? {
+        return "\(event.key!)_insights"
+    }
+
+    var isDataSourceEmpty: Bool {
         guard let insights = event.insights else {
             return true
         }
@@ -107,13 +111,15 @@ class EventStatsViewController: TBAViewController, Observable, ReactNative {
         return qual == nil || playoff == nil
     }
 
-    override func refresh() {
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchEventInsights(key: event.key!, completion: { (insights, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh event stats - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -128,7 +134,7 @@ class EventStatsViewController: TBAViewController, Observable, ReactNative {
     }
 
     override func reloadViewAfterRefresh() {
-        if shouldNoDataRefresh() {
+        if isDataSourceEmpty {
             showNoDataView()
         } else {
             updateEventStatsView()

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
@@ -70,7 +70,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable {
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -39,7 +39,7 @@ class WeekEventsViewController: EventsViewController {
         return "\(year)_events"
     }
 
-    override func refresh() {
+    @objc override func refresh() {
         removeNoDataView()
 
         // Default to refreshing the currently selected year

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -35,6 +35,10 @@ class WeekEventsViewController: EventsViewController {
 
     // MARK: - Refreshable
 
+    override var initialRefreshKey: String? {
+        return "\(year)_events"
+    }
+
     override func refresh() {
         removeNoDataView()
 
@@ -49,6 +53,8 @@ class WeekEventsViewController: EventsViewController {
         request = TBAKit.sharedKit.fetchEvents(year: year, completion: { (events, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh events - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -149,7 +149,7 @@ extension EventWeekSelectViewController: SelectTableViewControllerDelegate {
         return weeks.isEmpty
     }
 
-    func refresh() {
+    @objc func refresh() {
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchEvents(year: year, completion: { (events, error) in
             if let error = error {

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -122,7 +122,7 @@ private class EventWeekSelectViewController: ContainerViewController {
 
     private func updateWeeks() {
         weeks = Event.weekEvents(for: year, in: persistentContainer.viewContext)
-        if shouldNoDataRefresh() && hasRefreshed {
+        if isDataSourceEmpty && hasRefreshed {
             selectViewController.showNoDataView(with: "No weeks for \(year)")
         }
     }
@@ -141,11 +141,22 @@ extension EventWeekSelectViewController: SelectTableViewControllerDelegate {
         return option.weekString
     }
 
+    var initialRefreshKey: String? {
+        return "\(year)_events"
+    }
+
+    var isDataSourceEmpty: Bool {
+        return weeks.isEmpty
+    }
+
     func refresh() {
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchEvents(year: year, completion: { (events, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh events - \(error.localizedDescription)")
+            } else {
+                // TODO: Fix this
+                // self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -161,10 +172,6 @@ extension EventWeekSelectViewController: SelectTableViewControllerDelegate {
             })
         })
         selectViewController.addRequest(request: request!)
-    }
-
-    func shouldNoDataRefresh() -> Bool {
-        return weeks.isEmpty
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -155,8 +155,11 @@ extension EventWeekSelectViewController: SelectTableViewControllerDelegate {
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh events - \(error.localizedDescription)")
             } else {
-                // TODO: Fix this
-                // self.markRefreshSuccessful()
+                // TODO: Use markRefreshSuccessful from Refreshable
+                if let initialRefreshKey = self.initialRefreshKey {
+                    UserDefaults.standard.set(true, forKey: initialRefreshKey)
+                    UserDefaults.standard.synchronize()
+                }
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
@@ -59,7 +59,7 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         // I'd love to use MyTBAManaged's RemoteType here, but it doesn't seem like I can get it

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
@@ -108,7 +108,7 @@ class MyTBAViewController: ContainerViewController, GIDSignInUIDelegate {
         try! Auth.auth().signOut()
 
         // Cancel any ongoing requests
-        for vc in [favoritesViewController, subscriptionsViewController] {
+        for vc in [favoritesViewController, subscriptionsViewController] as! [Refreshable] {
             vc.cancelRefresh()
         }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamEventsViewController.swift
@@ -29,7 +29,7 @@ class TeamEventsViewController: EventsViewController {
         return "\(team.key!)_events"
     }
 
-    override func refresh() {
+    @objc override func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamEventsViewController.swift
@@ -23,7 +23,11 @@ class TeamEventsViewController: EventsViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Refreshing
+    // MARK: - Refreshable
+
+    override var initialRefreshKey: String? {
+        return "\(team.key!)_events"
+    }
 
     override func refresh() {
         removeNoDataView()
@@ -32,6 +36,8 @@ class TeamEventsViewController: EventsViewController {
         request = TBAKit.sharedKit.fetchTeamEvents(key: team.key!, completion: { (events, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh events - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamInfoViewController.swift
@@ -61,7 +61,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable {
         return team.name == nil
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamInfoViewController.swift
@@ -22,7 +22,7 @@ private enum TeamLinkRow: Int {
     case max
 }
 
-class TeamInfoViewController: TBATableViewController {
+class TeamInfoViewController: TBATableViewController, Refreshable {
 
     private var team: Team
     private let urlOpener: URLOpener
@@ -53,13 +53,23 @@ class TeamInfoViewController: TBATableViewController {
 
     // MARK: - Refresh
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return team.key!
+    }
+
+    var isDataSourceEmpty: Bool {
+        return team.name == nil
+    }
+
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchTeam(key: team.key!, completion: { (modelTeam, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh team - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -72,11 +82,6 @@ class TeamInfoViewController: TBATableViewController {
             })
         })
         addRequest(request: request!)
-    }
-
-    override func shouldNoDataRefresh() -> Bool {
-        // TODO: This is always going to exist... check on something else?
-        return team.name == nil
     }
 
     // MARK: - Table view data source

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
@@ -62,7 +62,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController, Refreshabl
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         guard let year = year else {
             showNoDataView(with: "No year selected")
             refreshControl?.endRefreshing()

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
@@ -68,7 +68,7 @@ class TeamStatsViewController: TBATableViewController, Refreshable, Observable {
         return teamStat == nil
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import CoreData
 import TBAKit
 
-class TeamStatsViewController: TBATableViewController, Observable {
+class TeamStatsViewController: TBATableViewController, Refreshable, Observable {
 
     private let event: Event
     private let team: Team
@@ -60,13 +60,23 @@ class TeamStatsViewController: TBATableViewController, Observable {
 
     // MARK: - Refresh
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return "\(event.key!)_team_stats"
+    }
+
+    var isDataSourceEmpty: Bool {
+        return teamStat == nil
+    }
+
+    func refresh() {
         removeNoDataView()
 
         var request: URLSessionDataTask?
         request = TBAKit.sharedKit.fetchEventTeamStats(key: event.key!, completion: { (stats, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh team stats - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -81,10 +91,6 @@ class TeamStatsViewController: TBATableViewController, Observable {
             })
         })
         addRequest(request: request!)
-    }
-
-    override func shouldNoDataRefresh() -> Bool {
-        return teamStat == nil
     }
 
     // MARK: Table View Data Source

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
@@ -175,7 +175,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable {
         return eventStatus == nil || teamAwards.count == 0
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         // Refresh team status

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
@@ -21,7 +21,7 @@ private enum TeamSummaryRow: Int {
     case max
 }
 
-class TeamSummaryViewController: TBATableViewController {
+class TeamSummaryViewController: TBATableViewController, Refreshable {
 
     private let team: Team
     private let event: Event
@@ -167,7 +167,15 @@ class TeamSummaryViewController: TBATableViewController {
 
     // MARK: - Refresh
 
-    override func refresh() {
+    var initialRefreshKey: String? {
+        return "\(team.key!)@\(event.key!)_status"
+    }
+
+    var isDataSourceEmpty: Bool {
+        return eventStatus == nil || teamAwards.count == 0
+    }
+
+    func refresh() {
         removeNoDataView()
 
         // Refresh team status
@@ -175,6 +183,8 @@ class TeamSummaryViewController: TBATableViewController {
         teamStatusRequest = TBAKit.sharedKit.fetchTeamStatus(key: team.key!, eventKey: event.key!, completion: { (modelStatus, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to refresh event - \(error.localizedDescription)")
+            } else {
+                self.markRefreshSuccessful()
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
@@ -211,10 +221,6 @@ class TeamSummaryViewController: TBATableViewController {
             })
         })
         addRequest(request: awardsRequest!)
-    }
-
-    override func shouldNoDataRefresh() -> Bool {
-        return eventStatus == nil || teamAwards.count == 0
     }
 
     // MARK: - Table view data source

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamViewController.swift
@@ -104,7 +104,7 @@ class TeamViewController: ContainerViewController, Observable {
     }
 
     private func refreshYearsParticipated() {
-        _ = TBAKit.sharedKit.fetchTeamYearsParticipated(key: team.key!, completion: { (years, error) in
+        TBAKit.sharedKit.fetchTeamYearsParticipated(key: team.key!, completion: { (years, error) in
             if let error = error {
                 self.showErrorAlert(with: "Unable to fetch years participated - \(error.localizedDescription)")
                 return

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -62,7 +62,7 @@ class TeamsViewController: TBATableViewController, Refreshable {
         return false
     }
 
-    func refresh() {
+    @objc func refresh() {
         removeNoDataView()
 
         if event != nil {


### PR DESCRIPTION
- Initially refresh view controllers (part of #197)
- Removes table view/collection view from `TableViewDataSource`/`CollectionViewDataSource`
- Upgrade TBAKit to 2.0.7
- Conform error enums to `LocalizedError` (and adds tests)
- Renames `APIError` in MyTBA to `MyTBAError`
- Explicitly conform data controllers to `Refreshable`
- Removes `shouldNoDataRefresh` in `Refreshable`, use `isDataSourceEmpty` instead
- Adds `Refreshable where` extension in `TBAViewController`/`TBATableViewController`/`TBACollectionViewController`