### PR TITLE
Store MatchAlliances on Match, store breakdown on Match as JSON

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -168,7 +168,7 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
-  - TBAKit (2.0.7)
+  - TBAKit (2.0.8)
   - yoga (0.57.1.React)
   - youtube-ios-player-helper (0.1.6)
   - ZIPFoundation (0.9.6)
@@ -277,7 +277,7 @@ SPEC CHECKSUMS:
   Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
   PureLayout: 4634d0b61e3b5021166e8ec7c18e9e0ca0720c8b
   React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
-  TBAKit: 13e66f7b1dde686f028785faf4e6514e817f8fe3
+  TBAKit: 6a59eb455ea498fb5e73ec0489293f01d8e099e2
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
   youtube-ios-player-helper: 21ab92db027c7ff86cb17a3843a3f6eafc8158d2
   ZIPFoundation: 68c35eb2637c21abe56dc60b3277636443bc1501

--- a/tba-unit-tests/Core Data/Match/MatchAlliance_Tests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchAlliance_Tests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import The_Blue_Alliance
+
+class MatchAlliance_TestCase: CoreDataTestCase {
+
+    var alliance: MatchAlliance!
+
+    override func setUp() {
+        super.setUp()
+
+        alliance = MatchAlliance.init(entity: MatchAlliance.entity(), insertInto: persistentContainer.viewContext)
+    }
+
+    override func tearDown() {
+        alliance = nil
+
+        super.tearDown()
+    }
+
+    func test_teams() {
+        alliance.teamsJoined = "frc2337,frc7332,frc3333"
+        XCTAssertEqual(alliance.teams, ["frc2337", "frc7332", "frc3333"])
+    }
+
+    func test_surrogateTeams() {
+        XCTAssertNil(alliance.surrogateTeams)
+        alliance.surrogateTeamsJoined = "frc7332,frc3333"
+        XCTAssertEqual(alliance.surrogateTeams, ["frc7332", "frc3333"])
+    }
+
+    func test_dqTeams() {
+        XCTAssertNil(alliance.dqTeams)
+        alliance.dqTeamsJoined = "frc7332,frc3333"
+        XCTAssertEqual(alliance.dqTeams, ["frc7332", "frc3333"])
+    }
+
+}

--- a/tba-unit-tests/Core Data/Match/MatchAlliance_Tests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchAlliance_Tests.swift
@@ -17,21 +17,6 @@ class MatchAlliance_TestCase: CoreDataTestCase {
         super.tearDown()
     }
 
-    func test_teams() {
-        alliance.teamsJoined = "frc2337,frc7332,frc3333"
-        XCTAssertEqual(alliance.teams, ["frc2337", "frc7332", "frc3333"])
-    }
-
-    func test_surrogateTeams() {
-        XCTAssertNil(alliance.surrogateTeams)
-        alliance.surrogateTeamsJoined = "frc7332,frc3333"
-        XCTAssertEqual(alliance.surrogateTeams, ["frc7332", "frc3333"])
-    }
-
-    func test_dqTeams() {
-        XCTAssertNil(alliance.dqTeams)
-        alliance.dqTeamsJoined = "frc7332,frc3333"
-        XCTAssertEqual(alliance.dqTeams, ["frc7332", "frc3333"])
-    }
+    // TODO: This needs tests once https://github.com/ZachOrr/TBAKit/issues/18 is done
 
 }

--- a/tba-unit-tests/Core Data/Match/MatchVideo_Tests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchVideo_Tests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import The_Blue_Alliance
+
+class MatchVideo_TestCase: CoreDataTestCase {
+
+    var video: MatchVideo!
+
+    override func setUp() {
+        super.setUp()
+
+        video = MatchVideo.init(entity: MatchVideo.entity(), insertInto: persistentContainer.viewContext)
+    }
+
+    override func tearDown() {
+        video = nil
+
+        super.tearDown()
+    }
+
+    func test_youtubeKey() {
+        let youtubeKey = "test_youtubeKey"
+        video.key = youtubeKey
+
+        // No type - no youtubeKey
+        XCTAssertNil(video.youtubeKey)
+
+        // Wrong type - no youtubeKey
+        video.typeString = MatchVideoType.tba.rawValue
+        XCTAssertNil(video.youtubeKey)
+
+        // Right type - should have key
+        video.typeString = MatchVideoType.youtube.rawValue
+        XCTAssertEqual(video.youtubeKey, youtubeKey)
+    }
+
+}

--- a/tba-unit-tests/Core Data/Match/Match_Tests.swift
+++ b/tba-unit-tests/Core Data/Match/Match_Tests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 @testable import The_Blue_Alliance
 
