### PR TITLE
Overwrite old data during refresh

### DIFF
--- a/the-blue-alliance-ios/Core Data/Media.swift
+++ b/the-blue-alliance-ios/Core Data/Media.swift
@@ -49,7 +49,7 @@ extension Media: Managed, Playable {
         return nil
     }
 
-    static func insert(with model: TBAMedia, for year: Int, in context: NSManagedObjectContext) -> Media {
+    static func insert(with model: TBAMedia, in year: Int, for team: Team, in context: NSManagedObjectContext) -> Media {
         var mediaPredicate: NSPredicate?
         if let key = model.key {
             mediaPredicate = NSPredicate(format: "key == %@ AND type == %@", key, model.type)
@@ -67,6 +67,8 @@ extension Media: Managed, Playable {
             media.foreignKey = model.foreignKey
             media.details = model.details
             media.preferred = model.preferred ?? false
+
+            media.team = team
         }
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
@@ -45,10 +45,12 @@ class DistrictEventsViewController: EventsViewController {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundDistrict = backgroundContext.object(with: self.district.objectID) as! District
-                let localEvents = events?.map({ (modelEvent) -> Event in
-                    return Event.insert(with: modelEvent, in: backgroundContext)
-                })
-                backgroundDistrict.events = Set(localEvents ?? []) as NSSet
+                if let events = events {
+                    let localEvents = events.map({ (modelEvent) -> Event in
+                        return Event.insert(with: modelEvent, in: backgroundContext)
+                    })
+                    backgroundDistrict.events = Set(localEvents) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictRankingsViewController.swift
@@ -101,6 +101,7 @@ class DistrictRankingsViewController: TBATableViewController, Refreshable {
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
+                // TODO: Delete old teams
                 backgroundContext.performAndWait {
                     events?.forEach({ (modelEvent) in
                         Event.insert(with: modelEvent, in: backgroundContext)
@@ -121,6 +122,7 @@ class DistrictRankingsViewController: TBATableViewController, Refreshable {
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
+                // TODO: Delete old teams
                 backgroundContext.performAndWait {
                     teams?.forEach({ (modelTeam) in
                         Team.insert(with: modelTeam, in: backgroundContext)
@@ -142,12 +144,13 @@ class DistrictRankingsViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundDistrict = backgroundContext.object(with: self.district.objectID) as! District
-
-                let localRankings = rankings?.compactMap({ (modelRanking) -> DistrictRanking? in
-                    let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
-                    return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
-                })
-                backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
+                if let rankings = rankings {
+                    let localRankings = rankings.map({ (modelRanking) -> DistrictRanking in
+                        let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
+                        return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
+                    })
+                    backgroundDistrict.rankings = Set(localRankings) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 completion(true)

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
@@ -68,6 +68,7 @@ class DistrictsViewController: TBATableViewController, Refreshable {
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
+                // TODO: Delete old districts
                 districts?.forEach({ (modelDistrict) in
                     District.insert(with: modelDistrict, in: backgroundContext)
                 })

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
@@ -102,12 +102,13 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Obse
                 dispatchGroup.wait()
 
                 let backgroundDistrict = backgroundContext.object(with: self.ranking.district!.objectID) as! District
-
-                let localRankings = rankings?.compactMap({ (modelRanking) -> DistrictRanking? in
-                    let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
-                    return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
-                })
-                backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
+                if let rankings = rankings {
+                    let localRankings = rankings.map({ (modelRanking) -> DistrictRanking in
+                        let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
+                        return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
+                    })
+                    backgroundDistrict.rankings = Set(localRankings) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: rankingsRequest!)

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
@@ -82,12 +82,13 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundDistrict = backgroundContext.object(with: self.ranking.district!.objectID) as! District
-
-                let localRankings = rankings?.compactMap({ (modelRanking) -> DistrictRanking? in
-                    let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
-                    return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
-                })
-                backgroundDistrict.rankings = Set(localRankings ?? []) as NSSet
+                if let rankings = rankings {
+                    let localRankings = rankings.map({ (modelRanking) -> DistrictRanking in
+                        let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
+                        return DistrictRanking.insert(with: modelRanking, for: backgroundDistrict, for: backgroundTeam, in: backgroundContext)
+                    })
+                    backgroundDistrict.rankings = Set(localRankings) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAlliancesViewController.swift
@@ -108,11 +108,12 @@ private class EventAlliancesViewController: TBATableViewController, Refreshable 
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localAlliances = alliances?.map({ (modelAlliance) -> EventAlliance in
-                    return EventAlliance.insert(with: modelAlliance, for: backgroundEvent, in: backgroundContext)
-                })
-                backgroundEvent.alliances = Set(localAlliances ?? []) as NSSet
+                if let alliances = alliances {
+                    let localAlliances = alliances.map({ (modelAlliance) -> EventAlliance in
+                        return EventAlliance.insert(with: modelAlliance, for: backgroundEvent, in: backgroundContext)
+                    })
+                    backgroundEvent.alliances = Set(localAlliances) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: alliancesRequest!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventAwardsViewController.swift
@@ -109,11 +109,12 @@ class EventAwardsViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localAwards = awards?.map({ (modelAward) -> Award in
-                    return Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
-                })
-                backgroundEvent.awards = Set(localAwards ?? []) as NSSet
+                if let awards = awards {
+                    let localAwards = awards.map({ (modelAward) -> Award in
+                        return Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
+                    })
+                    backgroundEvent.awards = Set(localAwards) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventDistrictPointsViewController.swift
@@ -97,11 +97,12 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localPoints = eventPoints?.map({ (modelPoints) -> DistrictEventPoints in
-                    return DistrictEventPoints.insert(with: modelPoints, for: backgroundEvent, in: backgroundContext)
-                })
-                backgroundEvent.points = Set(localPoints ?? []) as NSSet
+                if let eventPoints = eventPoints {
+                    let localPoints = eventPoints.map({ (modelPoints) -> DistrictEventPoints in
+                        return DistrictEventPoints.insert(with: modelPoints, for: backgroundEvent, in: backgroundContext)
+                    })
+                    backgroundEvent.points = Set(localPoints) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventRankingsViewController.swift
@@ -63,12 +63,13 @@ class EventRankingsViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localRankings = rankings?.compactMap({ (modelRanking) -> EventRanking? in
-                    let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
-                    return EventRanking.insert(with: modelRanking, for: backgroundEvent, for: backgroundTeam, for: sortOrder!, in: backgroundContext)
-                })
-                backgroundEvent.rankings = Set(localRankings ?? []) as NSSet
+                if let rankings = rankings {
+                    let localRankings = rankings.compactMap({ (modelRanking) -> EventRanking? in
+                        let backgroundTeam = Team.insert(withKey: modelRanking.teamKey, in: backgroundContext)
+                        return EventRanking.insert(with: modelRanking, for: backgroundEvent, for: backgroundTeam, for: sortOrder!, in: backgroundContext)
+                    })
+                    backgroundEvent.rankings = Set(localRankings) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: rankingsRequest!)

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -156,6 +156,7 @@ class MatchBreakdownViewController: TBAViewController, Refreshable, Observable, 
                 let backgroundEvent = backgroundContext.object(with: self.match.event!.objectID) as! Event
 
                 if let modelMatch = modelMatch {
+                    // TODO: Match can never be deleted
                     backgroundEvent.addToMatches(Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext))
                 }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
@@ -211,6 +211,7 @@ class MatchInfoViewController: TBAViewController, Refreshable, Observable {
                 let backgroundEvent = backgroundContext.object(with: self.match.event!.objectID) as! Event
 
                 if let modelMatch = modelMatch {
+                    // TODO: Match can never be deleted
                     backgroundEvent.addToMatches(Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext))
                 }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -65,11 +65,12 @@ class MatchesViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localMatches = matches?.map({ (modelMatch) -> Match in
-                    return Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext)
-                })
-                backgroundEvent.matches = Set(localMatches ?? []) as NSSet
+                if let matches = matches {
+                    let localMatches = matches.map({ (modelMatch) -> Match in
+                        return Match.insert(with: modelMatch, for: backgroundEvent, in: backgroundContext)
+                    })
+                    backgroundEvent.matches = Set(localMatches) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventStatsViewController.swift
@@ -128,6 +128,7 @@ class EventStatsViewController: TBAViewController, Refreshable, Observable, Reac
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
+                // TODO: If we get a 304 these insights will be deleted incorrectly
                 backgroundEvent.insights = insights
 
                 backgroundContext.saveOrRollback()

--- a/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Stats/EventTeamStatsViewController.swift
@@ -92,11 +92,12 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localStats = stats?.map({ (modelStat) -> EventTeamStat in
-                    return EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
-                })
-                backgroundEvent.stats = Set(localStats ?? []) as NSSet
+                if let stats = stats {
+                    let localStats = stats.map({ (modelStat) -> EventTeamStat in
+                        return EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
+                    })
+                    backgroundEvent.stats = Set(localStats) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -70,6 +70,7 @@ class WeekEventsViewController: EventsViewController {
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
+                // TODO: Delete old events for year?
                 events?.forEach({ (modelEvent) in
                     Event.insert(with: modelEvent, in: backgroundContext)
                 })

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -167,6 +167,7 @@ private class WeeksSelectTableViewController: SelectTableViewController<EventWee
             }
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
+                // TODO: Delete old events for year?
                 events?.forEach({ (modelEvent) in
                     Event.insert(with: modelEvent, in: backgroundContext)
                 })

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamEventsViewController.swift
@@ -55,10 +55,12 @@ class TeamEventsViewController: EventsViewController {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundTeam = backgroundContext.object(with: self.team.objectID) as! Team
-                let localEvents = events?.map({ (modelEvent) -> Event in
-                    return Event.insert(with: modelEvent, in: backgroundContext)
-                })
-                backgroundTeam.addToEvents(Set(localEvents ?? []) as NSSet)
+                if let events = events {
+                    let localEvents = events.map({ (modelEvent) -> Event in
+                        return Event.insert(with: modelEvent, in: backgroundContext)
+                    })
+                    backgroundTeam.events = Set(localEvents) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamMediaCollectionViewController.swift
@@ -96,22 +96,11 @@ class TeamMediaCollectionViewController: TBACollectionViewController, Refreshabl
             // TODO: This idea of deleting old and inserting new should be a pattern... basically everywhere
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundTeam = backgroundContext.object(with: self.team.objectID) as! Team
-
-                // Fetch all old media for team for year
-                let existingMedia = Media.fetch(in: backgroundContext, configurationBlock: { (request) in
-                    self.setupFetchRequest(request)
-                })
-                backgroundTeam.removeFromMedia(Set(existingMedia) as NSSet)
-
-                // Add/insert new media
-                let localMedia = media?.map({ (modelMedia) -> Media in
-                    return Media.insert(with: modelMedia, for: year, in: backgroundContext)
-                })
-                backgroundTeam.addToMedia(Set(localMedia ?? []) as NSSet)
-
-                // Cleanup orphaned media
-                existingMedia.filter({ $0.team == nil }).forEach {
-                    backgroundContext.delete($0)
+                if let media = media {
+                    let localMedia = media.map({ (modelMedia) -> Media in
+                        return Media.insert(with: modelMedia, in: year, for: backgroundTeam, in: backgroundContext)
+                    })
+                    backgroundTeam.media = Set(localMedia) as NSSet
                 }
 
                 backgroundContext.saveOrRollback()

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamStatsViewController.swift
@@ -90,10 +90,12 @@ class TeamStatsViewController: TBATableViewController, Refreshable, Observable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-                let localStats = stats?.map({ (modelStat) -> EventTeamStat in
-                    return EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
-                })
-                backgroundEvent.stats = Set(localStats ?? []) as NSSet
+                if let stats = stats {
+                    let localStats = stats.map({ (modelStat) -> EventTeamStat in
+                        return EventTeamStat.insert(with: modelStat, for: backgroundEvent, in: backgroundContext)
+                    })
+                    backgroundEvent.stats = Set(localStats) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamSummaryViewController.swift
@@ -201,6 +201,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable {
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
 
                 if let modelStatus = modelStatus {
+                    // TODO: EventStatus can never be removed if it's invalid
                     EventStatus.insert(with: modelStatus, team: backgroundTeam, event: backgroundEvent, in: backgroundContext)
                 }
 
@@ -219,11 +220,12 @@ class TeamSummaryViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: self.event.objectID) as! Event
-
-                let localAwards = awards?.map({ (modelAward) -> Award in
-                    return Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
-                })
-                backgroundEvent.addToAwards(Set(localAwards ?? []) as NSSet)
+                if let awards = awards {
+                    let localAwards = awards.map({ (modelAward) -> Award in
+                        return Award.insert(with: modelAward, for: backgroundEvent, in: backgroundContext)
+                    })
+                    backgroundEvent.awards = Set(localAwards)
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: awardsRequest!)

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -97,6 +97,7 @@ class TeamsViewController: TBATableViewController, Refreshable {
             request = task
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
+                // TODO: Delete old teams for page? Kinda a problem but
                 teams.forEach({ (modelTeam) in
                     Team.insert(with: modelTeam, in: backgroundContext)
                 })
@@ -131,10 +132,12 @@ class TeamsViewController: TBATableViewController, Refreshable {
 
             self.persistentContainer.performBackgroundTask({ (backgroundContext) in
                 let backgroundEvent = backgroundContext.object(with: event.objectID) as! Event
-                let localTeams = teams?.map({ (modelTeam) -> Team in
-                    return Team.insert(with: modelTeam, in: backgroundContext)
-                })
-                backgroundEvent.teams = Set(localTeams ?? []) as NSSet
+                if let teams = teams {
+                    let localTeams = teams.map({ (modelTeam) -> Team in
+                        return Team.insert(with: modelTeam, in: backgroundContext)
+                    })
+                    backgroundEvent.teams = Set(localTeams) as NSSet
+                }
 
                 backgroundContext.saveOrRollback()
                 self.removeRequest(request: request!)


### PR DESCRIPTION
I'll probably ship this when I can confirm that we're deleting old events for year, and deleting old teams. Should be simple-ish.