### PR TITLE
Make Event optional on a Match

### DIFF
--- a/tba-unit-tests/Core Data/Event/EventTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventTests.swift
@@ -277,6 +277,35 @@ class EventTestCase: CoreDataTestCase {
         XCTAssertNoThrow(try persistentContainer.viewContext.save())
     }
 
+    func test_insert_match() {
+        let event = districtEvent()
+
+        let redAlliance = TBAMatchAlliance(score: 200, teams: ["frc7332"])
+        let blueAlliance = TBAMatchAlliance(score: 300, teams: ["frc3333"])
+        let model = TBAMatch(key: "\(event.key!)_sf2m3",
+            compLevel: "sf",
+            setNumber: 2,
+            matchNumber: 3,
+            alliances: ["red": redAlliance, "blue": blueAlliance],
+            winningAlliance: "blue",
+            eventKey: event.key!,
+            time: 1520109780,
+            actualTime: 1520090745,
+            predictedTime: 1520109780,
+            postResultTime: 1520090929,
+            breakdown: ["red": [:], "blue": [:]],
+            videos: [TBAMatchVideo(key: "G-pq01gqMTw", type: "youtube")])
+
+        event.insert(model)
+
+        let matches = event.matches!.allObjects as! [Match]
+        let match = matches.first(where: { $0.key == "2018miket_sf2m3" })!
+
+        // Sanity check
+        XCTAssertEqual(event.matches?.count, 1)
+        XCTAssertEqual(match.event, event)
+    }
+
     func test_insert_matches() {
         let event = districtEvent()
 

--- a/tba-unit-tests/Core Data/Match/MatchAllianceTests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchAllianceTests.swift
@@ -5,8 +5,7 @@ import XCTest
 class MatchAllianceTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
-        let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: event.key!)
+        let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: "2018miket")
 
         let model = TBAMatchAlliance(score: 200, teams: ["frc1", "frc2"], surrogateTeams: ["frc3", "frc4"], dqTeams: ["frc5", "frc6"])
         let alliance = MatchAlliance.insert(model, allianceKey: "red", matchKey: matchModel.key, in: persistentContainer.viewContext)
@@ -20,7 +19,7 @@ class MatchAllianceTestCase: CoreDataTestCase {
         // Should throw - needs to be attached to a Match
         XCTAssertThrowsError(try persistentContainer.viewContext.save())
 
-        alliance.match = Match.insert(matchModel, event: event, in: persistentContainer.viewContext)
+        alliance.match = Match.insert(matchModel, in: persistentContainer.viewContext)
         XCTAssertNoThrow(try persistentContainer.viewContext.save())
     }
 
@@ -57,13 +56,12 @@ class MatchAllianceTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
-        let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: event.key!)
+        let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: "2018miket")
 
         let model = TBAMatchAlliance(score: 200, teams: ["frc1", "frc2"], surrogateTeams: ["frc3", "frc4"], dqTeams: ["frc5", "frc6"])
         let alliance = MatchAlliance.insert(model, allianceKey: "red", matchKey: matchModel.key, in: persistentContainer.viewContext)
 
-        let match = Match.insert(matchModel, event: event, in: persistentContainer.viewContext)
+        let match = Match.insert(matchModel, in: persistentContainer.viewContext)
         alliance.match = match
 
         let teams = alliance.teams!.array as! [TeamKey]