@@ -100,10 +101,18 @@ class Match_TestCase: CoreDataTestCase {
     }
 
     func test_timeString() {
+        let defaultTimeZone = NSTimeZone.default
+
+        NSTimeZone.default = TimeZone(abbreviation: "EST")!
         XCTAssertNil(match.timeString)
 
+        // Set default time zone for this test
         match.time = NSNumber(value: 1425764880)
         XCTAssertEqual(match.timeString, "Sat 4:48 PM")
+
+        addTeardownBlock {
+            NSTimeZone.default = defaultTimeZone
+        }
     }
 
     func test_redAlliance() {

--- a/tba-unit-tests/Core Data/Match/Match_Tests.swift
+++ b/tba-unit-tests/Core Data/Match/Match_Tests.swift
@@ -21,7 +21,11 @@ class Match_TestCase: CoreDataTestCase {
     func alliance(allianceKey: String) -> MatchAlliance {
         let alliance = MatchAlliance(entity: MatchAlliance.entity(), insertInto: persistentContainer.viewContext)
         alliance.allianceKey = allianceKey
-        alliance.teamsJoined = "frc3333,frc7332,frc2337"
+        alliance.teams = NSOrderedSet(array: ["frc3333", "frc7332", "frc2337"].map({ (key) -> TeamKey in
+            let teamKey = TeamKey.init(entity: TeamKey.entity(), insertInto: persistentContainer.viewContext)
+            teamKey.key = key
+            return teamKey
+        }))
         return alliance
     }
 

--- a/tba-unit-tests/Core Data/Match/Match_Tests.swift
+++ b/tba-unit-tests/Core Data/Match/Match_Tests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import The_Blue_Alliance
+
+class Match_TestCase: CoreDataTestCase {
+
+    var match: Match!
+
+    override func setUp() {
+        super.setUp()
+
+        match = Match.init(entity: Match.entity(), insertInto: persistentContainer.viewContext)
+    }
+
+    override func tearDown() {
+        match = nil
+
+        super.tearDown()
+    }
+
+    func alliance(allianceKey: String) -> MatchAlliance {
+        let alliance = MatchAlliance(entity: MatchAlliance.entity(), insertInto: persistentContainer.viewContext)
+        alliance.allianceKey = allianceKey
+        alliance.teamsJoined = "frc3333,frc7332,frc2337"
+        return alliance
+    }
+
+    func test_compLevel() {
+        // No compLevelString
+        XCTAssertNil(match.compLevel)
+
+        // Unknown compLevelString
+        match.compLevelString = "zz"
+        XCTAssertNil(match.compLevel)
+
+        match.compLevelString = "qm"
+        XCTAssertEqual(match.compLevel, .qualification)
+
+        match.compLevelString = "ef"
+        XCTAssertEqual(match.compLevel, .eightfinal)
+
+        match.compLevelString = "qf"
+        XCTAssertEqual(match.compLevel, .quarterfinal)
+
+        match.compLevelString = "sf"
+        XCTAssertEqual(match.compLevel, .semifinal)
+
+        match.compLevelString = "f"
+        XCTAssertEqual(match.compLevel, .final)
+    }
+
+    func test_compLevel_sortOrder() {
+        match.compLevelString = "qm"
+        XCTAssertEqual(match.compLevel?.sortOrder, 0)
+
+        match.compLevelString = "ef"
+        XCTAssertEqual(match.compLevel?.sortOrder, 1)
+
+        match.compLevelString = "qf"
+        XCTAssertEqual(match.compLevel?.sortOrder, 2)
+
+        match.compLevelString = "sf"
+        XCTAssertEqual(match.compLevel?.sortOrder, 3)
+
+        match.compLevelString = "f"
+        XCTAssertEqual(match.compLevel?.sortOrder, 4)
+    }
+
+    func test_compLevel_level() {
+        match.compLevelString = "qm"
+        XCTAssertEqual(match.compLevel?.level, "Qualification")
+
+        match.compLevelString = "ef"
+        XCTAssertEqual(match.compLevel?.level, "Octofinal")
+
+        match.compLevelString = "qf"
+        XCTAssertEqual(match.compLevel?.level, "Quarterfinal")
+
+        match.compLevelString = "sf"
+        XCTAssertEqual(match.compLevel?.level, "Semifinal")
+
+        match.compLevelString = "f"
+        XCTAssertEqual(match.compLevel?.level, "Finals")
+    }
+
+    func test_compLevel_levelShort() {
+        match.compLevelString = "qm"
+        XCTAssertEqual(match.compLevel?.levelShort, "Quals")
+
+        match.compLevelString = "ef"
+        XCTAssertEqual(match.compLevel?.levelShort, "Eighths")
+
+        match.compLevelString = "qf"
+        XCTAssertEqual(match.compLevel?.levelShort, "Quarters")
+
+        match.compLevelString = "sf"
+        XCTAssertEqual(match.compLevel?.levelShort, "Semis")
+
+        match.compLevelString = "f"
+        XCTAssertEqual(match.compLevel?.levelShort, "Finals")
+    }
+
+    func test_timeString() {
+        XCTAssertNil(match.timeString)
+
+        match.time = NSNumber(value: 1425764880)
+        XCTAssertEqual(match.timeString, "Sat 4:48 PM")
+    }
+
+    func test_redAlliance() {
+        XCTAssertNil(match.redAlliance)
+
+        match.alliances = Set([alliance(allianceKey: "red")]) as NSSet
+        XCTAssertNotNil(match.redAlliance)
+    }
+
+    func test_redAllianceTeamNumbers() {
+        match.alliances = Set([alliance(allianceKey: "red")]) as NSSet
+        XCTAssertEqual(match.redAllianceTeamNumbers, ["2337", "7332", "3333"])
+    }
+
+    func test_blueAlliance() {
+        XCTAssertNil(match.blueAlliance)
+
+        match.alliances = Set([alliance(allianceKey: "blue")]) as NSSet
+        XCTAssertNotNil(match.blueAlliance)
+    }
+
+    func test_blueAllianceTeamNumbers() {
+        match.alliances = Set([alliance(allianceKey: "blue")]) as NSSet
+        XCTAssertEqual(match.blueAllianceTeamNumbers, ["2337", "7332", "3333"])
+    }
+
+    func test_friendlyName() {
+        match.setNumber = 2
+        match.matchNumber = 73
+
+        // No compLevel - just show the match number
+        XCTAssertEqual(match.friendlyName, "Match 73")
+
+        match.compLevelString = MatchCompLevel.qualification.rawValue
+        XCTAssertEqual(match.friendlyName, "Quals 73")
+
+        match.compLevelString = MatchCompLevel.eightfinal.rawValue
+        XCTAssertEqual(match.friendlyName, "Eighths 2 - 73")
+    }
+
+}

--- a/tba-unit-tests/Core Data/Team/TeamKey_Tests.swift
+++ b/tba-unit-tests/Core Data/Team/TeamKey_Tests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import The_Blue_Alliance
+
+class TeamKey_TestCase: CoreDataTestCase {
+
+    func test_insert_required() {
+        let teamKey = TeamKey.init(entity: TeamKey.entity(), insertInto: persistentContainer.viewContext)
+        XCTAssertThrowsError(try persistentContainer.viewContext.save())
+        teamKey.key = "frc7332"
+        XCTAssertNoThrow(try persistentContainer.viewContext.save())
+
+        addTeardownBlock {
+            self.persistentContainer.viewContext.delete(teamKey)
+            try! self.persistentContainer.viewContext.save()
+        }
+    }
+
+    func test_insert() {
+        let testTeamKey = "frc7332"
+
+        let teamKey_first = TeamKey.insert(withKey: testTeamKey, in: persistentContainer.viewContext)
+        XCTAssertNotNil(teamKey_first)
+        XCTAssertEqual(teamKey_first.key, testTeamKey)
+
+        let teamKey_second = TeamKey.insert(withKey: testTeamKey, in: persistentContainer.viewContext)
+        XCTAssertEqual(teamKey_first, teamKey_second)
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		9223AC831EE7003C00F54F93 /* CollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */; };
 		9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */; };
 		9236101F2178245C000CC5E9 /* Media_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236101E2178245C000CC5E9 /* Media_Tests.swift */; };
+		9236102221795796000CC5E9 /* MatchAlliance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236102121795796000CC5E9 /* MatchAlliance.swift */; };
 		923AEE87216583CA00EF50C8 /* Bundle+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE86216583CA00EF50C8 /* Bundle+Version.swift */; };
 		923AEE8A21658BC400EF50C8 /* Launch_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE8921658BC400EF50C8 /* Launch_UITests.swift */; };
 		923AEE8C21658C5800EF50C8 /* Bundle+Version_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE8B21658C5800EF50C8 /* Bundle+Version_Tests.swift */; };
@@ -253,6 +254,7 @@
 		9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSource.swift; sourceTree = "<group>"; };
 		9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaCollectionViewCell.swift; sourceTree = "<group>"; };
 		9236101E2178245C000CC5E9 /* Media_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media_Tests.swift; sourceTree = "<group>"; };
+		9236102121795796000CC5E9 /* MatchAlliance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchAlliance.swift; sourceTree = "<group>"; };
 		923AEE86216583CA00EF50C8 /* Bundle+Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Bundle+Version.swift"; path = "Extensions/Bundle+Version.swift"; sourceTree = "<group>"; };
 		923AEE8921658BC400EF50C8 /* Launch_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Launch_UITests.swift; sourceTree = "<group>"; };
 		923AEE8B21658C5800EF50C8 /* Bundle+Version_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Version_Tests.swift"; sourceTree = "<group>"; };
@@ -462,6 +464,7 @@
 			isa = PBXGroup;
 			children = (
 				1405237E1ED3524C0072FB91 /* Match.swift */,
