### PR TITLE
Fix model relationships being overwritten by empty cache responses

### DIFF
--- a/the-blue-alliance-ios/Core Data/Award.swift
+++ b/the-blue-alliance-ios/Core Data/Award.swift
@@ -4,6 +4,7 @@ import TBAKit
 
 extension Award: Managed {
 
+    @discardableResult
     static func insert(with model: TBAAward, for event: Event, in context: NSManagedObjectContext) -> Award {
         let predicate = NSPredicate(format: "awardType == %ld && year == %ld && event == %@", model.awardType, model.year, event)
         return findOrCreate(in: context, matching: predicate) { (award) in

--- a/the-blue-alliance-ios/Core Data/DistrictEventPoints.swift
+++ b/the-blue-alliance-ios/Core Data/DistrictEventPoints.swift
@@ -4,6 +4,7 @@ import TBAKit
 
 extension DistrictEventPoints: Managed {
 
+    @discardableResult
     static func insert(with model: TBADistrictEventPoints, for event: Event, in context: NSManagedObjectContext) -> DistrictEventPoints {
         guard let teamKey = model.teamKey else {
             fatalError("Need team key")

--- a/the-blue-alliance-ios/Core Data/DistrictRanking.swift
+++ b/the-blue-alliance-ios/Core Data/DistrictRanking.swift
@@ -4,6 +4,7 @@ import CoreData
 
 extension DistrictRanking: Managed {
 
+    @discardableResult
     static func insert(with model: TBADistrictRanking, for district: District, for team: Team, in context: NSManagedObjectContext) -> DistrictRanking {
         let predicate = NSPredicate(format: "district == %@ AND team == %@", district, team)
         return findOrCreate(in: context, matching: predicate, configure: { (ranking) in

--- a/the-blue-alliance-ios/Core Data/EventAlliance.swift
+++ b/the-blue-alliance-ios/Core Data/EventAlliance.swift
@@ -4,6 +4,7 @@ import CoreData
 
 extension EventAlliance: Managed {
 
+    @discardableResult
     static func insert(with model: TBAAlliance, for event: Event, in context: NSManagedObjectContext) -> EventAlliance {
         // Kill.... me.....
         let predicate = NSPredicate(format: "event == %@ AND (SUBQUERY(picks, $pick, $pick.key IN %@) .@count == %d)", event, model.picks, model.picks.count)

--- a/the-blue-alliance-ios/Core Data/EventRanking.swift
+++ b/the-blue-alliance-ios/Core Data/EventRanking.swift
@@ -17,6 +17,7 @@ extension EventRanking: Managed {
         }
     }
 
+    @discardableResult
     static func insert(with model: TBAEventRanking, for event: Event, for team: Team, for sortOrderInfo: [TBAEventRankingSortOrder], in context: NSManagedObjectContext) -> EventRanking {
         let predicate = NSPredicate(format: "event == %@ AND team == %@", event, team)
         return findOrCreate(in: context, matching: predicate, configure: { (ranking) in

--- a/the-blue-alliance-ios/Core Data/EventTeamStat.swift
+++ b/the-blue-alliance-ios/Core Data/EventTeamStat.swift
@@ -4,6 +4,7 @@ import CoreData
 
 extension EventTeamStat: Managed {
 
+    @discardableResult
     static func insert(with model: TBAStat, for event: Event, in context: NSManagedObjectContext) -> EventTeamStat {
         let team = Team.insert(withKey: model.teamKey, in: context)
         return insert(with: model, for: event, and: team, in: context)

--- a/the-blue-alliance-ios/Core Data/Media.swift
+++ b/the-blue-alliance-ios/Core Data/Media.swift
@@ -49,7 +49,8 @@ extension Media: Managed, Playable {
         return nil
     }
 
-    static func insert(with model: TBAMedia, for year: Int, in context: NSManagedObjectContext) -> Media {
+    @discardableResult
+    static func insert(with model: TBAMedia, in year: Int, for team: Team, in context: NSManagedObjectContext) -> Media {
         var mediaPredicate: NSPredicate?
         if let key = model.key {
             mediaPredicate = NSPredicate(format: "key == %@ AND type == %@", key, model.type)
@@ -67,6 +68,8 @@ extension Media: Managed, Playable {
             media.foreignKey = model.foreignKey
             media.details = model.details
             media.preferred = model.preferred ?? false
+
+            media.team = team
         }
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
@@ -48,7 +48,7 @@ class DistrictEventsViewController: EventsViewController {
                 let localEvents = events?.map({ (modelEvent) -> Event in
                     return Event.insert(with: modelEvent, in: backgroundContext)
                 })
-                backgroundDistrict.events = Set(localEvents ?? []) as NSSet
+                backgroundDistrict.addToEvents(Set(localEvents ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
@@ -142,12 +142,10 @@ class DistrictRankingsViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundDistrict = backgroundContext.object(with: self.district.objectID) as! District
-
-                let localRankings = rankings?.compactMap({ (modelRanking) -> DistrictRanking? in
+                rankings?.forEach({ (modelRanking) in
                     let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
-                    return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
+                    DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
                 })
-                backgroundDistrict.addToRankings(Set(localRankings ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 completion(true)

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
@@ -147,7 +147,7 @@ class DistrictRankingsViewController: TBATableViewController, Refreshable {
                     let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
                     return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
                 })
-                backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
+                backgroundDistrict.addToRankings(Set(localRankings ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 completion(true)

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
@@ -103,11 +103,10 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Obse
 
                 let backgroundDistrict = backgroundContext.object(with: self.ranking.district!.objectID) as! District
 
-                let localRankings = rankings?.compactMap({ (modelRanking) -> DistrictRanking? in
+                rankings?.forEach({ (modelRanking) in
                     let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
-                    return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
+                    DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
                 })
-                backgroundDistrict.addToRankings(Set(localRankings ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: rankingsRequest!)

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
@@ -107,7 +107,7 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Obse
                     let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
                     return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
                 })
-                backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
+                backgroundDistrict.addToRankings(Set(localRankings ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: rankingsRequest!)

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
@@ -87,7 +87,7 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable {
                     let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
                     return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
                 })
-                backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
+                backgroundDistrict.addToRankings(Set(localRankings ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
@@ -82,12 +82,10 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundDistrict = backgroundContext.object(with: self.ranking.district!.objectID) as! District
-
-                let localRankings = rankings?.compactMap({ (modelRanking) -> DistrictRanking? in
+                rankings?.forEach({ (modelRanking) in
                     let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
-                    return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
+                    DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
                 })
-                backgroundDistrict.addToRankings(Set(localRankings ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
@@ -108,11 +108,9 @@ private class EventAlliancesViewController: TBATableViewController, Refreshable 
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localAlliances = alliances?.map({ (modelAlliance) -> EventAlliance in
-                    return EventAlliance.insert(with: modelAlliance, for: backgroundEvent, in: backgroundContext)
+                alliances?.forEach({ (modelAlliance) in
+                    EventAlliance.insert(with: modelAlliance, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.addToAlliances(Set(localAlliances ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: alliancesRequest!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
@@ -112,7 +112,7 @@ private class EventAlliancesViewController: TBATableViewController, Refreshable 
                 let localAlliances = alliances?.map({ (modelAlliance) -> EventAlliance in
                     return EventAlliance.insert(with: modelAlliance, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.alliances = Set(localAlliances ?? []) as NSSet
+                backgroundEvent.addToAlliances(Set(localAlliances ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: alliancesRequest!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
@@ -109,11 +109,9 @@ class EventAwardsViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localAwards = awards?.map({ (modelAward) -> Award in
-                    return Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
+                awards?.forEach({ (modelAward) in
+                    Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.addToAwards(Set(localAwards ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
@@ -113,7 +113,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable {
                 let localAwards = awards?.map({ (modelAward) -> Award in
                     return Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.awards = Set(localAwards ?? []) as NSSet
+                backgroundEvent.addToAwards(Set(localAwards ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
@@ -101,7 +101,7 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
                 let localPoints = eventPoints?.map({ (modelPoints) -> DistrictEventPoints in
                     return DistrictEventPoints.insert(with: modelPoints, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.points = Set(localPoints ?? []) as NSSet
+                backgroundEvent.addToPoints(Set(localPoints ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
@@ -97,11 +97,9 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localPoints = eventPoints?.map({ (modelPoints) -> DistrictEventPoints in
-                    return DistrictEventPoints.insert(with: modelPoints, for: backgroundEvent, in: backgroundContext)
+                eventPoints?.forEach({ (modelPoints) in
+                    DistrictEventPoints.insert(with: modelPoints, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.addToPoints(Set(localPoints ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
@@ -63,12 +63,10 @@ class EventRankingsViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localRankings = rankings?.compactMap({ (modelRanking) -> EventRanking? in
+                rankings?.forEach({ (modelRanking) in
                     let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
-                    return EventRanking.insert(with: modelRanking, for: backgroundEvent, for: backgroundTeam, for: sortOrder!, in: backgroundContext)
+                    EventRanking.insert(with: modelRanking, for: backgroundEvent, for: backgroundTeam, for: sortOrder!, in: backgroundContext)
                 })
-                backgroundEvent.addToRankings(Set(localRankings ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: rankingsRequest!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
@@ -68,7 +68,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable {
                     let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
                     return EventRanking.insert(with: modelRanking, for: backgroundEvent, for: backgroundTeam, for: sortOrder!, in: backgroundContext)
                 })
-                backgroundEvent.rankings = Set(localRankings ?? []) as NSSet
+                backgroundEvent.addToRankings(Set(localRankings ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: rankingsRequest!)

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -65,11 +65,9 @@ class MatchesViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localMatches = matches?.map({ (modelMatch) -> Match in
-                    return Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext)
+                matches?.forEach({ (modelMatch) in
+                    Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.addToMatches(Set(localMatches ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -69,7 +69,7 @@ class MatchesViewController: TBATableViewController, Refreshable {
                 let localMatches = matches?.map({ (modelMatch) -> Match in
                     return Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.matches = Set(localMatches ?? []) as NSSet
+                backgroundEvent.addToMatches(Set(localMatches ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
@@ -92,11 +92,9 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localStats = stats?.map({ (modelStat) -> EventTeamStat in
-                    return EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
+                stats?.forEach({ (modelStat) in
+                    EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.addToStats(Set(localStats ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
@@ -96,7 +96,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable {
                 let localStats = stats?.map({ (modelStat) -> EventTeamStat in
                     return EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.stats = Set(localStats ?? []) as NSSet
+                backgroundEvent.addToStats(Set(localStats ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
@@ -93,26 +93,12 @@ class TeamMediaCollectionViewController: TBACollectionViewController, Refreshabl
                 self.markRefreshSuccessful()
             }
 
-            // TODO: This idea of deleting old and inserting new should be a pattern... basically everywhere
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundTeam = backgroundContext.object(with: self.team.objectID) as! Team
-
-                // Fetch all old media for team for year
-                let existingMedia = Media.fetch(in: backgroundContext, configurationBlock: { (request) in
-                    self.setupFetchRequest(request)
-                })
-                backgroundTeam.removeFromMedia(Set(existingMedia) as NSSet)
-
-                // Add/insert new media
                 let localMedia = media?.map({ (modelMedia) -> Media in
                     return Media.insert(with: modelMedia, for: year, in: backgroundContext)
                 })
                 backgroundTeam.addToMedia(Set(localMedia ?? []) as NSSet)
-
-                // Cleanup orphaned media
-                existingMedia.filter({ $0.team == nil }).forEach {
-                    backgroundContext.delete($0)
-                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
@@ -95,10 +95,9 @@ class TeamMediaCollectionViewController: TBACollectionViewController, Refreshabl
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundTeam = backgroundContext.object(with: self.team.objectID) as! Team
-                let localMedia = media?.map({ (modelMedia) -> Media in
-                    return Media.insert(with: modelMedia, for: year, in: backgroundContext)
+                media?.forEach({ (modelMedia) in
+                    Media.insert(with: modelMedia, in: year, for: backgroundTeam, in: backgroundContext)
                 })
-                backgroundTeam.addToMedia(Set(localMedia ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
@@ -93,7 +93,7 @@ class TeamStatsViewController: TBATableViewController, Refreshable, Observable {
                 let localStats = stats?.map({ (modelStat) -> EventTeamStat in
                     return EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.stats = Set(localStats ?? []) as NSSet
+                backgroundEvent.addToStats(Set(localStats ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
@@ -90,10 +90,9 @@ class TeamStatsViewController: TBATableViewController, Refreshable, Observable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-                let localStats = stats?.map({ (modelStat) -> EventTeamStat in
-                    return EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
+                stats?.forEach({ (modelStat) in
+                    EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.addToStats(Set(localStats ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
@@ -219,11 +219,9 @@ class TeamSummaryViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localAwards = awards?.map({ (modelAward) -> Award in
-                    return Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
+                awards?.forEach({ (modelAward) in
+                    Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
                 })
-                backgroundEvent.addToAwards(Set(localAwards ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: awardsRequest!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -134,7 +134,7 @@ class TeamsViewController: TBATableViewController, Refreshable {
                 let localTeams = teams?.map({ (modelTeam) -> Team in
                     return Team.insert(with: modelTeam, in: backgroundContext)
                 })
-                backgroundEvent.teams = Set(localTeams ?? []) as NSSet
+                backgroundEvent.addToTeams(Set(localTeams ?? []) as NSSet)
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)


### PR DESCRIPTION
Previously in a lot of places we were setting up model relationships twice. Once in the `insert` method, and then once in the TBAKit callback. This is problematic when we a 304 from the API, since we will get back an empty array. Our TBAKit callback won't insert any objects, but we'll overwrite the model's relationship. An example of this is in the District Events view

`backgroundDistrict.events = Set(localEvents ?? []) as NSSet`

If we didn't get a modified response from the API, `localEvents` will be nil (or empty), and we'll overwrite all the previous relationships for Events in that district.

This makes our `insert` model the source of truth for setting up most relationships. Other places where we're not passing a Core Data object on inserts we're doing append-only for setting up relationships.