### PR TITLE
Fix year select crash

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
@@ -12,7 +12,13 @@ protocol SelectTableViewControllerDelegate: AnyObject {
 class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TBATableViewController, Refreshable {
 
     private let current: Delegate.OptionType?
-    var options: [Delegate.OptionType]
+    var options: [Delegate.OptionType] {
+        didSet {
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
+        }
+    }
     private let willPush: Bool
     weak var delegate: Delegate?
 
@@ -82,8 +88,16 @@ class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TB
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
-        fatalError("implement in subclass")
+    var refreshKey: String? {
+        return nil
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {
@@ -91,7 +105,7 @@ class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TB
     }
 
     @objc func refresh() {
-        fatalError("implement in subclass")
+        // NOP
     }
 
     // MARK: - Private Methods

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
@@ -18,15 +18,15 @@ class DistrictEventsViewController: EventsViewController {
 
     // MARK: - Refreshable
 
-    override var refreshKey: String {
+    override var refreshKey: String? {
         return "\(district.key!)_events"
     }
 
-    var automaticRefreshInterval: DateComponents? {
+    override var automaticRefreshInterval: DateComponents? {
         return DateComponents(day: 7)
     }
 
-    var automaticRefreshEndDate: Date? {
+    override var automaticRefreshEndDate: Date? {
         // Automatically refresh event districts during the year before the selected year (when events are rolling in)
         // Ex: Districts for 2019 will stop automatically refreshing on January 1st, 2019 (should all be set by then)
         return Calendar.current.date(from: DateComponents(year: Int(district.year)))

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
@@ -30,7 +30,7 @@ class DistrictRankingsViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(district.key!)_rankings"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
@@ -35,7 +35,7 @@ class DistrictsViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(year)_districts"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
@@ -45,7 +45,7 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Obse
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(ranking.district!.key!)_breakdown"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
@@ -52,7 +52,7 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refresh
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(ranking.district!.key!)_rankings"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
@@ -82,8 +82,16 @@ private class EventAlliancesViewController: TBATableViewController, Refreshable 
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(event.key!)_alliances"
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {

--- a/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
@@ -83,8 +83,16 @@ class EventAwardsViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(event.key!)_awards"
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {

--- a/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
@@ -71,8 +71,16 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(event.key!)_district_points"
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {

--- a/the-blue-alliance-ios/View Controllers/Events/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventInfoViewController.swift
@@ -76,8 +76,16 @@ class EventInfoViewController: TBATableViewController, Refreshable, Observable {
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
-        return event.key!
+    var refreshKey: String? {
+        return event.key
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {

--- a/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
@@ -30,7 +30,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(event.key!)_rankings"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
@@ -54,8 +54,16 @@ class EventsViewController: TBATableViewController, Refreshable, EventsViewContr
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         fatalError("implement in subclass")
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -125,8 +125,16 @@ class MatchBreakdownViewController: TBAViewController, Refreshable, Observable, 
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
-        return match.key!
+    var refreshKey: String? {
+        return match.key
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
@@ -176,8 +176,8 @@ class MatchInfoViewController: TBAViewController, Refreshable, Observable {
 
     // MARK: Refresh
 
-    var refreshKey: String {
-        return match.key!
+    var refreshKey: String? {
+        return match.key
     }
 
     var automaticRefreshInterval: DateComponents? {

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -32,7 +32,7 @@ class MatchesViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(event.key!)_matches"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
@@ -97,7 +97,7 @@ class EventStatsViewController: TBAViewController, Refreshable, Observable, Reac
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(event.key!)_insights"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
@@ -59,7 +59,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(event.key!)_team_stats"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -35,15 +35,15 @@ class WeekEventsViewController: EventsViewController {
 
     // MARK: - Refreshable
 
-    override var refreshKey: String {
+    override var refreshKey: String? {
         return "\(year)_events"
     }
 
-    var automaticRefreshInterval: DateComponents? {
+    override var automaticRefreshInterval: DateComponents? {
         return DateComponents(day: 7)
     }
 
-    var automaticRefreshEndDate: Date? {
+    override var automaticRefreshEndDate: Date? {
         // Automatically refresh the events for the duration of the year
         // Ex: 2019 events will stop automatically refreshing on Jan 1st, 2020
         return Calendar.current.date(from: DateComponents(year: year + 1))

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
@@ -48,12 +48,16 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return J.arrayKey
     }
 
     var automaticRefreshInterval: DateComponents? {
         return DateComponents(day: 1)
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {

--- a/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
@@ -173,6 +173,7 @@ class SettingsViewController: UITableViewController, Persistable {
     }
 
     internal func deleteNetworkCache() {
+        clearSuccessfulRefreshes()
         TBAKit.clearLastModified()
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamEventsViewController.swift
@@ -25,15 +25,15 @@ class TeamEventsViewController: EventsViewController {
 
     // MARK: - Refreshable
 
-    override var refreshKey: String {
+    override var refreshKey: String? {
         return "\(team.key!)_events"
     }
 
-    var automaticRefreshInterval: DateComponents? {
+    override var automaticRefreshInterval: DateComponents? {
         return DateComponents(day: 7)
     }
 
-    var automaticRefreshEndDate: Date? {
+    override var automaticRefreshEndDate: Date? {
         guard let year = year else {
             return nil
         }

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamInfoViewController.swift
@@ -53,8 +53,16 @@ class TeamInfoViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refresh
 
-    var refreshKey: String {
-        return team.key!
+    var refreshKey: String? {
+        return team.key
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
     }
 
     var isDataSourceEmpty: Bool {

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
@@ -48,16 +48,11 @@ class TeamMediaCollectionViewController: TBACollectionViewController, Refreshabl
 
     // MARK: - Refreshable
 
-    var initialRefreshKey: String? {
+    var refreshKey: String? {
         guard let year = year else {
             return nil
         }
         return "\(year)_\(team.key!)_media"
-    }
-
-    var refreshKey: String {
-        // TODO: This is going to crash, for sure. Show loading spinner and avoid methods until we have years
-        return "\(year!)_\(team.key!)_media"
     }
 
     var automaticRefreshInterval: DateComponents? {

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
@@ -60,7 +60,7 @@ class TeamStatsViewController: TBATableViewController, Refreshable, Observable {
 
     // MARK: - Refresh
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(event.key!)_team_stats"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
@@ -167,7 +167,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refresh
 
-    var refreshKey: String {
+    var refreshKey: String? {
         return "\(team.key!)@\(event.key!)_status"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -48,7 +48,7 @@ class TeamsViewController: TBATableViewController, Refreshable {
 
     // MARK: - Refreshable
 
-    var refreshKey: String {
+    var refreshKey: String? {
         if let event = event {
             return "\(event.key!)_teams"
         }


### PR DESCRIPTION
- Add WeeksSelectTableViewController to handle refresh logic for EventWeekSelectViewController
- Makes `refreshKey` nullable, for `SelectTableViewController`
- Remove default protocol implementation of `automaticRefreshInterval` and `automaticRefreshEndDate`
- Make `lastRefresh` date private
- Add `clearSuccessfulRefreshes` to clear all previous refreshes
- Call `clearSuccessfulRefreshes` during `Delete Network Cache` in Settings
- Update Refreshable tests for new behavior