+				9236102121795796000CC5E9 /* MatchAlliance.swift */,
 				9257DF45208BDCBF00F7E2BA /* MatchVideo.swift */,
 			);
 			name = Match;
@@ -1642,6 +1645,7 @@
 				92942E361E2A81E8008E79CA /* EventInfoViewController.swift in Sources */,
 				304ED0421EF1D2D300E31791 /* RankingTableViewCell.swift in Sources */,
 				140523821ED352570072FB91 /* Media.swift in Sources */,
+				9236102221795796000CC5E9 /* MatchAlliance.swift in Sources */,
 				92B55623215D688600C1D9A3 /* TeamEventsViewController.swift in Sources */,
 				92B55625215D69DE00C1D9A3 /* WeekEventsViewController.swift in Sources */,
 				929FCDA81EC8BE7200A38E46 /* DistrictRankingsViewController.swift in Sources */,

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		9221C618209BFF8700477DE2 /* LoadingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9221C617209BFF8700477DE2 /* LoadingTableViewCell.xib */; };
 		9223AC831EE7003C00F54F93 /* CollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */; };
 		9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */; };
+		922E907D217BCE3700E81447 /* TeamKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922E907C217BCE3700E81447 /* TeamKey.swift */; };
+		922E9080217BD18400E81447 /* TeamKey_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922E907F217BD18400E81447 /* TeamKey_Tests.swift */; };
 		9236101F2178245C000CC5E9 /* Media_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236101E2178245C000CC5E9 /* Media_Tests.swift */; };
 		9236102221795796000CC5E9 /* MatchAlliance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236102121795796000CC5E9 /* MatchAlliance.swift */; };
 		9236102521798655000CC5E9 /* Match_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236102421798655000CC5E9 /* Match_Tests.swift */; };
@@ -256,6 +258,8 @@
 		9221C617209BFF8700477DE2 /* LoadingTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoadingTableViewCell.xib; sourceTree = "<group>"; };
 		9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSource.swift; sourceTree = "<group>"; };
 		9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaCollectionViewCell.swift; sourceTree = "<group>"; };
+		922E907C217BCE3700E81447 /* TeamKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamKey.swift; sourceTree = "<group>"; };
+		922E907F217BD18400E81447 /* TeamKey_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamKey_Tests.swift; sourceTree = "<group>"; };
 		9236101E2178245C000CC5E9 /* Media_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media_Tests.swift; sourceTree = "<group>"; };
 		9236102121795796000CC5E9 /* MatchAlliance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchAlliance.swift; sourceTree = "<group>"; };
 		9236102421798655000CC5E9 /* Match_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Match_Tests.swift; sourceTree = "<group>"; };
@@ -536,6 +540,14 @@
 			path = "Team@District";
 			sourceTree = "<group>";
 		};
+		922E907E217BD17C00E81447 /* Team */ = {
+			isa = PBXGroup;
+			children = (
+				922E907F217BD18400E81447 /* TeamKey_Tests.swift */,
+			);
+			path = Team;
+			sourceTree = "<group>";
+		};
 		9236101D217823F1000CC5E9 /* Media */ = {
 			isa = PBXGroup;
 			children = (
@@ -614,10 +626,11 @@
 		924459BF20CB796B0007570D /* Core Data */ = {
 			isa = PBXGroup;
 			children = (
+				926652622156C55C000E4F4F /* Event */,
 				9236102321798647000CC5E9 /* Match */,
 				9236101D217823F1000CC5E9 /* Media */,
+				922E907E217BD17C00E81447 /* Team */,
 				92C1F2DD216994CF00BD8445 /* CoreDataTestCase.swift */,
-				926652622156C55C000E4F4F /* Event */,
 				92A2F5522156BD4B00267C63 /* Extensions */,
 			);
 			path = "Core Data";
@@ -1156,6 +1169,7 @@
 			isa = PBXGroup;
 			children = (
 				92D855CE1EC68ACE00572F27 /* Team.swift */,
+				922E907C217BCE3700E81447 /* TeamKey.swift */,
 			);
 			name = Team;
 			sourceTree = "<group>";
@@ -1622,6 +1636,7 @@
 				929BBB051EC55742006D3854 /* InfoTableViewCell.swift in Sources */,
 				92C9BD3120968FAC007FB9C8 /* Favorite.swift in Sources */,
 				926A8EE620B9B55100A25563 /* EventStatus.swift in Sources */,
+				922E907D217BCE3700E81447 /* TeamKey.swift in Sources */,
 				92D855E21EC755D000572F27 /* TeamInfoViewController.swift in Sources */,
 				1405237C1ED33F500072FB91 /* MatchViewController.swift in Sources */,
 				92C9BD3320968FB3007FB9C8 /* Subscription.swift in Sources */,
@@ -1760,6 +1775,7 @@
 				923AEE99216703CB00EF50C8 /* MyTBA_Tests.swift in Sources */,
 				92B076F120FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift in Sources */,
 				92C2E939217B92C500004B9E /* MatchVideo_Tests.swift in Sources */,
+				922E9080217BD18400E81447 /* TeamKey_Tests.swift in Sources */,
 				924459C320CB796B0007570D /* Date+TBA_Tests.swift in Sources */,
 				92C1F2E02169A3B800BD8445 /* MockNavigationController.swift in Sources */,
 				9236102521798655000CC5E9 /* Match_Tests.swift in Sources */,

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */; };
 		9236101F2178245C000CC5E9 /* Media_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236101E2178245C000CC5E9 /* Media_Tests.swift */; };
 		9236102221795796000CC5E9 /* MatchAlliance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236102121795796000CC5E9 /* MatchAlliance.swift */; };
+		9236102521798655000CC5E9 /* Match_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236102421798655000CC5E9 /* Match_Tests.swift */; };
 		923AEE87216583CA00EF50C8 /* Bundle+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE86216583CA00EF50C8 /* Bundle+Version.swift */; };
 		923AEE8A21658BC400EF50C8 /* Launch_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE8921658BC400EF50C8 /* Launch_UITests.swift */; };
 		923AEE8C21658C5800EF50C8 /* Bundle+Version_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE8B21658C5800EF50C8 /* Bundle+Version_Tests.swift */; };
@@ -169,6 +170,8 @@
 		92C1F2E02169A3B800BD8445 /* MockNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2DF2169A3B800BD8445 /* MockNavigationController.swift */; };
 		92C1F2E42169AA7200BD8445 /* TeamsContainerViewController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2E32169AA7200BD8445 /* TeamsContainerViewController_Tests.swift */; };
 		92C1F2E62169AB9F00BD8445 /* DistrictsContainerViewController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2E52169AB9F00BD8445 /* DistrictsContainerViewController_Tests.swift */; };