--- a/tba-unit-tests/Core Data/Match/MatchTests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchTests.swift
@@ -17,16 +17,15 @@ class MatchTestCase: CoreDataTestCase {
     }
 
     func test_insert() {
-        let event = districtEvent()
         let redAlliance = TBAMatchAlliance(score: 200, teams: ["frc7332"])
         let blueAlliance = TBAMatchAlliance(score: 300, teams: ["frc3333"])
-        let model = TBAMatch(key: "\(event.key!)_sf2m3",
+        let model = TBAMatch(key: "2018miket_sf2m3",
                              compLevel: "sf",
                              setNumber: 2,
                              matchNumber: 3,
                              alliances: ["red": redAlliance, "blue": blueAlliance],
                              winningAlliance: "blue",
-                             eventKey: event.key!,
+                             eventKey: "2018miket",
                              time: 1520109780,
                              actualTime: 1520090745,
                              predictedTime: 1520109780,
@@ -34,7 +33,7 @@ class MatchTestCase: CoreDataTestCase {
                              breakdown: ["red": [:], "blue": [:]],
                              videos: [TBAMatchVideo(key: "G-pq01gqMTw", type: "youtube")])
 
-        let match = Match.insert(model, event: event, in: persistentContainer.viewContext)
+        let match = Match.insert(model, in: persistentContainer.viewContext)
 
         XCTAssertNoThrow(try persistentContainer.viewContext.save())
 
@@ -44,26 +43,31 @@ class MatchTestCase: CoreDataTestCase {
         XCTAssertEqual(match.matchNumber, 3)
         XCTAssertEqual(match.alliances?.count, 2)
         XCTAssertEqual(match.winningAlliance, "blue")
-        XCTAssertEqual(match.event, event)
         XCTAssertEqual(match.time, 1520109780)
         XCTAssertEqual(match.actualTime, 1520090745)
         XCTAssertEqual(match.predictedTime, 1520109780)
         XCTAssertEqual(match.postResultTime, 1520090929)
         XCTAssertEqual(match.videos?.count, 1)
+
+        // Ensure Match can have an Event
+        let event = districtEvent()
+        match.event = event
+
+        XCTAssertEqual(match.event, event)
+        XCTAssert(event.matches!.contains(match))
     }
 
     func test_update() {
-        let event = districtEvent()
         let redAllianceModel = TBAMatchAlliance(score: 200, teams: ["frc7332"])
         let blueAllianceModel = TBAMatchAlliance(score: 300, teams: ["frc3333"])
         let orangeAllianceModel = TBAMatchAlliance(score: 100, teams: ["frc1111"])
-        let modelOne = TBAMatch(key: "\(event.key!)_sf2m3",
+        let modelOne = TBAMatch(key: "2018miket_sf2m3",
             compLevel: "sf",
             setNumber: 2,
             matchNumber: 3,
             alliances: ["red": redAllianceModel, "blue": blueAllianceModel, "orange": orangeAllianceModel],
             winningAlliance: "blue",
-            eventKey: event.key!,
+            eventKey: "2018miket",
             time: 1520109780,
             actualTime: 1520090745,
             predictedTime: 1520109780,
@@ -71,7 +75,7 @@ class MatchTestCase: CoreDataTestCase {
             breakdown: ["red": [:], "blue": [:]],
             videos: [TBAMatchVideo(key: "G-pq01gqMTw", type: "youtube")])
 
-        let matchOne = Match.insert(modelOne, event: event, in: persistentContainer.viewContext)
+        let matchOne = Match.insert(modelOne, in: persistentContainer.viewContext)
         let blueAlliance = (matchOne.alliances!.allObjects as! [MatchAlliance]).first(where: { $0.allianceKey == "blue" })!
         let orangeAlliance = (matchOne.alliances!.allObjects as! [MatchAlliance]).first(where: { $0.allianceKey == "orange" })!
         let redAllianceOne = (matchOne.alliances!.allObjects as! [MatchAlliance]).first(where: { $0.allianceKey == "red" })!
@@ -81,13 +85,13 @@ class MatchTestCase: CoreDataTestCase {
 
         let redAllianceModelTwo = TBAMatchAlliance(score: 200, teams: ["frc7777"])
 
-        let modelTwo = TBAMatch(key: "\(event.key!)_sf2m3",
+        let modelTwo = TBAMatch(key: "2018miket_sf2m3",
             compLevel: "sf",
             setNumber: 2,
             matchNumber: 3,
             alliances: ["red": redAllianceModelTwo, "blue": blueAllianceModel],
             winningAlliance: "red",
-            eventKey: event.key!,
+            eventKey: "2018miket",
             time: 1520109781,
             actualTime: 1520090745,
             predictedTime: 1520109780,
@@ -95,7 +99,7 @@ class MatchTestCase: CoreDataTestCase {
             breakdown: ["red": [:], "blue": [:]],
             videos: [])
 
-        let matchTwo = Match.insert(modelTwo, event: event, in: persistentContainer.viewContext)
+        let matchTwo = Match.insert(modelTwo, in: persistentContainer.viewContext)
         let redAllianceTwo = (matchTwo.alliances!.allObjects as! [MatchAlliance]).first(where: { $0.allianceKey == "red" })!
 
         // Sanity check
@@ -122,42 +126,41 @@ class MatchTestCase: CoreDataTestCase {
     }
 
     func test_update_orphans() {
-        let event = districtEvent()
         let redAllianceModel = TBAMatchAlliance(score: 200, teams: ["frc1"])
         let videoOneModel = TBAMatchVideo(key: "key_one", type: "youtube")
         let videoTwoModel = TBAMatchVideo(key: "key_two", type: "youtube")
-        let modelOne = TBAMatch(key: "\(event.key!)_sf2m3",
+        let modelOne = TBAMatch(key: "2018miket_sf2m3",
             compLevel: "sf",
             setNumber: 2,
             matchNumber: 3,
             alliances: ["red": redAllianceModel],
             winningAlliance: "red",
-            eventKey: event.key!,
+            eventKey: "2018miket",
             time: nil,
             actualTime: nil,
             predictedTime: nil,
             postResultTime: nil,
             breakdown: nil,
             videos: [videoOneModel, videoTwoModel])
-        let matchOne = Match.insert(modelOne, event: event, in: persistentContainer.viewContext)
+        let matchOne = Match.insert(modelOne, in: persistentContainer.viewContext)
 
         let videoOne = (matchOne.videos!.allObjects as! [MatchVideo]).first(where: { $0.key == "key_one" })!
         let videoTwo = (matchOne.videos!.allObjects as! [MatchVideo]).first(where: { $0.key == "key_two" })!
 
-        let modelTwo = TBAMatch(key: "\(event.key!)_sf2m3",
+        let modelTwo = TBAMatch(key: "2018miket_sf2m3",
             compLevel: "sf",
             setNumber: 2,
             matchNumber: 3,
             alliances: ["red": redAllianceModel],
             winningAlliance: "red",
-            eventKey: event.key!,
+            eventKey: "2018miket",
             time: nil,
             actualTime: nil,
             predictedTime: nil,
             postResultTime: nil,
             breakdown: nil,
             videos: [videoTwoModel])
-        let matchTwo = Match.insert(modelTwo, event: event, in: persistentContainer.viewContext)
+        let matchTwo = Match.insert(modelTwo, in: persistentContainer.viewContext)
 
         // Sanity check
         XCTAssertEqual(matchOne, matchTwo)
@@ -177,16 +180,15 @@ class MatchTestCase: CoreDataTestCase {
 
     func test_delete() {
         // Test cascades
-        let event = districtEvent()
         let redAllianceModel = TBAMatchAlliance(score: 200, teams: ["frc7332"])
         let blueAllianceModel = TBAMatchAlliance(score: 300, teams: ["frc3333"])
-        let model = TBAMatch(key: "\(event.key!)_sf2m3",
+        let model = TBAMatch(key: "2018miket_sf2m3",
             compLevel: "sf",
             setNumber: 2,
             matchNumber: 3,
             alliances: ["red": redAllianceModel, "blue": blueAllianceModel],
             winningAlliance: "blue",
-            eventKey: event.key!,
+            eventKey: "2018miket",
             time: 1520109780,
             actualTime: 1520090745,
             predictedTime: 1520109780,
@@ -194,7 +196,7 @@ class MatchTestCase: CoreDataTestCase {
             breakdown: ["red": [:], "blue": [:]],
             videos: [TBAMatchVideo(key: "G-pq01gqMTw", type: "youtube")])
 
-        let match = Match.insert(model, event: event, in: persistentContainer.viewContext)
+        let match = Match.insert(model, in: persistentContainer.viewContext)
 
         XCTAssertNoThrow(try persistentContainer.viewContext.save())
 
@@ -217,42 +219,41 @@ class MatchTestCase: CoreDataTestCase {
     }
 
     func test_delete_videoHasMatch() {
-        let event = districtEvent()
         let redAllianceModel = TBAMatchAlliance(score: 200, teams: ["frc1"])
         let videoOneModel = TBAMatchVideo(key: "key_one", type: "youtube")
         let videoTwoModel = TBAMatchVideo(key: "key_two", type: "youtube")
-        let modelOne = TBAMatch(key: "\(event.key!)_sf2m3",
+        let modelOne = TBAMatch(key: "2018miket_sf2m3",
             compLevel: "sf",
             setNumber: 2,
             matchNumber: 3,
             alliances: ["red": redAllianceModel],
             winningAlliance: "red",
-            eventKey: event.key!,
+            eventKey: "2018miket",
             time: nil,
             actualTime: nil,
             predictedTime: nil,
             postResultTime: nil,
             breakdown: nil,
             videos: [videoOneModel, videoTwoModel])
-        let matchOne = Match.insert(modelOne, event: event, in: persistentContainer.viewContext)
+        let matchOne = Match.insert(modelOne, in: persistentContainer.viewContext)
 
         let videoOne = (matchOne.videos!.allObjects as! [MatchVideo]).first(where: { $0.key == "key_one" })!
         let videoTwo = (matchOne.videos!.allObjects as! [MatchVideo]).first(where: { $0.key == "key_two" })!
 
-        let modelTwo = TBAMatch(key: "\(event.key!)_f1m1",
+        let modelTwo = TBAMatch(key: "2018miket_f1m1",
             compLevel: "f",
             setNumber: 1,
             matchNumber: 1,
             alliances: ["red": redAllianceModel],
             winningAlliance: "red",
-            eventKey: event.key!,
+            eventKey: "2018miket",
             time: nil,
             actualTime: nil,
             predictedTime: nil,
             postResultTime: nil,
             breakdown: nil,
             videos: [videoTwoModel])
-        let matchTwo = Match.insert(modelTwo, event: event, in: persistentContainer.viewContext)
+        let matchTwo = Match.insert(modelTwo, in: persistentContainer.viewContext)
 
         // Sanity check
         XCTAssertNotEqual(matchOne, matchTwo)
@@ -273,14 +274,21 @@ class MatchTestCase: CoreDataTestCase {
 
     func test_isOrphaned() {
         let match = Match.init(entity: Match.entity(), insertInto: persistentContainer.viewContext)
+        match.key = "2018miket_qm1"
         XCTAssert(match.isOrphaned)
 
+        // Is not orphaned if attached to an Event
         let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
         event.addToMatches(match)
         XCTAssertFalse(match.isOrphaned)
 
         event.removeFromMatches(match)
         XCTAssert(match.isOrphaned)
+
+        // Is not orphaned if attached to a myTBA object
+        let favorite = Favorite.init(entity: Favorite.entity(), insertInto: persistentContainer.viewContext)
+        favorite.modelKey = match.key
+        XCTAssertFalse(match.isOrphaned)
     }
 
     func test_compLevel() {

--- a/tba-unit-tests/Core Data/Match/MatchVideoTests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchVideoTests.swift
@@ -5,8 +5,7 @@ import XCTest
 class MatchVideoTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
-        let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: event.key!)
+        let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: "2018miket")
 
         let model = TBAMatchVideo(key: "key", type: "youtube")
         let video = MatchVideo.insert(model, in: persistentContainer.viewContext)
@@ -17,21 +16,20 @@ class MatchVideoTestCase: CoreDataTestCase {
         // Should fail - needs to be related to a Match
         XCTAssertThrowsError(try persistentContainer.viewContext.save())
 
-        let match = Match.insert(matchModel, event: event, in: persistentContainer.viewContext)
+        let match = Match.insert(matchModel, in: persistentContainer.viewContext)
         match.addToVideos(video)
 
         XCTAssertNoThrow(try persistentContainer.viewContext.save())
     }
 
     func test_insert_multiple() {
-        let event = districtEvent()
         let model = TBAMatchVideo(key: "key", type: "youtube")
         let video = MatchVideo.insert(model, in: persistentContainer.viewContext)
 
-        let matchModelOne = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: event.key!)
-        let matchModelTwo = TBAMatch(key: "2018miket_f1m2", compLevel: "f", setNumber: 1, matchNumber: 2, eventKey: event.key!)
-        let matchOne = Match.insert(matchModelOne, event: event, in: persistentContainer.viewContext)
-        let matchTwo = Match.insert(matchModelTwo, event: event, in: persistentContainer.viewContext)
+        let matchModelOne = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: "2018miket")
+        let matchModelTwo = TBAMatch(key: "2018miket_f1m2", compLevel: "f", setNumber: 1, matchNumber: 2, eventKey: "2018miket")
+        let matchOne = Match.insert(matchModelOne, in: persistentContainer.viewContext)
+        let matchTwo = Match.insert(matchModelTwo, in: persistentContainer.viewContext)
         matchOne.addToVideos(video)
         matchTwo.addToVideos(video)
 
@@ -41,13 +39,11 @@ class MatchVideoTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
-
         let model = TBAMatchVideo(key: "key", type: "youtube")
         let video = MatchVideo.insert(model, in: persistentContainer.viewContext)
 
-        let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: event.key!)
-        let match = Match.insert(matchModel, event: event, in: persistentContainer.viewContext)
+        let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: "2018miket")
+        let match = Match.insert(matchModel, in: persistentContainer.viewContext)
         match.addToVideos(video)
 
         XCTAssertEqual(video.key, "key")

--- a/the-blue-alliance-ios/Core Data/Event/Event.swift
+++ b/the-blue-alliance-ios/Core Data/Event/Event.swift
@@ -207,6 +207,21 @@ extension Event: Locatable, Managed {
     }
 
     /**
+     Insert a Match with values from a TBAKit Match model in to the managed object context.
+
+     This method will manage setting up a Match's relationship to an Event.
+
+     - Parameter match: The TBAKit Match representation to set values from.
+     */
+    func insert(_ match: TBAMatch) {
+        guard let managedObjectContext = managedObjectContext else {
+            return
+        }
+
+        addToMatches(Match.insert(match, in: managedObjectContext))
+    }
+
+    /**
      Insert Matches with values from TBAKit Match models in to the managed object context.
 
      This method will manage setting up a Match's relationship to an Event and the deletion of oprhaned Matches on the Event.
@@ -219,7 +234,7 @@ extension Event: Locatable, Managed {
         }
 
         updateToManyRelationship(relationship: #keyPath(Event.matches), newValues: matches.map({
-            return Match.insert($0, event: self, in: managedObjectContext)
+            return Match.insert($0, in: managedObjectContext)
         }))
     }
 

--- a/the-blue-alliance-ios/Core Data/MyTBA/Favorite.swift
+++ b/the-blue-alliance-ios/Core Data/MyTBA/Favorite.swift
@@ -29,9 +29,4 @@ extension Favorite: MyTBAManaged {
         return MyTBAFavorite(modelKey: modelKey!, modelType: MyTBAModelType(rawValue: modelType!)!)
     }
 
-    var isOrphaned: Bool {
-        // We manage the deletion of these root objects ourselves
-        return false
-    }
-
 }

--- a/the-blue-alliance-ios/Core Data/MyTBA/MyTBAEntity.swift
+++ b/the-blue-alliance-ios/Core Data/MyTBA/MyTBAEntity.swift
@@ -8,3 +8,12 @@ protocol MyTBAManaged: Managed {
     @discardableResult static func insert(_ model: RemoteType, in context: NSManagedObjectContext) -> MyType
     func toRemoteModel() -> RemoteType
 }
+
+extension MyTBAEntity: Managed {
+
+    var isOrphaned: Bool {
+        // We manage the deletion of these objects ourselves
+        return false
+    }
+
+}

--- a/the-blue-alliance-ios/Core Data/MyTBA/Subscription.swift
+++ b/the-blue-alliance-ios/Core Data/MyTBA/Subscription.swift
@@ -31,9 +31,4 @@ extension Subscription: MyTBAManaged {
         return MyTBASubscription(modelKey: modelKey!, modelType: MyTBAModelType(rawValue: modelType!)!, notifications: notifications!.map({ NotificationType(rawValue: $0)! }))
     }
 
-    var isOrphaned: Bool {
-        // We manage the deletion of these root objects ourselves
-        return false
-    }
-
 }

--- a/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
+++ b/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
@@ -177,7 +177,7 @@
         <attribute name="time" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="winningAlliance" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="alliances" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MatchAlliance" inverseName="match" inverseEntity="MatchAlliance" syncable="YES"/>
-        <relationship name="event" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="matches" inverseEntity="Event" syncable="YES"/>
+        <relationship name="event" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="matches" inverseEntity="Event" syncable="YES"/>
         <relationship name="videos" optional="YES" toMany="YES" deletionRule="Deny" destinationEntity="MatchVideo" inverseName="matches" inverseEntity="MatchVideo" syncable="YES"/>
     </entity>
     <entity name="MatchAlliance" representedClassName="MatchAlliance" syncable="YES" codeGenerationType="class">
@@ -269,6 +269,7 @@
         <element name="Event" positionX="-63" positionY="-18" width="128" height="630"/>
         <element name="EventAlliance" positionX="54" positionY="144" width="128" height="135"/>
         <element name="EventAllianceBackup" positionX="63" positionY="153" width="128" height="105"/>
+        <element name="EventInsights" positionX="45" positionY="135" width="128" height="90"/>
         <element name="EventKey" positionX="45" positionY="135" width="128" height="105"/>
         <element name="EventRanking" positionX="160" positionY="192" width="128" height="225"/>
         <element name="EventStatus" positionX="45" positionY="135" width="128" height="195"/>
@@ -286,6 +287,5 @@
         <element name="TeamKey" positionX="45" positionY="135" width="128" height="255"/>
         <element name="TeamMedia" positionX="-45" positionY="144" width="128" height="180"/>
         <element name="Webcast" positionX="-45" positionY="144" width="128" height="120"/>
-        <element name="EventInsights" positionX="45" positionY="135" width="128" height="90"/>
     </elements>
 </model>

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchBreakdownViewController.swift
@@ -193,7 +193,7 @@ extension MatchBreakdownViewController: Refreshable {
                 if let modelMatch = modelMatch {
                     // TODO: Match can never be deleted
                     let event = backgroundContext.object(with: self.match.event!.objectID) as! Event
-                    Match.insert(modelMatch, event: event, in: backgroundContext)
+                    event.insert(modelMatch)
 
                     if backgroundContext.saveOrRollback() {
                         TBAKit.setLastModified(for: request!)

--- a/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Match/MatchInfoViewController.swift
@@ -217,7 +217,7 @@ extension MatchInfoViewController: Refreshable {
                 if let modelMatch = modelMatch {
                     // TODO: Match can never be deleted
                     let event = backgroundContext.object(with: self.match.event!.objectID) as! Event
-                    Match.insert(modelMatch, event: event, in: backgroundContext)
+                    event.insert(modelMatch)
 
                     if backgroundContext.saveOrRollback() {
                         TBAKit.setLastModified(for: request!)


### PR DESCRIPTION
This is part of the myTBA work - when loading data from myTBA, we get keys for objects. Sometimes that's a Match key. We don't want to chain network requests together, so this allows Matches to be saved without an Event associated with them. The only difference is when loading an Event for the first time after loading myTBA, that Match won't show up in the list (we can handle this in the myTBA fetching code)