### PR TITLE
Remove view clean from prepareForReuse to configureCell

### DIFF
--- a/the-blue-alliance-ios/View Elements/Awards/AwardTableViewCell.swift
+++ b/the-blue-alliance-ios/View Elements/Awards/AwardTableViewCell.swift
@@ -21,15 +21,13 @@ class AwardTableViewCell: UITableViewCell, Reusable {
     @IBOutlet private weak var awardNameLabel: UILabel!
     @IBOutlet private weak var awardInfoStackView: UIStackView!
 
-    // MARK: - View Methods
+    // MARK: - Private Methods
 
-    override func prepareForReuse() {
+    private func removeAwards() {
         for view in awardInfoStackView.arrangedSubviews {
             view.removeFromSuperview()
         }
     }
-
-    // MARK: - Private Methods
 
     private func configureCell() {
         guard let viewModel = viewModel else {
@@ -37,6 +35,8 @@ class AwardTableViewCell: UITableViewCell, Reusable {
         }
 
         awardNameLabel.text = viewModel.awardName
+
+        removeAwards()
 
         for (index, recipient) in viewModel.recipients.enumerated() {
             let stackView = UIStackView()

--- a/the-blue-alliance-ios/View Elements/Events/EventAllianceTableViewCell.swift
+++ b/the-blue-alliance-ios/View Elements/Events/EventAllianceTableViewCell.swift
@@ -26,17 +26,13 @@ class EventAllianceTableViewCell: UITableViewCell, Reusable {
 
     private let underlineAttribute = [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue]
 
-    // MARK: - View Methods
+    // MARK: - Private Methods
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-
+    private func removeAllianceTeams() {
         for view in allianceTeamsStackView.arrangedSubviews {
             view.removeFromSuperview()
         }
     }
-
-    // MARK: - Private Methods
 
     private func labelWithText(_ text: String) -> UILabel {
         let label = UILabel()
@@ -63,6 +59,8 @@ class EventAllianceTableViewCell: UITableViewCell, Reusable {
 
         nameLabel.isHidden = !viewModel.hasAllianceName
         nameLabel.text = viewModel.allianceName
+
+        removeAllianceTeams()
 
         // OH PICK BOY http://photos.prnewswire.com/prnvar/20140130/NY56077
         for (index, teamKey) in viewModel.picks.enumerated() {

--- a/the-blue-alliance-ios/View Elements/Info/InfoTableViewCell.swift
+++ b/the-blue-alliance-ios/View Elements/Info/InfoTableViewCell.swift
@@ -18,17 +18,13 @@ class InfoTableViewCell: UITableViewCell, Reusable {
 
     @IBOutlet private weak var infoStackView: UIStackView!
 
-    // MARK: - View Methods
+    // MARK: - Private Methods
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-
+    private func removeInfo() {
         for view in infoStackView.arrangedSubviews {
             view.removeFromSuperview()
         }
     }
-
-    // MARK: - Private Methods
 
     private func labelWithText(_ text: String) -> UILabel {
         let label = UILabel()
@@ -54,6 +50,8 @@ class InfoTableViewCell: UITableViewCell, Reusable {
         guard let viewModel = viewModel else {
             return
         }
+
+        removeInfo()
 
         let nameLabel = titleLabelWithText(viewModel.nameString)
         infoStackView.addArrangedSubview(nameLabel)

--- a/the-blue-alliance-ios/View Elements/Match/MatchView.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchView.swift
@@ -62,15 +62,6 @@ class MatchView: UIView {
     // MARK: - Public Methods
 
     func resetView() {
-        for stackView in [redStackView, blueStackView] as [UIStackView] {
-            for view in stackView.arrangedSubviews {
-                if [redScoreLabel, blueScoreLabel].contains(view) {
-                    continue
-                }
-                view.removeFromSuperview()
-            }
-        }
-
         redContainerView.layer.borderWidth = 0.0
         blueContainerView.layer.borderWidth = 0.0
 
@@ -80,6 +71,17 @@ class MatchView: UIView {
 
     // MARK: - Private Methods
 
+    private func removeTeams() {
+        for stackView in [redStackView, blueStackView] as [UIStackView] {
+            for view in stackView.arrangedSubviews {
+                if [redScoreLabel, blueScoreLabel].contains(view) {
+                    continue
+                }
+                view.removeFromSuperview()
+            }
+        }
+    }
+
     private func configureView() {
         guard let viewModel = viewModel else {
             return
@@ -87,6 +89,8 @@ class MatchView: UIView {
 
         matchNumberLabel.text = viewModel.matchName
         playIconImageView.isHidden = viewModel.hasVideos
+
+        removeTeams()
 
         for teamKey in viewModel.redAlliance {
             let teamLabel = label(for: teamKey, baseTeamKey: viewModel.baseTeamKey)


### PR DESCRIPTION
This fixes Event Alliances not removing the default cell content - the cells were never "reused", they were just init'd for the first time. This goes with the safer (and previous) route of removing existing info when setting up a cell.