+		92C2E937217B907900004B9E /* MatchAlliance_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C2E936217B907900004B9E /* MatchAlliance_Tests.swift */; };
+		92C2E939217B92C500004B9E /* MatchVideo_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C2E938217B92C500004B9E /* MatchVideo_Tests.swift */; };
 		92C9BD3120968FAC007FB9C8 /* Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BD3020968FAC007FB9C8 /* Favorite.swift */; };
 		92C9BD3320968FB3007FB9C8 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BD3220968FB3007FB9C8 /* Subscription.swift */; };
 		92C9BD352096907E007FB9C8 /* Stateful.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BD342096907E007FB9C8 /* Stateful.swift */; };
@@ -255,6 +258,7 @@
 		9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaCollectionViewCell.swift; sourceTree = "<group>"; };
 		9236101E2178245C000CC5E9 /* Media_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media_Tests.swift; sourceTree = "<group>"; };
 		9236102121795796000CC5E9 /* MatchAlliance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchAlliance.swift; sourceTree = "<group>"; };
+		9236102421798655000CC5E9 /* Match_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Match_Tests.swift; sourceTree = "<group>"; };
 		923AEE86216583CA00EF50C8 /* Bundle+Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Bundle+Version.swift"; path = "Extensions/Bundle+Version.swift"; sourceTree = "<group>"; };
 		923AEE8921658BC400EF50C8 /* Launch_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Launch_UITests.swift; sourceTree = "<group>"; };
 		923AEE8B21658C5800EF50C8 /* Bundle+Version_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Version_Tests.swift"; sourceTree = "<group>"; };
@@ -383,6 +387,8 @@
 		92C1F2DF2169A3B800BD8445 /* MockNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationController.swift; sourceTree = "<group>"; };
 		92C1F2E32169AA7200BD8445 /* TeamsContainerViewController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamsContainerViewController_Tests.swift; sourceTree = "<group>"; };
 		92C1F2E52169AB9F00BD8445 /* DistrictsContainerViewController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistrictsContainerViewController_Tests.swift; sourceTree = "<group>"; };
+		92C2E936217B907900004B9E /* MatchAlliance_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchAlliance_Tests.swift; sourceTree = "<group>"; };
+		92C2E938217B92C500004B9E /* MatchVideo_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchVideo_Tests.swift; sourceTree = "<group>"; };
 		92C9BD3020968FAC007FB9C8 /* Favorite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Favorite.swift; sourceTree = "<group>"; };
 		92C9BD3220968FB3007FB9C8 /* Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
 		92C9BD342096907E007FB9C8 /* Stateful.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stateful.swift; sourceTree = "<group>"; };
@@ -538,6 +544,16 @@
 			path = Media;
 			sourceTree = "<group>";
 		};
+		9236102321798647000CC5E9 /* Match */ = {
+			isa = PBXGroup;
+			children = (
+				9236102421798655000CC5E9 /* Match_Tests.swift */,
+				92C2E936217B907900004B9E /* MatchAlliance_Tests.swift */,
+				92C2E938217B92C500004B9E /* MatchVideo_Tests.swift */,
+			);
+			path = Match;
+			sourceTree = "<group>";
+		};
 		923A0D7620D21D3800BF5E31 /* Launch Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -598,6 +614,7 @@
 		924459BF20CB796B0007570D /* Core Data */ = {
 			isa = PBXGroup;
 			children = (
+				9236102321798647000CC5E9 /* Match */,
 				9236101D217823F1000CC5E9 /* Media */,
 				92C1F2DD216994CF00BD8445 /* CoreDataTestCase.swift */,
 				926652622156C55C000E4F4F /* Event */,
@@ -1742,8 +1759,10 @@
 				92BB718420CE1E310081F4E5 /* Test.xcdatamodeld in Sources */,
 				923AEE99216703CB00EF50C8 /* MyTBA_Tests.swift in Sources */,
 				92B076F120FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift in Sources */,
+				92C2E939217B92C500004B9E /* MatchVideo_Tests.swift in Sources */,
 				924459C320CB796B0007570D /* Date+TBA_Tests.swift in Sources */,
 				92C1F2E02169A3B800BD8445 /* MockNavigationController.swift in Sources */,
+				9236102521798655000CC5E9 /* Match_Tests.swift in Sources */,
 				923AEE8C21658C5800EF50C8 /* Bundle+Version_Tests.swift in Sources */,
 				92BB717F20CE19F40081F4E5 /* PersistentContainerOperation_Tests.swift in Sources */,
 				14B6727321529DEE00FDDAB2 /* MockRealtimeDatabaseService.swift in Sources */,
@@ -1756,6 +1775,7 @@
 				92BB717C20CE116C0081F4E5 /* TBAOperation_Tests.swift in Sources */,
 				929820CF216968020080C1C8 /* TBATestCase.swift in Sources */,
 				924459C420CB796B0007570D /* Int16+Suffix_Tests.swift in Sources */,
+				92C2E937217B907900004B9E /* MatchAlliance_Tests.swift in Sources */,
 				924459C820CB797E0007570D /* RetryService_Tests.swift in Sources */,
 				14B424F62167B01700E1904C /* Calendar+TBA_Tests.swift in Sources */,
 				9236101F2178245C000CC5E9 /* Media_Tests.swift in Sources */,

--- a/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/The Blue Alliance.xcscheme
+++ b/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/The Blue Alliance.xcscheme
@@ -84,6 +84,16 @@
             ReferencedContainer = "container:the-blue-alliance-ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.SQLDebug 2"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/the-blue-alliance-ios/Core Data/Match.swift
+++ b/the-blue-alliance-ios/Core Data/Match.swift
@@ -97,7 +97,7 @@ extension Match: Managed {
      Returns the trimmed team keys for the red alliance.
      */
     var redAllianceTeamNumbers: [String] {
-        return redAlliance?.teams.map({ Team.trimFRCPrefix($0) }).reversed() ?? []
+        return (redAlliance?.teams?.array as? [TeamKey])?.map({ Team.trimFRCPrefix($0.key!) }).reversed() ?? []
     }
 
     /**
@@ -111,7 +111,7 @@ extension Match: Managed {
      Returns the trimmed team keys for the blue alliance.
      */
     var blueAllianceTeamNumbers: [String] {
-        return blueAlliance?.teams.map({ Team.trimFRCPrefix($0) }).reversed() ?? []
+        return (blueAlliance?.teams!.array as? [TeamKey])?.map({ Team.trimFRCPrefix($0.key!) }).reversed() ?? []
     }
 
     private func alliance(with allianceKey: String) -> MatchAlliance? {

--- a/the-blue-alliance-ios/Core Data/MatchAlliance.swift
+++ b/the-blue-alliance-ios/Core Data/MatchAlliance.swift
@@ -1,0 +1,34 @@
+import Foundation
+import TBAKit
+import CoreData
+
+extension MatchAlliance: Managed {
+
+    var teams: [String] {
+        return teamsJoined!.split(separator: ",").map({ String($0) })
+    }
+
+    var surrogateTeams: [String]? {
+        return surrogateTeamsJoined?.split(separator: ",").map({ String($0) })
+    }
+
+    var dqTeams: [String]? {
+        return dqTeamsJoined?.split(separator: ",").map({ String($0) })
+    }
+
+    static func insert(with model: TBAMatchAlliance, allianceKey: String, for match: Match, in context: NSManagedObjectContext) -> MatchAlliance {
+        let predicate = NSPredicate(format: "allianceKey == %@ AND match == %@", allianceKey, match)
+        return findOrCreate(in: context, matching: predicate) { (matchAlliance) in
+            // Required: allianceKey, score, teams
+            matchAlliance.allianceKey = allianceKey
+            matchAlliance.score = NSNumber(value: model.score)
+            // These are stored as comma separated strings so they can be queried against with predicates
+            // If they were stored as Transformables, they're stored as binary blobs, and can't be used with predicates
+            // There's probably a way to do this with value transformers but https://stackoverflow.com/a/21815411
+            matchAlliance.teamsJoined = model.teams.joined(separator: ",")
+            matchAlliance.surrogateTeamsJoined = model.surrogateTeams?.joined(separator: ",")
+            matchAlliance.dqTeamsJoined = model.dqTeams?.joined(separator: ",")
+        }
+    }
+
+}

--- a/the-blue-alliance-ios/Core Data/MatchAlliance.swift
+++ b/the-blue-alliance-ios/Core Data/MatchAlliance.swift
@@ -4,18 +4,6 @@ import CoreData
 
 extension MatchAlliance: Managed {
 
-    var teams: [String] {
-        return teamsJoined!.split(separator: ",").map({ String($0) })
-    }
-
-    var surrogateTeams: [String]? {
-        return surrogateTeamsJoined?.split(separator: ",").map({ String($0) })
-    }
-
-    var dqTeams: [String]? {
-        return dqTeamsJoined?.split(separator: ",").map({ String($0) })
-    }
-
     static func insert(with model: TBAMatchAlliance, allianceKey: String, for match: Match, in context: NSManagedObjectContext) -> MatchAlliance {
         let predicate = NSPredicate(format: "allianceKey == %@ AND match == %@", allianceKey, match)
         return findOrCreate(in: context, matching: predicate) { (matchAlliance) in
@@ -29,12 +17,25 @@ extension MatchAlliance: Managed {
                 matchAlliance.score = nil
             }
 
-            // These are stored as comma separated strings so they can be queried against with predicates
-            // If they were stored as Transformables, they're stored as binary blobs, and can't be used with predicates
-            // There's probably a way to do this with value transformers but https://stackoverflow.com/a/21815411
-            matchAlliance.teamsJoined = model.teams.joined(separator: ",")
-            matchAlliance.surrogateTeamsJoined = model.surrogateTeams?.joined(separator: ",")
-            matchAlliance.dqTeamsJoined = model.dqTeams?.joined(separator: ",")
+            matchAlliance.teams = NSOrderedSet(array: model.teams.map({ (key) -> TeamKey in
+                return TeamKey.insert(withKey: key, in: context)
+            }))
+
+            if let surrogateTeams = model.surrogateTeams {
+                matchAlliance.surrogateTeams = NSOrderedSet(array: surrogateTeams.map({ (key) -> TeamKey in
+                    return TeamKey.insert(withKey: key, in: context)
+                }))
+            } else {
+                matchAlliance.surrogateTeams = nil
+            }
+
+            if let dqTeams = model.dqTeams {
+                matchAlliance.dqTeams = NSOrderedSet(array: dqTeams.map({ (key) -> TeamKey in
+                    return TeamKey.insert(withKey: key, in: context)
+                }))
+            } else {
+                matchAlliance.dqTeams = nil
+            }
         }
     }
 

--- a/the-blue-alliance-ios/Core Data/MatchAlliance.swift
+++ b/the-blue-alliance-ios/Core Data/MatchAlliance.swift
@@ -21,7 +21,14 @@ extension MatchAlliance: Managed {
         return findOrCreate(in: context, matching: predicate) { (matchAlliance) in
             // Required: allianceKey, score, teams
             matchAlliance.allianceKey = allianceKey
-            matchAlliance.score = NSNumber(value: model.score)
+
+            // Match scores for unplayed matches are returned as -1 from the API
+            if model.score > -1 {
+                matchAlliance.score = NSNumber(value: model.score)
+            } else {
+                matchAlliance.score = nil
+            }
+
             // These are stored as comma separated strings so they can be queried against with predicates
             // If they were stored as Transformables, they're stored as binary blobs, and can't be used with predicates
             // There's probably a way to do this with value transformers but https://stackoverflow.com/a/21815411

--- a/the-blue-alliance-ios/Core Data/MatchVideo.swift
+++ b/the-blue-alliance-ios/Core Data/MatchVideo.swift
@@ -9,20 +9,26 @@ public enum MatchVideoType: String {
 
 extension MatchVideo: Managed, Playable {
 
+    var type: MatchVideoType? {
+        guard let typeString = typeString else {
+            return nil
+        }
+        return MatchVideoType(rawValue: typeString)
+    }
+
     var youtubeKey: String? {
-        if type == MatchVideoType.youtube.rawValue {
+        if type == .youtube {
             return key
         }
         return nil
     }
 
-    static func insert(with model: TBAMatchVideo, for match: Match, in context: NSManagedObjectContext) -> MatchVideo {
-        let predicate = NSPredicate(format: "key == %@ AND type == %@", model.key, model.type)
+    static func insert(with model: TBAMatchVideo, in context: NSManagedObjectContext) -> MatchVideo {
+        let predicate = NSPredicate(format: "key == %@ AND typeString == %@", model.key, model.type)
         return findOrCreate(in: context, matching: predicate) { (matchVideo) in
             // Required: key, type
             matchVideo.key = model.key
-            matchVideo.type = model.type
-            matchVideo.match = match
+            matchVideo.typeString = model.type
         }
     }
 

--- a/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
+++ b/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
@@ -156,8 +156,8 @@
     <entity name="Match" representedClassName="Match" syncable="YES" codeGenerationType="class">
         <attribute name="actualTime" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="breakdown" optional="YES" attributeType="Transformable" customClassName="[String: Any]" syncable="YES"/>
-        <attribute name="compLevel" attributeType="String" syncable="YES"/>
-        <attribute name="compLevelInt" attributeType="Integer 16" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="compLevelSortOrder" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="compLevelString" attributeType="String" syncable="YES"/>
         <attribute name="key" attributeType="String" syncable="YES"/>
         <attribute name="matchNumber" attributeType="Integer 16" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="postResultTime" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
@@ -167,7 +167,7 @@
         <attribute name="winningAlliance" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="alliances" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MatchAlliance" inverseName="match" inverseEntity="MatchAlliance" syncable="YES"/>
         <relationship name="event" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="matches" inverseEntity="Event" syncable="YES"/>
-        <relationship name="videos" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MatchVideo" inverseName="match" inverseEntity="MatchVideo" syncable="YES"/>
+        <relationship name="videos" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MatchVideo" inverseName="match" inverseEntity="MatchVideo" syncable="YES"/>
     </entity>
     <entity name="MatchAlliance" representedClassName="MatchAlliance" syncable="YES" codeGenerationType="class">
         <attribute name="allianceKey" attributeType="String" syncable="YES"/>
@@ -179,7 +179,7 @@
     </entity>
     <entity name="MatchVideo" representedClassName="MatchVideo" syncable="YES" codeGenerationType="class">
         <attribute name="key" attributeType="String" syncable="YES"/>
-        <attribute name="type" attributeType="String" syncable="YES"/>
+        <attribute name="typeString" attributeType="String" syncable="YES"/>
         <relationship name="match" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Match" inverseName="videos" inverseEntity="Match" syncable="YES"/>
     </entity>
     <entity name="Media" representedClassName="Media" syncable="YES" codeGenerationType="class">
@@ -260,12 +260,12 @@
         <element name="EventTeamStat" positionX="-54" positionY="135" width="128" height="120"/>
         <element name="Favorite" positionX="45" positionY="135" width="128" height="45"/>
         <element name="Match" positionX="-54" positionY="135" width="128" height="255"/>
+        <element name="MatchAlliance" positionX="45" positionY="135" width="128" height="135"/>
         <element name="MatchVideo" positionX="45" positionY="135" width="128" height="90"/>
         <element name="Media" positionX="-45" positionY="144" width="128" height="180"/>
         <element name="MyTBAEntity" positionX="45" positionY="135" width="128" height="75"/>
         <element name="Subscription" positionX="54" positionY="144" width="128" height="60"/>
         <element name="Team" positionX="-54" positionY="135" width="128" height="510"/>
         <element name="Webcast" positionX="-45" positionY="144" width="128" height="120"/>
-        <element name="MatchAlliance" positionX="45" positionY="135" width="128" height="135"/>
     </elements>
 </model>

--- a/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
+++ b/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
@@ -171,11 +171,11 @@
     </entity>
     <entity name="MatchAlliance" representedClassName="MatchAlliance" syncable="YES" codeGenerationType="class">
         <attribute name="allianceKey" attributeType="String" syncable="YES"/>
-        <attribute name="dqTeamsJoined" optional="YES" attributeType="String" customClassName="[String]" syncable="YES"/>
         <attribute name="score" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="surrogateTeamsJoined" optional="YES" attributeType="String" customClassName="[String]" syncable="YES"/>
-        <attribute name="teamsJoined" optional="YES" attributeType="String" customClassName="[String]" syncable="YES"/>
-        <relationship name="match" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Match" inverseName="alliances" inverseEntity="Match" syncable="YES"/>
+        <relationship name="dqTeams" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="TeamKey" inverseName="dqAlliances" inverseEntity="TeamKey" syncable="YES"/>
+        <relationship name="match" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Match" inverseName="alliances" inverseEntity="Match" syncable="YES"/>
+        <relationship name="surrogateTeams" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="TeamKey" inverseName="surrogateAlliances" inverseEntity="TeamKey" syncable="YES"/>
+        <relationship name="teams" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="TeamKey" inverseName="alliances" inverseEntity="TeamKey" syncable="YES"/>
     </entity>
     <entity name="MatchVideo" representedClassName="MatchVideo" syncable="YES" codeGenerationType="class">
         <attribute name="key" attributeType="String" syncable="YES"/>
@@ -236,6 +236,12 @@
             <fetchIndexElement property="key" type="Binary" order="ascending"/>
         </fetchIndex>
     </entity>
+    <entity name="TeamKey" representedClassName="TeamKey" syncable="YES" codeGenerationType="class">
+        <attribute name="key" attributeType="String" syncable="YES"/>
+        <relationship name="alliances" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MatchAlliance" inverseName="teams" inverseEntity="MatchAlliance" syncable="YES"/>
+        <relationship name="dqAlliances" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MatchAlliance" inverseName="dqTeams" inverseEntity="MatchAlliance" syncable="YES"/>
+        <relationship name="surrogateAlliances" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MatchAlliance" inverseName="surrogateTeams" inverseEntity="MatchAlliance" syncable="YES"/>
+    </entity>
     <entity name="Webcast" representedClassName="Webcast" syncable="YES" codeGenerationType="class">
         <attribute name="channel" attributeType="String" syncable="YES"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -267,5 +273,6 @@
         <element name="Subscription" positionX="54" positionY="144" width="128" height="60"/>
         <element name="Team" positionX="-54" positionY="135" width="128" height="510"/>
         <element name="Webcast" positionX="-45" positionY="144" width="128" height="120"/>
+        <element name="TeamKey" positionX="45" positionY="135" width="128" height="105"/>
     </elements>
 </model>

--- a/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
+++ b/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
@@ -155,30 +155,27 @@
     <entity name="Favorite" representedClassName="Favorite" parentEntity="MyTBAEntity" syncable="YES" codeGenerationType="class"/>
     <entity name="Match" representedClassName="Match" syncable="YES" codeGenerationType="class">
         <attribute name="actualTime" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="blueBreakdown" optional="YES" attributeType="Transformable" customClassName="[String: Any]" syncable="YES"/>
-        <attribute name="blueDQTeamKeys" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
-        <attribute name="blueScore" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="blueSurrogateTeamKeys" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
+        <attribute name="breakdown" optional="YES" attributeType="Transformable" customClassName="[String: Any]" syncable="YES"/>
         <attribute name="compLevel" attributeType="String" syncable="YES"/>
         <attribute name="compLevelInt" attributeType="Integer 16" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="key" attributeType="String" syncable="YES"/>
         <attribute name="matchNumber" attributeType="Integer 16" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="postResultTime" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="predictedTime" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="redBreakdown" optional="YES" attributeType="Transformable" customClassName="[String: Any]" syncable="YES"/>
-        <attribute name="redDQTeamKeys" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
-        <attribute name="redScore" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="redSurrogateTeamKeys" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
         <attribute name="setNumber" attributeType="Integer 16" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="time" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="winningAlliance" optional="YES" attributeType="String" syncable="YES"/>
-        <relationship name="blueAlliance" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Team" inverseName="blueMatches" inverseEntity="Team" syncable="YES"/>
+        <relationship name="alliances" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MatchAlliance" inverseName="match" inverseEntity="MatchAlliance" syncable="YES"/>
         <relationship name="event" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="matches" inverseEntity="Event" syncable="YES"/>
-        <relationship name="redAlliance" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Team" inverseName="redMatches" inverseEntity="Team" syncable="YES"/>
         <relationship name="videos" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MatchVideo" inverseName="match" inverseEntity="MatchVideo" syncable="YES"/>
-        <fetchIndex name="byKeyIndex">
-            <fetchIndexElement property="key" type="Binary" order="ascending"/>
-        </fetchIndex>
+    </entity>
+    <entity name="MatchAlliance" representedClassName="MatchAlliance" syncable="YES" codeGenerationType="class">
+        <attribute name="allianceKey" attributeType="String" syncable="YES"/>
+        <attribute name="dqTeamsJoined" optional="YES" attributeType="String" customClassName="[String]" syncable="YES"/>
+        <attribute name="score" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="surrogateTeamsJoined" optional="YES" attributeType="String" customClassName="[String]" syncable="YES"/>
+        <attribute name="teamsJoined" optional="YES" attributeType="String" customClassName="[String]" syncable="YES"/>
+        <relationship name="match" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Match" inverseName="alliances" inverseEntity="Match" syncable="YES"/>
     </entity>
     <entity name="MatchVideo" representedClassName="MatchVideo" syncable="YES" codeGenerationType="class">
         <attribute name="key" attributeType="String" syncable="YES"/>
@@ -224,7 +221,6 @@
         <attribute name="website" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="yearsParticipated" optional="YES" attributeType="Transformable" customClassName="[Int]" syncable="YES"/>
         <relationship name="awards" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AwardRecipient" inverseName="team" inverseEntity="AwardRecipient" syncable="YES"/>
-        <relationship name="blueMatches" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Match" inverseName="blueAlliance" inverseEntity="Match" syncable="YES"/>
         <relationship name="declinedAlliances" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventAlliance" inverseName="declines" inverseEntity="EventAlliance" syncable="YES"/>
         <relationship name="districtRankings" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DistrictRanking" inverseName="team" inverseEntity="DistrictRanking" syncable="YES"/>
         <relationship name="eventPoints" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DistrictEventPoints" inverseName="team" inverseEntity="DistrictEventPoints" syncable="YES"/>
@@ -235,7 +231,6 @@
         <relationship name="media" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Media" inverseName="team" inverseEntity="Media" syncable="YES"/>
         <relationship name="outBackupAlliances" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventAllianceBackup" inverseName="outTeam" inverseEntity="EventAllianceBackup" syncable="YES"/>
         <relationship name="pickedAlliances" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventAlliance" inverseName="picks" inverseEntity="EventAlliance" syncable="YES"/>
-        <relationship name="redMatches" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Match" inverseName="redAlliance" inverseEntity="Match" syncable="YES"/>
         <relationship name="stats" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventTeamStat" inverseName="team" inverseEntity="EventTeamStat" syncable="YES"/>
         <fetchIndex name="byKeyIndex">
             <fetchIndexElement property="key" type="Binary" order="ascending"/>
@@ -264,12 +259,13 @@
         <element name="EventStatusQual" positionX="54" positionY="144" width="128" height="105"/>
         <element name="EventTeamStat" positionX="-54" positionY="135" width="128" height="120"/>
         <element name="Favorite" positionX="45" positionY="135" width="128" height="45"/>
-        <element name="Match" positionX="-54" positionY="135" width="128" height="30"/>
+        <element name="Match" positionX="-54" positionY="135" width="128" height="255"/>
         <element name="MatchVideo" positionX="45" positionY="135" width="128" height="90"/>
         <element name="Media" positionX="-45" positionY="144" width="128" height="180"/>
         <element name="MyTBAEntity" positionX="45" positionY="135" width="128" height="75"/>
         <element name="Subscription" positionX="54" positionY="144" width="128" height="60"/>
-        <element name="Team" positionX="-54" positionY="135" width="128" height="540"/>
+        <element name="Team" positionX="-54" positionY="135" width="128" height="510"/>
         <element name="Webcast" positionX="-45" positionY="144" width="128" height="120"/>
+        <element name="MatchAlliance" positionX="45" positionY="135" width="128" height="135"/>
     </elements>
 </model>

--- a/the-blue-alliance-ios/Core Data/TeamKey.swift
+++ b/the-blue-alliance-ios/Core Data/TeamKey.swift
@@ -1,0 +1,24 @@
+import CoreData
+
+/**
+ A TeamKey is an object used to represent just a team key returned from an API call. This allows us to keep
+ relationships between objects and team representations, without having to store full team objects (we may not have)
+ or store arrays of keys (which we can't filter against).
+
+ A TeamKey is a VERY specific model. If you're not use if you need a TeamKey or a Team, you probably need a Team.
+ */
+extension TeamKey: Managed {
+
+    var team: Team? {
+        return Team.findOrFetch(in: managedObjectContext!, matching: NSPredicate(format: "key == %@", key!))
+    }
+
+    static func insert(withKey key: String, in context: NSManagedObjectContext) -> TeamKey {
+        let predicate = NSPredicate(format: "key == %@", key)
+        return findOrCreate(in: context, matching: predicate) { (teamKey) in
+            // Required: key
+            teamKey.key = key
+        }
+    }
+
+}

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -99,26 +99,27 @@ class MatchBreakdownViewController: TBAViewController, Observable, ReactNative {
     // MARK: Private
 
     func dataForBreakdown() -> [String: Any]? {
-        guard let redBreakdown = match.redBreakdown else {
+        // TODO: This isn't very robust, and only supports red/blue
+        guard var redBreakdown = match.breakdown?["red"] as? [String: Any] else {
             return nil
         }
-        guard let blueBreakdown = match.blueBreakdown else {
+        guard var blueBreakdown = match.breakdown?["blue"] as? [String: Any] else {
             return nil
         }
 
-        let redAllianceTeams = match.redAlliance?.array as? [Team]
-        let redAlliance = redAllianceTeams?.map({ (team) -> String in
-            return "\(team.teamNumber)"
-        })
+        // For 2015 - map `coopertition` and `coopertition_points` points in to each breakdown dictionary
+        if let coopertition = match.breakdown?["coopertition"] as? String, let coopertitionPoints = match.breakdown?["coopertition_points"] as? Int {
+            // Setting these individually, since I can't seem to do a 'for in' to modify the above maps
+            redBreakdown["coopertition"] = coopertition
+            redBreakdown["coopertition_points"] = coopertitionPoints
 
-        let blueAllianceTeams = match.blueAlliance?.array as? [Team]
-        let blueAlliance = blueAllianceTeams?.map({ (team) -> String in
-            return "\(team.teamNumber)"
-        })
+            blueBreakdown["coopertition"] = coopertition
+            blueBreakdown["coopertition_points"] = coopertitionPoints
+        }
 
-        return ["redTeams": redAlliance ?? [],
+        return ["redTeams": match.redAllianceTeamNumbers,
                 "redBreakdown": redBreakdown,
-                "blueTeams": blueAlliance ?? [],
+                "blueTeams": match.blueAllianceTeamNumbers,
                 "blueBreakdown": blueBreakdown,
                 "compLevel": match.compLevel!]
     }
@@ -171,7 +172,7 @@ extension MatchBreakdownViewController: Refreshable {
     }
 
     var isDataSourceEmpty: Bool {
-        return match.redBreakdown == nil || match.blueBreakdown == nil
+        return match.breakdown == nil
     }
 
     @objc func refresh() {

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -99,7 +99,8 @@ class MatchBreakdownViewController: TBAViewController, Observable, ReactNative {
     // MARK: Private
 
     func dataForBreakdown() -> [String: Any]? {
-        // TODO: This isn't very robust, and only supports red/blue
+        // TODO: Support all alliances
+        // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/273
         guard var redBreakdown = match.breakdown?["red"] as? [String: Any] else {
             return nil
         }

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -121,7 +121,7 @@ class MatchBreakdownViewController: TBAViewController, Observable, ReactNative {
                 "redBreakdown": redBreakdown,
                 "blueTeams": match.blueAllianceTeamNumbers,
                 "blueBreakdown": blueBreakdown,
-                "compLevel": match.compLevel!]
+                "compLevel": match.compLevelString!]
     }
 
 

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchViewController.swift
@@ -27,7 +27,7 @@ class MatchContainerViewController: ContainerViewController {
                    segmentedControlTitles: titles,
                    persistentContainer: persistentContainer)
 
-        navigationTitle = "\(match.friendlyMatchName())"
+        navigationTitle = "\(match.friendlyName)"
         navigationSubtitle = "@ \(match.event!.friendlyNameWithYear)"
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -49,7 +49,7 @@ class MatchesViewController: TBATableViewController {
 
     private func setupFetchRequest(_ request: NSFetchRequest<Match>) {
         if let team = team {
-            request.predicate = NSPredicate(format: "event == %@ AND SUBQUERY(alliances, $a, SUBQUERY($a.teams, $t, $t.key == %@).@count > 0).@count > 0", event, team.key!)
+            request.predicate = NSPredicate(format: "event == %@ AND SUBQUERY(alliances, $a, ANY $a.teams.key == %@).@count > 0", event, team.key!)
         } else {
             request.predicate = NSPredicate(format: "event == %@", event)
         }

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -49,7 +49,7 @@ class MatchesViewController: TBATableViewController {
 
     private func setupFetchRequest(_ request: NSFetchRequest<Match>) {
         if let team = team {
-            request.predicate = NSPredicate(format: "event == %@ AND (ANY alliances.teamsJoined CONTAINS[c] %@)", event, team.key!)
+            request.predicate = NSPredicate(format: "event == %@ AND SUBQUERY(alliances, $a, SUBQUERY($a.teams, $t, $t.key == %@).@count > 0).@count > 0", event, team.key!)
         } else {
             request.predicate = NSPredicate(format: "event == %@", event)
         }

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -49,7 +49,7 @@ class MatchesViewController: TBATableViewController {
 
     private func setupFetchRequest(_ request: NSFetchRequest<Match>) {
         if let team = team {
-            request.predicate = NSPredicate(format: "event == %@ AND (ANY redAlliance == %@ OR ANY blueAlliance == %@)", event, team, team)
+            request.predicate = NSPredicate(format: "event == %@ AND (ANY alliances.teamsJoined CONTAINS[c] %@)", event, team.key!)
         } else {
             request.predicate = NSPredicate(format: "event == %@", event)
         }

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchesViewController.swift
@@ -34,12 +34,12 @@ class MatchesViewController: TBATableViewController {
 
     private func setupDataSource() {
         let fetchRequest: NSFetchRequest<Match> = Match.fetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "compLevelInt", ascending: true),
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "compLevelSortOrder", ascending: true),
                                         NSSortDescriptor(key: "setNumber", ascending: true),
                                         NSSortDescriptor(key: "matchNumber", ascending: true)]
         setupFetchRequest(fetchRequest)
 
-        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: "compLevelInt", cacheName: nil)
+        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: "compLevelSortOrder", cacheName: nil)
         dataSource = TableViewDataSource(fetchedResultsController: frc, delegate: self)
     }
 
@@ -72,7 +72,7 @@ extension MatchesViewController: TableViewDataSourceDelegate {
 
     func title(for section: Int) -> String? {
         let firstMatch = dataSource.object(at: IndexPath(row: 0, section: section))
-        return "\(firstMatch.compLevelString) Matches"
+        return "\(firstMatch.compLevel?.level ?? firstMatch.compLevelString!) Matches"
     }
 
     func configure(_ cell: MatchTableViewCell, for object: Match, at indexPath: IndexPath) {

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
@@ -275,7 +275,7 @@ extension MyTBATableViewController: Refreshable {
                     case .match:
                         let match = Match.findOrFetch(in: backgroundContext, matching: predicate)
                         // Fetch our match if it doesn't exist or we don't have scores
-                        if match?.redScore == nil || match?.blueScore == nil {
+                        if match?.redAlliance?.score == nil || match?.blueAlliance?.score == nil {
                             self?.backgroundFetchKeys.insert(model.modelKey)
                             TBABackgroundService.backgroundFetchMatch(model.modelKey, in: backgroundContext, completion: { (_, _) in
                                 self?.backgroundFetchKeys.remove(model.modelKey)

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -20,7 +20,8 @@ struct MatchViewModel {
     let baseTeamKey: String?
 
     init(match: Match, team: Team? = nil) {
-        // TODO: This isn't very robust - only supports red/blue
+        // TODO: Support all alliances
+        // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/274
         matchName = match.friendlyName
 
         hasVideos = match.videos?.count == 0

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -20,15 +20,16 @@ struct MatchViewModel {
     let baseTeamKey: String?
 
     init(match: Match, team: Team? = nil) {
+        // TODO: This isn't very robust - only supports red/blue
         matchName = match.friendlyMatchName()
 
         hasVideos = match.videos?.count == 0
 
-        redAlliance = (match.redAlliance?.array as? [Team])?.reversed().map({ $0.key! }) ?? []
-        redScore = match.redScore?.stringValue
+        redAlliance = match.redAllianceTeamNumbers
+        redScore = match.redAlliance?.score?.stringValue
 
-        blueAlliance = (match.blueAlliance?.array as? [Team])?.reversed().map({ $0.key! }) ?? []
-        blueScore = match.blueScore?.stringValue
+        blueAlliance = match.blueAllianceTeamNumbers
+        blueScore = match.blueAlliance?.score?.stringValue
 
         timeString = match.timeString ?? "No Time Yet"
 

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -21,7 +21,7 @@ struct MatchViewModel {
 
     init(match: Match, team: Team? = nil) {
         // TODO: This isn't very robust - only supports red/blue
-        matchName = match.friendlyMatchName()
+        matchName = match.friendlyName
 
         hasVideos = match.videos?.count == 0
 
@@ -38,13 +38,7 @@ struct MatchViewModel {
         // If we can't figure out a piece of information, default to yes, the match is a regular match,
         // where someone wins, and someone loses
         let hasWinnersAndLosers: Bool = {
-            guard let compLevelAbbrev = match.compLevel, let compLevel = MatchCompLevel(rawValue: compLevelAbbrev) else {
-                return true
-            }
-            guard let year16 = match.event?.year else {
-                return true
-            }
-            if Int(year16) == 2015 && compLevel != MatchCompLevel.final {
+            if Int(match.event!.year) == 2015 && match.compLevel != .final {
                 return false
             }
             return true


### PR DESCRIPTION
This is a bit of a tech debt thing, but also the first step in removing all usages of `Team.insert(withKey:)` (#265). Core Data can't handle this migration for us (obviously), but we should be able to migrate our old objects to this new format without any problems.

- Update TBAKit to 2.0.8
- Remove `redAlliance` and `blueAlliance` from Match
- Remove `redBreakdown` and `blueBreakdown` from Match
- Remove `redDQTeamKeys` and `blueDQTeamKeys` from Match
- Remove `redScore` and `blueSurrogateTeamKeys` from Match
- Add MatchAlliance Core Data model, to represent `alliances` on a `Match`
- Nullify missing Match values when updating a model from a TBAKit object

TODO, before merging
- [x] Add tests for Match
- [x] Add tests for MatchAlliance
- [x] File ticket and link for breakdown and MatchViewModel supporting dynamic number of alliances
- [ ] Write migration code for old Match -> new Match