### PR TITLE
Remove observerPredicate default implementation on Observable extension

### DIFF
--- a/the-blue-alliance-ios/Protocols/Observable.swift
+++ b/the-blue-alliance-ios/Protocols/Observable.swift
@@ -9,12 +9,3 @@ protocol Observable: Persistable {
     var contextObserver: CoreDataContextObserver<ManagedType> { get }
     var observerPredicate: NSPredicate { get }
 }
-
-extension Observable {
-
-    // Make observerPredicate optional
-    var observerPredicate: NSPredicate {
-        return NSPredicate()
-    }
-
-}

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
@@ -14,6 +14,9 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Obse
     lazy var contextObserver: CoreDataContextObserver<DistrictRanking> = {
         return CoreDataContextObserver(context: persistentContainer.viewContext)
     }()
+    lazy var observerPredicate: NSPredicate = {
+        return NSPredicate()
+    }()
 
     // MARK: - Init
 

--- a/the-blue-alliance-ios/View Controllers/Events/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventInfoViewController.swift
@@ -45,6 +45,9 @@ class EventInfoViewController: TBATableViewController, Refreshable, Observable {
     lazy var contextObserver: CoreDataContextObserver<Event> = {
         return CoreDataContextObserver(context: persistentContainer.viewContext)
     }()
+    lazy var observerPredicate: NSPredicate = {
+        return NSPredicate()
+    }()
 
     // MARK: - Init
 

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -35,6 +35,9 @@ class MatchBreakdownViewController: TBAViewController, Refreshable, Observable, 
     lazy var contextObserver: CoreDataContextObserver<Match> = {
         return CoreDataContextObserver(context: persistentContainer.viewContext)
     }()
+    lazy var observerPredicate: NSPredicate = {
+        return NSPredicate()
+    }()
 
     // MARK: - Init
 

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
@@ -68,6 +68,9 @@ class MatchInfoViewController: TBAViewController, Refreshable, Observable {
     lazy var contextObserver: CoreDataContextObserver<Match> = {
         return CoreDataContextObserver(context: persistentContainer.viewContext)
     }()
+    lazy var observerPredicate: NSPredicate = {
+        return NSPredicate()
+    }()
 
     // MARK: Class Methods
 

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
@@ -36,6 +36,9 @@ class EventStatsViewController: TBAViewController, Refreshable, Observable, Reac
     lazy var contextObserver: CoreDataContextObserver<Event> = {
         return CoreDataContextObserver(context: persistentContainer.viewContext)
     }()
+    lazy var observerPredicate: NSPredicate = {
+        return NSPredicate()
+    }()
 
     // MARK: - Init
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamViewController.swift
@@ -33,6 +33,9 @@ class TeamViewController: ContainerViewController, Observable {
     lazy var contextObserver: CoreDataContextObserver<Team> = {
         return CoreDataContextObserver(context: persistentContainer.viewContext)
     }()
+    lazy var observerPredicate: NSPredicate = {
+        return NSPredicate()
+    }()
 
     // MARK: Init
 


### PR DESCRIPTION
Subclasses can't override protocol extensions by default, so we need to have them explicitly define that empty functionality in the conforming classes