### PR TITLE
Fix team events not grouping offseason events by month

### DIFF
--- a/tba-unit-tests/Core Data/Event/Event_Tests.swift
+++ b/tba-unit-tests/Core Data/Event/Event_Tests.swift
@@ -98,6 +98,10 @@ class Event_TestCase: CoreDataTestCase {
         districtChampionshipDivision.district = district
 
         XCTAssertEqual(districtChampionshipDivision.calculateHybridType(), "2..fim.dcmpd")
+
+        let districtChampionship = event(type: EventType.districtChampionship)
+        // Ensure district championship divisions appear before district championships
+        XCTAssert(districtChampionshipDivision.calculateHybridType() < districtChampionship.calculateHybridType())
     }
 
     func test_hybridType_festivalOfChampions() {
@@ -108,16 +112,23 @@ class Event_TestCase: CoreDataTestCase {
 
     func test_hybridType_offseason() {
         let eventType = EventType.offseason
-        let offseason = event(type: eventType)
-        offseason.startDate = Calendar.current.date(from: DateComponents(year: 2015, month: 10, day: 1))
-        XCTAssertEqual(offseason.calculateHybridType(), "99.10")
+
+        let novermberOffseason = event(type: eventType)
+        novermberOffseason.startDate = Calendar.current.date(from: DateComponents(year: 2015, month: 11, day: 1))
+        XCTAssertEqual(novermberOffseason.calculateHybridType(), "99.11")
+
+        let septemberOffseason = event(type: eventType)
+        septemberOffseason.startDate = Calendar.current.date(from: DateComponents(year: 2015, month: 9, day: 1))
+        XCTAssertEqual(septemberOffseason.calculateHybridType(), "99.9")
+
+        // Ensure single-digit month offseason events show up before double-digit month offseason events
+        XCTAssert(septemberOffseason.calculateHybridType() > novermberOffseason.calculateHybridType())
     }
 
     func test_hybridType_preseason() {
         let eventType = EventType.preseason
         let preseason = event(type: eventType)
         XCTAssertEqual(preseason.calculateHybridType(), "100")
-
     }
 
     func test_hybridType_unlabeled() {

--- a/tba-unit-tests/Core Data/Event/Event_Tests.swift
+++ b/tba-unit-tests/Core Data/Event/Event_Tests.swift
@@ -18,6 +18,12 @@ class Event_TestCase: CoreDataTestCase {
         super.tearDown()
     }
 
+    func event(type eventType: EventType) -> Event {
+        let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
+        event.eventType = Int16(eventType.rawValue)
+        return event
+    }
+
     func test_isHappeningNow() {
         // Event started two days ago, ends today
         let today = calendar.date(bySettingHour: 0, minute: 0, second: 0, of: Date())!
@@ -35,23 +41,89 @@ class Event_TestCase: CoreDataTestCase {
     }
 
     func test_isDistrictChampionshipEvent() {
-        let dcmp = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        dcmp.eventType = Int16(EventType.districtChampionship.rawValue)
+        let dcmp = event(type: EventType.districtChampionship)
         XCTAssert(dcmp.isDistrictChampionshipEvent)
-
-        let dcmpDivision = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        dcmpDivision.eventType = Int16(EventType.districtChampionshipDivision.rawValue)
-        XCTAssert(dcmpDivision.isDistrictChampionshipEvent)
-    }
-
-    func test_isDistrictChampionship() {
-        let dcmp = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        dcmp.eventType = Int16(EventType.districtChampionship.rawValue)
         XCTAssert(dcmp.isDistrictChampionship)
 
-        let dcmpDivision = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        dcmpDivision.eventType = Int16(EventType.districtChampionshipDivision.rawValue)
+        let dcmpDivision = event(type: EventType.districtChampionshipDivision)
+        XCTAssert(dcmpDivision.isDistrictChampionshipEvent)
         XCTAssertFalse(dcmpDivision.isDistrictChampionship)
+    }
+
+    func test_hybridType_regional() {
+        let eventType = EventType.regional
+        let regional = event(type: eventType)
+        XCTAssertEqual(regional.calculateHybridType(), "0")
+    }
+
+    func test_hybridType_district() {
+        let eventType = EventType.district
+        let districtAbbreviation = "fim"
+
+        let district = District(entity: District.entity(), insertInto: persistentContainer.viewContext)
+        district.abbreviation = districtAbbreviation
+
+        let districtEvent = event(type: eventType)
+        districtEvent.district = district
+
+        XCTAssertEqual(districtEvent.calculateHybridType(), "1.fim")
+    }
+
+    func test_hybridType_districtChampionship() {
+        let eventType = EventType.districtChampionship
+        let districtChampionship = event(type: eventType)
+        XCTAssertEqual(districtChampionship.calculateHybridType(), "2.dcmp")
+    }
+
+    func test_hybridType_championshipDivision() {
+        let eventType = EventType.championshipDivision
+        let championshipDivision = event(type: eventType)
+        XCTAssertEqual(championshipDivision.calculateHybridType(), "3")
+    }
+
+    func test_hybridType_championshipFinals() {
+        let eventType = EventType.championshipFinals
+        let championshipFinals = event(type: eventType)
+        XCTAssertEqual(championshipFinals.calculateHybridType(), "4")
+    }
+
+    func test_hybridType_districtChampionshipDivision() {
+        let eventType = EventType.districtChampionshipDivision
+        let districtAbbreviation = "fim"
+
+        let district = District(entity: District.entity(), insertInto: persistentContainer.viewContext)
+        district.abbreviation = districtAbbreviation
+
+        let districtChampionshipDivision = event(type: eventType)
+        districtChampionshipDivision.district = district
+
+        XCTAssertEqual(districtChampionshipDivision.calculateHybridType(), "2..fim.dcmpd")
+    }
+
+    func test_hybridType_festivalOfChampions() {
+        let eventType = EventType.festivalOfChampions
+        let festivalOfChampions = event(type: eventType)
+        XCTAssertEqual(festivalOfChampions.calculateHybridType(), "6")
+    }
+
+    func test_hybridType_offseason() {
+        let eventType = EventType.offseason
+        let offseason = event(type: eventType)
+        offseason.startDate = Calendar.current.date(from: DateComponents(year: 2015, month: 10, day: 1))
+        XCTAssertEqual(offseason.calculateHybridType(), "99.10")
+    }
+
+    func test_hybridType_preseason() {
+        let eventType = EventType.preseason
+        let preseason = event(type: eventType)
+        XCTAssertEqual(preseason.calculateHybridType(), "100")
+
+    }
+
+    func test_hybridType_unlabeled() {
+        let eventType = EventType.unlabeled
+        let unlabeled = event(type: eventType)
+        XCTAssertEqual(unlabeled.calculateHybridType(), "-1")
     }
 
 }

--- a/the-blue-alliance-ios/Core Data/Event.swift
+++ b/the-blue-alliance-ios/Core Data/Event.swift
@@ -86,7 +86,7 @@ extension Event: Locatable, Managed {
 
     // hybridType is used a mechanism for sorting Events properly in fetch result controllers... they use a variety
     // of event data to kinda "move around" events in our data model to get groups/order right
-    private func calculateHybridType() -> String {
+    func calculateHybridType() -> String {
         var hybridType = String(eventType)
         // Group districts together, group district CMPs together
         if isDistrictChampionshipEvent {
@@ -100,6 +100,10 @@ extension Event: Locatable, Managed {
             }
         } else if let district = district, !isDistrictChampionshipEvent {
             hybridType = "\(hybridType).\(district.abbreviation!)"
+        } else if Int(eventType) == EventType.offseason.rawValue, let startDate = startDate {
+            // Group offseason events together by month
+            let month = Calendar.current.component(.month, from: startDate)
+            hybridType = "\(hybridType).\(month)"
         }
         return hybridType
     }


### PR DESCRIPTION
Adds a condition for `hybridType` that handles offseason events to group offseason events together by months. Fixes #264 