### PR TITLE
Adds some ways to test view controllers, kinda

### DIFF
--- a/tba-unit-tests/Core Data/Award/AwardRecipientTests.swift
+++ b/tba-unit-tests/Core Data/Award/AwardRecipientTests.swift
@@ -41,7 +41,7 @@ class AwardRecipientTestCase: AwardTestCase {
         // Our Award Recipient shouldn't be able to be saved without an Award Recipient
         XCTAssertThrowsError(try persistentContainer.viewContext.save())
 
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelAward = TBAAward(name: "The Fake Award",
                                   awardType: 2,
@@ -91,7 +91,7 @@ class AwardRecipientTestCase: AwardTestCase {
     }
 
     override func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelRecipient = TBAAwardRecipient(teamKey: "frc7332")
         let recipient = AwardRecipient.insert(modelRecipient, in: persistentContainer.viewContext)
@@ -126,7 +126,7 @@ class AwardRecipientTestCase: AwardTestCase {
     }
 
     func test_delete_deny() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelRecipient = TBAAwardRecipient(awardee: "Zachary Orr")
         let recipient = AwardRecipient.insert(modelRecipient, in: persistentContainer.viewContext)

--- a/tba-unit-tests/Core Data/Award/AwardTests.swift
+++ b/tba-unit-tests/Core Data/Award/AwardTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class AwardTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelAwardRecipient = TBAAwardRecipient(teamKey: "frc7332")
         let modelAward = TBAAward(name: "The Fake Award",
@@ -29,7 +29,7 @@ class AwardTestCase: CoreDataTestCase {
     }
 
     func test_insert_validate() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelAward = TBAAward(name: "The Fake Award",
                                   awardType: 2,
@@ -50,7 +50,7 @@ class AwardTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let frc1Model = TBAAwardRecipient(teamKey: "frc1")
         let frc2Model = TBAAwardRecipient(teamKey: "frc2")
@@ -112,7 +112,7 @@ class AwardTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let frc1Model = TBAAwardRecipient(teamKey: "frc1")
         let frc2Model = TBAAwardRecipient(teamKey: "frc2")

--- a/tba-unit-tests/Core Data/CoreDataTestCase.swift
+++ b/tba-unit-tests/Core Data/CoreDataTestCase.swift
@@ -16,6 +16,8 @@ class CoreDataTestCase: FBSnapshotTestCase {
         super.setUp()
 
         agnosticOptions = .OS
+        // Uncomment to record all new snapshots
+        // recordMode = true
 
         persistentContainer = NSPersistentContainer(name: "TBA", managedObjectModel: CoreDataTestCase.managedObjectModel)
 
@@ -37,7 +39,45 @@ class CoreDataTestCase: FBSnapshotTestCase {
         wait(for: [persistentContainerSetupExpectation], timeout: 10.0)
     }
 
-    func districtEvent(eventKey: String = "2018miket") -> Event {
+    func insertEvent(year: Int = 2015) -> Event {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        let model = TBAEvent(key: "\(year)qcmo",
+                             name: "FRC Festival de Robotique - Montreal Regional",
+                             eventCode: "qcmo",
+                             eventType: 0,
+                             district: nil,
+                             city: nil,
+                             stateProv: nil,
+                             country: nil,
+                             startDate: dateFormatter.date(from: "\(year)-03-18")!,
+                             endDate: dateFormatter.date(from: "\(year)-03-21")!,
+                             year: year,
+                             shortName: "Festival de Robotique - Montreal",
+                             eventTypeString: "Reginal",
+                             week: 3,
+                             address: nil,
+                             postalCode: nil,
+                             gmapsPlaceID: nil,
+                             gmapsURL: nil,
+                             lat: nil,
+                             lng: nil,
+                             locationName: nil,
+                             timezone: nil,
+                             website: nil,
+                             firstEventID: nil,
+                             firstEventCode: nil,
+                             webcasts: nil,
+                             divisionKeys: [],
+                             parentEventKey: nil,
+                             playoffType: nil,
+                             playoffTypeString: nil)
+
+        return Event.insert(model, in: persistentContainer.viewContext)
+    }
+
+    func insertDistrictEvent(eventKey: String = "2018miket") -> Event {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
 
@@ -76,7 +116,34 @@ class CoreDataTestCase: FBSnapshotTestCase {
         return Event.insert(model, in: persistentContainer.viewContext)
     }
 
-    func verifyView(_ view: UIView, identifier: String) {
+    func insertTeam() -> Team {
+        let team = TBATeam(key: "frc7332",
+                           teamNumber: 7332,
+                           nickname: "The Rawrbotz",
+                           name: "General Motors/Premier Tooling Systems/Microsoft/The Chrysler Foundation/Davison Tool & Engineering, L.L.C./The Robot Space/Michigan Department of Education/Kettering University/Taylor Steel/DXC Technology/Complete Scrap/ZF North America & Grand Blanc Community High School",
+                           city: nil,
+                           stateProv: nil,
+                           country: nil,
+                           address: nil,
+                           postalCode: nil,
+                           gmapsPlaceID: nil,
+                           gmapsURL: nil,
+                           lat: nil,
+                           lng: nil,
+                           locationName: nil,
+                           website: nil,
+                           rookieYear: 2010,
+                           motto: nil,
+                           homeChampionship: nil)
+        return Team.insert(team, in: persistentContainer.viewContext)
+    }
+
+    func insertDistrict() -> District {
+        let district = TBADistrict(abbreviation: "fim", name: "FIRST In Michigan", key: "2018fim", year: 2018)
+        return District.insert(district, in: persistentContainer.viewContext)
+    }
+
+    func verifyView(_ view: UIView, identifier: String = "") {
         FBSnapshotVerifyView(view,
                              identifier: identifier,
                              suffixes: NSOrderedSet(array: [""]))

--- a/tba-unit-tests/Core Data/District/DistrictEventPointsTests.swift
+++ b/tba-unit-tests/Core Data/District/DistrictEventPointsTests.swift
@@ -20,7 +20,7 @@ class DistrictEventPointsTestCase: CoreDataTestCase {
     }
 
     func test_insert_event() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelPointsOne = TBADistrictEventPoints(teamKey: "frc7332", eventKey: event.key!, alliancePoints: 10, awardPoints: 20, qualPoints: 30, elimPoints: 40, total: 50)
         DistrictEventPoints.insert([modelPointsOne], eventKey: event.key!, in: persistentContainer.viewContext)
@@ -60,7 +60,7 @@ class DistrictEventPointsTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         let modelEventPoints = TBADistrictEventPoints(teamKey: "frc7332", eventKey: event.key!, alliancePoints: 10, awardPoints: 20, qualPoints: 30, elimPoints: 40, total: 50)
         let modelDistrictRanking = TBADistrictRanking(teamKey: "frc7332", rank: 1, rookieBonus: 10, pointTotal: 30, eventPoints: [modelEventPoints])
         event.district!.insert([modelDistrictRanking])

--- a/tba-unit-tests/Core Data/District/DistrictRankingTests.swift
+++ b/tba-unit-tests/Core Data/District/DistrictRankingTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class DistrictRankingTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let eventPoints = TBADistrictEventPoints(teamKey: "frc7332", eventKey: event.key!, alliancePoints: 10, awardPoints: 20, qualPoints: 30, elimPoints: 40, total: 50)
         let modelDistrictRanking = TBADistrictRanking(teamKey: "frc7332", rank: 1, rookieBonus: 10, pointTotal: 30, eventPoints: [eventPoints])
@@ -23,7 +23,7 @@ class DistrictRankingTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let eventPoints = TBADistrictEventPoints(teamKey: "frc7332", eventKey: event.key!, alliancePoints: 10, awardPoints: 20, qualPoints: 30, elimPoints: 40, total: 50)
         let modelDistrictRanking = TBADistrictRanking(teamKey: "frc7332", rank: 1, rookieBonus: 10, pointTotal: 30, eventPoints: [eventPoints])
@@ -33,7 +33,7 @@ class DistrictRankingTestCase: CoreDataTestCase {
         // Attach to a District so we can save
         event.district!.addToRankings(districtRanking)
 
-        let eventNew = districtEvent(eventKey: "2018mike2")
+        let eventNew = insertDistrictEvent(eventKey: "2018mike2")
 
         let eventPointsNew = TBADistrictEventPoints(teamKey: "frc7332", eventKey: eventNew.key!, alliancePoints: 10, awardPoints: 20, qualPoints: 30, elimPoints: 40, total: 50)
         let duplicateModelDistrictRanking = TBADistrictRanking(teamKey: "frc7332", rank: 2, rookieBonus: 10, pointTotal: 40, eventPoints: [eventPointsNew])
@@ -64,7 +64,7 @@ class DistrictRankingTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         let district = event.district!
 
         let eventPoints = TBADistrictEventPoints(teamKey: "frc7332", eventKey: event.key!, alliancePoints: 10, awardPoints: 20, qualPoints: 30, elimPoints: 40, total: 50)

--- a/tba-unit-tests/Core Data/District/DistrictTests.swift
+++ b/tba-unit-tests/Core Data/District/DistrictTests.swift
@@ -126,7 +126,7 @@ class DistrictTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         let district = event.district!
 
         let ranking = DistrictRanking(entity: DistrictRanking.entity(), insertInto: persistentContainer.viewContext)

--- a/tba-unit-tests/Core Data/Event/EventAllianceBackupTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventAllianceBackupTests.swift
@@ -25,7 +25,7 @@ class EventAllianceBackupTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelBackup = TBAAllianceBackup(teamIn: "frc1", teamOut: "frc2")
         let modelAlliance = TBAAlliance(name: "Alliance 1", backup: modelBackup, declines: ["frc5"], picks: ["frc1", "frc2", "frc3"], status: nil)

--- a/tba-unit-tests/Core Data/Event/EventAllianceTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventAllianceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class EventAllianceTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let status = TBAAllianceStatus(currentRecord: nil, level: nil, playoffAverage: nil, record: nil, status: nil)
         let model = TBAAlliance(name: "Alliance 1", backup: nil, declines: ["frc5"], picks: ["frc1", "frc2", "frc3"], status: status)
@@ -29,7 +29,7 @@ class EventAllianceTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelBackup = TBAAllianceBackup(teamIn: "frc6", teamOut: "frc2")
         let modelStatus = TBAAllianceStatus(currentRecord: nil, level: nil, playoffAverage: nil, record: nil, status: nil)
@@ -65,7 +65,7 @@ class EventAllianceTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelBackup = TBAAllianceBackup(teamIn: "frc2", teamOut: "frc3")
         let modelStatus = TBAAllianceStatus(currentRecord: nil, level: nil, playoffAverage: nil, record: nil, status: nil)
@@ -96,7 +96,7 @@ class EventAllianceTestCase: CoreDataTestCase {
     }
 
     func test_delete_backup() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelBackup = TBAAllianceBackup(teamIn: "frc2", teamOut: "frc3")
 
@@ -107,7 +107,7 @@ class EventAllianceTestCase: CoreDataTestCase {
         let backup = allianceOne.backup!
 
         // Attach our Backup to another alliance, so it's not an oprhan after AllianceOne is gone
-        let eventTwo = districtEvent(eventKey: "2018mike2")
+        let eventTwo = insertDistrictEvent(eventKey: "2018mike2")
         let modelTwo = TBAAlliance(name: "Alliance 1", backup: modelBackup, declines: nil, picks: ["frc1"], status: nil)
         let allianceTwo = EventAlliance.insert(modelTwo, eventKey: eventTwo.key!, in: persistentContainer.viewContext)
         eventTwo.addToAlliances(allianceTwo)
@@ -134,7 +134,7 @@ class EventAllianceTestCase: CoreDataTestCase {
     }
 
     func test_delete_backup_status() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelBackup = TBAAllianceBackup(teamIn: "frc2", teamOut: "frc3")
 
@@ -166,7 +166,7 @@ class EventAllianceTestCase: CoreDataTestCase {
 
     func test_delete_status() {
         // Should not delete status when still attached to an Event Status
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelStatus = TBAAllianceStatus(currentRecord: nil, level: nil, playoffAverage: nil, record: nil, status: nil)
 

--- a/tba-unit-tests/Core Data/Event/EventInsightsTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventInsightsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class EventInsightsTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let model = TBAEventInsights(qual: ["abc": 2], playoff: ["def": 3])
         let insights = EventInsights.insert(model, eventKey: event.key!, in: persistentContainer.viewContext)
@@ -20,7 +20,7 @@ class EventInsightsTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelOne = TBAEventInsights(qual: ["abc": 2], playoff: ["def": 3])
         let insightsOne = EventInsights.insert(modelOne, eventKey: event.key!, in: persistentContainer.viewContext)
@@ -39,7 +39,7 @@ class EventInsightsTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let model = TBAEventInsights(qual: ["abc": 2], playoff: ["def": 3])
         let insights = EventInsights.insert(model, eventKey: event.key!, in: persistentContainer.viewContext)
@@ -56,7 +56,7 @@ class EventInsightsTestCase: CoreDataTestCase {
         let insights = EventInsights.init(entity: EventInsights.entity(), insertInto: persistentContainer.viewContext)
         XCTAssert(insights.isOrphaned)
 
-        insights.event = districtEvent()
+        insights.event = insertDistrictEvent()
         XCTAssertFalse(insights.isOrphaned)
         insights.event = nil
 

--- a/tba-unit-tests/Core Data/Event/EventKeyTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventKeyTests.swift
@@ -25,7 +25,7 @@ class EventKeyTestCase: CoreDataTestCase {
         let eventKey = EventKey.insert(withKey: "2018miket", in: persistentContainer.viewContext)
         XCTAssertNil(eventKey.event)
 
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         XCTAssertNotNil(eventKey.event)
         XCTAssertEqual(eventKey.event, event)
     }

--- a/tba-unit-tests/Core Data/Event/EventRankingTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventRankingTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class EventRankingTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let extraStatsInfo = [TBAEventRankingSortOrder(name: "Total Ranking Points", precision: 0)]
         let sortOrderInfo = [
@@ -34,7 +34,7 @@ class EventRankingTestCase: CoreDataTestCase {
     }
 
     func test_insertPredicate() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         let model = TBAEventRanking(teamKey: "frc1", rank: 2)
 
         let ranking = EventRanking.init(entity: EventRanking.entity(), insertInto: persistentContainer.viewContext)
@@ -58,7 +58,7 @@ class EventRankingTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let extraStatsInfo = [TBAEventRankingSortOrder(name: "Total Ranking Points", precision: 0)]
         let sortOrderInfo = [
@@ -92,7 +92,7 @@ class EventRankingTestCase: CoreDataTestCase {
     }
 
     func test_delete_orphan() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         let model = TBAEventRanking(teamKey: "frc1", rank: 2)
         let qualStatusModel = TBAEventStatusQual(numTeams: nil, status: nil, ranking: nil, sortOrder: nil)
 
@@ -117,7 +117,7 @@ class EventRankingTestCase: CoreDataTestCase {
     }
 
     func test_delete_qualStatus() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         let model = TBAEventRanking(teamKey: "frc1", rank: 2)
         let eventStatusModel = TBAEventStatus(teamKey: "frc1", eventKey: event.key!)
         let qualStatusModel = TBAEventStatusQual(numTeams: nil, status: nil, ranking: nil, sortOrder: nil)

--- a/tba-unit-tests/Core Data/Event/EventStatusAllianceTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventStatusAllianceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class EventStatusAllianceTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let backupModel = TBAAllianceBackup(teamIn: "frc3", teamOut: "frc2")
         let model = TBAEventStatusAlliance(number: 2, pick: 1, name: "Alliance One", backup: backupModel)
@@ -27,7 +27,7 @@ class EventStatusAllianceTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let backupModel = TBAAllianceBackup(teamIn: "frc3", teamOut: "frc2")
         let modelOne = TBAEventStatusAlliance(number: 2, pick: 1, name: "Alliance One", backup: backupModel)
@@ -59,7 +59,7 @@ class EventStatusAllianceTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let backupModel = TBAAllianceBackup(teamIn: "frc3", teamOut: "frc2")
         let model = TBAEventStatusAlliance(number: 2, pick: 1, name: "Alliance One", backup: backupModel)
@@ -75,7 +75,7 @@ class EventStatusAllianceTestCase: CoreDataTestCase {
     }
 
     func test_delete_backup() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let backupModel = TBAAllianceBackup(teamIn: "frc3", teamOut: "frc2")
         let model = TBAEventStatusAlliance(number: 2, pick: 1, name: "Alliance One", backup: backupModel)

--- a/tba-unit-tests/Core Data/Event/EventStatusPlayoffTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventStatusPlayoffTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class EventStatusPlayoffTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let model = TBAAllianceStatus(currentRecord: TBAWLT(wins: 1, losses: 2, ties: 3), level: "level", playoffAverage: 2.22, record: TBAWLT(wins: 2, losses: 2, ties: 3), status: "status")
         let status = EventStatusPlayoff.insert(model, eventKey: event.key!, teamKey: "frc1", in: persistentContainer.viewContext)
@@ -20,7 +20,7 @@ class EventStatusPlayoffTestCase: CoreDataTestCase {
     }
 
     func test_insertPredicate() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         let teamKey = "frc1"
 
         let model = TBAAllianceStatus(currentRecord: nil, level: nil, playoffAverage: nil, record: nil, status: nil)
@@ -49,7 +49,7 @@ class EventStatusPlayoffTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelAlliance = TBAAlliance(name: nil, backup: nil, declines: nil, picks: ["frc1"], status: nil)
         let alliance = EventAlliance.insert(modelAlliance, eventKey: event.key!, in: persistentContainer.viewContext)
@@ -74,7 +74,7 @@ class EventStatusPlayoffTestCase: CoreDataTestCase {
 
     // This is a good example of how we should be testing deletes
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let model = TBAAllianceStatus(currentRecord: nil, level: nil, playoffAverage: nil, record: nil, status: nil)
         let status = EventStatusPlayoff.insert(model, eventKey: event.key!, teamKey: "frc1", in: persistentContainer.viewContext)

--- a/tba-unit-tests/Core Data/Event/EventStatusQualTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventStatusQualTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class EventStatusQualTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let model = TBAEventStatusQual(numTeams: 3, status: "playing", ranking: nil, sortOrder: nil)
         let status = EventStatusQual.insert(model, eventKey: event.key!, teamKey: "frc1", in: persistentContainer.viewContext)
@@ -18,7 +18,7 @@ class EventStatusQualTestCase: CoreDataTestCase {
     }
 
     func test_insertPredicate() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         let teamKey = "frc1"
 
         let model = TBAEventStatusQual(numTeams: nil, status: nil, ranking: nil, sortOrder: nil)
@@ -45,7 +45,7 @@ class EventStatusQualTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelOne = TBAEventStatusQual(numTeams: 3, status: "playing", ranking: TBAEventRanking(teamKey: "frc1", rank: 3), sortOrder: nil)
         let statusOne = EventStatusQual.insert(modelOne, eventKey: event.key!, teamKey: "frc1", in: persistentContainer.viewContext)
@@ -71,7 +71,7 @@ class EventStatusQualTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let model = TBAEventStatusQual(numTeams: 3, status: "playing", ranking: TBAEventRanking(teamKey: "frc1", rank: 3), sortOrder: nil)
         let status = EventStatusQual.insert(model, eventKey: event.key!, teamKey: "frc1", in: persistentContainer.viewContext)

--- a/tba-unit-tests/Core Data/Event/EventStatusTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventStatusTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class EventStatusTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let qual = TBAEventStatusQual(numTeams: nil, status: nil, ranking: nil, sortOrder: nil)
         let alliance = TBAEventStatusAlliance(number: 1, pick: 1)
@@ -31,7 +31,7 @@ class EventStatusTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let qualModel = TBAEventStatusQual(numTeams: nil, status: nil, ranking: nil, sortOrder: nil)
         let allianceModel = TBAEventStatusAlliance(number: 1, pick: 1)
@@ -71,7 +71,7 @@ class EventStatusTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let qualModel = TBAEventStatusQual(numTeams: nil, status: nil, ranking: nil, sortOrder: nil)
         let allianceModel = TBAEventStatusAlliance(number: 1, pick: 1)
@@ -100,7 +100,7 @@ class EventStatusTestCase: CoreDataTestCase {
     }
 
     func test_delete_qual() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let qualModel = TBAEventStatusQual(numTeams: nil, status: nil, ranking: nil, sortOrder: nil)
 
@@ -130,7 +130,7 @@ class EventStatusTestCase: CoreDataTestCase {
     }
 
     func test_delete_playoff() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let playoffModel = TBAAllianceStatus(currentRecord: nil, level: nil, playoffAverage: nil, record: nil, status: nil)
 

--- a/tba-unit-tests/Core Data/Event/EventTeamStatsTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventTeamStatsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class EventTeamStatTestCase: CoreDataTestCase {
 
     func test_insert() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let model = TBAStat(teamKey: "frc1", ccwm: 2.2, dpr: 3.3, opr: 4.44)
         let stat = EventTeamStat.insert(model, eventKey: event.key!, in: persistentContainer.viewContext)
@@ -22,7 +22,7 @@ class EventTeamStatTestCase: CoreDataTestCase {
     }
 
     func test_update() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelOne = TBAStat(teamKey: "frc1", ccwm: 2.2, dpr: 3.3, opr: 4.44)
         let statOne = EventTeamStat.insert(modelOne, eventKey: event.key!, in: persistentContainer.viewContext)
@@ -40,7 +40,7 @@ class EventTeamStatTestCase: CoreDataTestCase {
     }
 
     func test_delete() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let model = TBAStat(teamKey: "frc1", ccwm: 2.2, dpr: 3.3, opr: 4.44)
         let stat = EventTeamStat.insert(model, eventKey: event.key!, in: persistentContainer.viewContext)
@@ -60,7 +60,7 @@ class EventTeamStatTestCase: CoreDataTestCase {
         let stat = EventTeamStat.init(entity: EventTeamStat.entity(), insertInto: persistentContainer.viewContext)
         XCTAssert(stat.isOrphaned)
 
-        stat.event = districtEvent()
+        stat.event = insertDistrictEvent()
         XCTAssertFalse(stat.isOrphaned)
         stat.event = nil
 

--- a/tba-unit-tests/Core Data/Event/EventTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventTests.swift
@@ -114,7 +114,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_alliances() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelAllianceOne = TBAAlliance(name: "Alliance 1", picks: ["frc1"])
         let modelAllianceTwo = TBAAlliance(name: "Alliance 2", picks: ["frc2"])
@@ -148,7 +148,7 @@ class EventTestCase: CoreDataTestCase {
     func test_insert_awards() {
         // Orphaned Awards and their relationships should be cleaned up
         // We're going to assume this tests `insert` and `prepareForDeletion`
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         // Insert Two Awards - one with two Award Recipients, one with one Award Recipient
         let frc1Model = TBAAwardRecipient(teamKey: "frc1")
@@ -199,7 +199,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_awards_teamKey() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let frc1Model = TBAAwardRecipient(teamKey: "frc1")
         let frc2Model = TBAAwardRecipient(teamKey: "frc2")
@@ -265,7 +265,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_insights() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelInsights = TBAEventInsights(qual: ["abc": 1], playoff: ["def": 2])
         event.insert(modelInsights)
@@ -276,7 +276,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_match() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let redAlliance = TBAMatchAlliance(score: 200, teams: ["frc7332"])
         let blueAlliance = TBAMatchAlliance(score: 300, teams: ["frc3333"])
@@ -305,7 +305,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_matches() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let redAlliance = TBAMatchAlliance(score: 200, teams: ["frc7332"])
         let blueAlliance = TBAMatchAlliance(score: 300, teams: ["frc3333"])
@@ -362,7 +362,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_rankings() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelRankingOne = TBAEventRanking(teamKey: "frc1", rank: 1)
         let modelRankingTwo = TBAEventRanking(teamKey: "frc2", rank: 2)
@@ -392,7 +392,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_stats() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelStatsOne = TBAStat(teamKey: "frc1", ccwm: 2.2, dpr: 3.3, opr: 4.4)
         let modelStatsTwo = TBAStat(teamKey: "frc2", ccwm: 2.2, dpr: 3.3, opr: 4.4)
@@ -422,7 +422,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_status() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelEventStatusOne = TBAEventStatus(teamKey: "frc1", eventKey: event.key!, qual: TBAEventStatusQual(numTeams: nil, status: nil, ranking: TBAEventRanking(teamKey: "frc1", rank: 3), sortOrder: nil), alliance: nil, playoff: nil, allianceStatusString: nil, playoffStatusString: nil, overallStatusString: nil, nextMatchKey: nil, lastMatchKey: nil)
         let modelEventStatusTwo = TBAEventStatus(teamKey: "frc2", eventKey: event.key!)
@@ -454,7 +454,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_teams() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelTeamOne = TBATeam(key: "frc1", teamNumber: 1, name: "One", rookieYear: 2000)
         let modelTeamTwo = TBATeam(key: "frc2", teamNumber: 2, name: "Two", rookieYear: 2001)
@@ -482,7 +482,7 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert_webcasts() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let modelWebcastOne = TBAWebcast(type: "twitch", channel: "firstinmichigan")
         let modelWebcastTwo = TBAWebcast(type: "twitch", channel: "firstinmichigan2")

--- a/tba-unit-tests/Core Data/Event/WebcastTests.swift
+++ b/tba-unit-tests/Core Data/Event/WebcastTests.swift
@@ -14,7 +14,7 @@ class WebcastTestCase: CoreDataTestCase {
         // Should fail - Webcasts need to be associated with at least one Event
         XCTAssertThrowsError(try persistentContainer.viewContext.save())
 
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         event.addToWebcasts(webcast)
 
         XCTAssertNoThrow(try persistentContainer.viewContext.save())
@@ -38,7 +38,7 @@ class WebcastTestCase: CoreDataTestCase {
         let model = TBAWebcast(type: "twitch", channel: "firstinmichigan")
         let webcast = Webcast.insert(model, in: persistentContainer.viewContext)
 
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         event.addToWebcasts(webcast)
 
         persistentContainer.viewContext.delete(webcast)
@@ -60,10 +60,10 @@ class WebcastTestCase: CoreDataTestCase {
         // Sanity check
         XCTAssertNotEqual(webcastOne, webcastTwo)
 
-        let eventOne = districtEvent()
+        let eventOne = insertDistrictEvent()
         eventOne.addToWebcasts(Set([webcastOne, webcastTwo]) as NSSet)
 
-        let eventTwo = districtEvent(eventKey: "2018mike2")
+        let eventTwo = insertDistrictEvent(eventKey: "2018mike2")
         eventTwo.addToWebcasts(webcastTwo)
 
         persistentContainer.viewContext.delete(eventOne)

--- a/tba-unit-tests/Core Data/Match/MatchTests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchTests.swift
@@ -53,7 +53,7 @@ class MatchTestCase: CoreDataTestCase {
         XCTAssertEqual(match.videos?.count, 1)
 
         // Ensure Match can have an Event
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         match.event = event
 
         XCTAssertEqual(match.event, event)

--- a/tba-unit-tests/Core Data/Team/TeamTests.swift
+++ b/tba-unit-tests/Core Data/Team/TeamTests.swift
@@ -183,7 +183,7 @@ class TeamTestCase: CoreDataTestCase {
         let teamModel = TBATeam(key: "frc7332", teamNumber: 7332, name: "The Rawrbotz", rookieYear: 2010)
         let team = Team.insert(teamModel, in: persistentContainer.viewContext)
 
-        let event = districtEvent()
+        let event = insertDistrictEvent()
         team.addToEvents(event)
 
         let mediaModel = TBAMedia(key: "key", type: "youtube", foreignKey: nil, details: nil, preferred: nil)

--- a/tba-unit-tests/Core Data/myTBA/MyTBAEntityTests.swift
+++ b/tba-unit-tests/Core Data/myTBA/MyTBAEntityTests.swift
@@ -65,7 +65,7 @@ class MyTBAEntityTestCase: CoreDataTestCase {
     }
 
     func test_prepareForDeletion_match_event() {
-        let event = districtEvent()
+        let event = insertDistrictEvent()
 
         let redAlliance = TBAMatchAlliance(score: 200, teams: ["frc7332"])
         let blueAlliance = TBAMatchAlliance(score: 300, teams: ["frc3333"])

--- a/tba-unit-tests/Mocks/MockNavigationController.swift
+++ b/tba-unit-tests/Mocks/MockNavigationController.swift
@@ -4,19 +4,29 @@ import UIKit
 class MockNavigationController: UINavigationController {
 
     var presentCalled: ((UIViewController) -> ())?
-    var showDetailViewControllerCalled: ((UIViewController) -> ())?
+
+    var detailViewController: UIViewController?
+    var pushedViewController: UIViewController?
 
     var dismissExpectation: XCTestExpectation?
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
         presentCalled?(viewControllerToPresent)
     }
 
     override func showDetailViewController(_ vc: UIViewController, sender: Any?) {
-        showDetailViewControllerCalled?(vc)
+        detailViewController = vc
+    }
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        pushedViewController = viewController
+        super.pushViewController(viewController, animated: animated)
     }
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: completion)
         dismissExpectation?.fulfill()
     }
+
 }

--- a/tba-unit-tests/TBATestCase.swift
+++ b/tba-unit-tests/TBATestCase.swift
@@ -33,6 +33,25 @@ class TBATestCase: CoreDataTestCase {
 
 }
 
+class TBAViewControllerTester {
+
+    let viewController: UIViewController
+
+    init(withViewController viewController: UIViewController) {
+        self.viewController = viewController
+
+        _ = viewController.view
+
+        viewController.viewWillAppear(false)
+        viewController.viewDidAppear(false)
+    }
+
+    deinit {
+        viewController.viewWillDisappear(false)
+        viewController.viewDidDisappear(false)
+    }
+}
+
 class MockRemoteConfig: RemoteConfig {
 
     let config: [String: NSObject]?

--- a/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import The_Blue_Alliance
+
+class DistrictViewControllerTests: TBATestCase {
+
+    var district: District {
+        return districtViewController.district
+    }
+
+    var districtViewController: DistrictViewController!
+    var navigationController: MockNavigationController!
+
+    var viewControllerTester: TBAViewControllerTester!
+
+    override func setUp() {
+        super.setUp()
+
+        let district = insertDistrict()
+
+        districtViewController = DistrictViewController(district: district,
+                                                        urlOpener: urlOpener,
+                                                        userDefaults: userDefaults,
+                                                        persistentContainer: persistentContainer,
+                                                        tbaKit: tbaKit)
+        navigationController = MockNavigationController(rootViewController: districtViewController)
+
+        viewControllerTester = TBAViewControllerTester(withViewController: districtViewController)
+    }
+
+    override func tearDown() {
+        districtViewController = nil
+        navigationController = nil
+        viewControllerTester = nil
+
+        super.tearDown()
+    }
+
+    private func insertDistrictEvents(district: District) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        let eventOne = TBAEvent(key: "2018miket",
+                                name: "FIM District Kettering University Event #1",
+                                eventCode: "miket",
+                                eventType: 1,
+                                district: nil,
+                                city: nil,
+                                stateProv: nil,
+                                country: nil,
+                                startDate: dateFormatter.date(from: "2018-03-01")!,
+                                endDate: dateFormatter.date(from: "2018-03-03")!,
+                                year: 2018,
+                                shortName: "Kettering University #1",
+                                eventTypeString: "District",
+                                week: 0,
+                                address: nil,
+                                postalCode: nil,
+                                gmapsPlaceID: nil,
+                                gmapsURL: nil,
+                                lat: nil,
+                                lng: nil,
+                                locationName: nil,
+                                timezone: nil,
+                                website: nil,
+                                firstEventID: nil,
+                                firstEventCode: nil,
+                                webcasts: nil,
+                                divisionKeys: [],
+                                parentEventKey: nil,
+                                playoffType: nil,
+                                playoffTypeString: nil)
+
+        let eventTwo = TBAEvent(key: "2018mike2",
+                                name: "FIM District Kettering University Event #2",
+                                eventCode: "mike2",
+                                eventType: 1,
+                                district: nil,
+                                city: nil,
+                                stateProv: nil,
+                                country: nil,
+                                startDate: dateFormatter.date(from: "2018-03-08")!,
+                                endDate: dateFormatter.date(from: "2018-03-10")!,
+                                year: 2018,
+                                shortName: "Kettering University #2",
+                                eventTypeString: "District",
+                                week: 0,
+                                address: nil,
+                                postalCode: nil,
+                                gmapsPlaceID: nil,
+                                gmapsURL: nil,
+                                lat: nil,
+                                lng: nil,
+                                locationName: nil,
+                                timezone: nil,
+                                website: nil,
+                                firstEventID: nil,
+                                firstEventCode: nil,
+                                webcasts: nil,
+                                divisionKeys: [],
+                                parentEventKey: nil,
+                                playoffType: nil,
+                                playoffTypeString: nil)
+
+        district.insert([eventOne, eventTwo])
+    }
+
+    private func insertDistrictRankings(district: District) {
+        let rankingOne = TBADistrictRanking(teamKey: "frc7332", rank: 1, pointTotal: 209, eventPoints: [])
+        let rankingTwo = TBADistrictRanking(teamKey: "frc1", rank: 2, pointTotal: 32, eventPoints: [])
+
+        district.insert([rankingOne, rankingTwo])
+    }
+
+    func test_delegates() {
+        XCTAssertNotNil(districtViewController.eventsViewController.delegate)
+        XCTAssertNotNil(districtViewController.rankingsViewController.delegate)
+    }
+
+    func test_title() {
+        XCTAssertEqual(districtViewController.title, "2018 FIRST In Michigan Districts")
+    }
+
+    func test_showsEvents() {
+        XCTAssert(districtViewController.children.contains(where: { (viewController) -> Bool in
+            return viewController is DistrictEventsViewController
+        }))
+    }
+
+    func test_showsRankings() {
+        XCTAssert(districtViewController.children.contains(where: { (viewController) -> Bool in
+            return viewController is DistrictRankingsViewController
+        }))
+    }
+
+    func test_evets_pushesEvent() {
+        insertDistrictEvents(district: district)
+
+        let event = district.events!.anyObject() as! Event
+        districtViewController.eventSelected(event)
+
+        XCTAssert(navigationController.pushedViewController is EventViewController)
+        let eventViewController = navigationController.pushedViewController as! EventViewController
+        XCTAssertEqual(eventViewController.event, event)
+    }
+
+    func test_events_eventWeekTitle() {
+        insertDistrictEvents(district: district)
+
+        let event = (district.events!.allObjects as! [Event]).first(where: { $0.week == 0 })!
+        XCTAssertEqual(districtViewController.title(for: event), "Week 1 Events")
+    }
+
+    func test_rankings_pushesRanking() {
+        insertDistrictRankings(district: district)
+
+        let ranking = district.rankings!.anyObject() as! DistrictRanking
+        districtViewController.districtRankingSelected(ranking)
+
+        XCTAssert(navigationController.pushedViewController is TeamAtDistrictViewController)
+        let teamAtDistrictViewController = navigationController.pushedViewController as! TeamAtDistrictViewController
+        XCTAssertEqual(teamAtDistrictViewController.ranking, ranking)
+    }
+
+}

--- a/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
@@ -1,10 +1,12 @@
 import XCTest
 @testable import The_Blue_Alliance
 
-class TeamsContainerViewController_TestCase: TBATestCase {
+class TeamsContainerViewControllerTests: TBATestCase {
 
     var teamsContainerViewController: TeamsContainerViewController!
     var navigationController: MockNavigationController!
+
+    var viewControllerTester: TBAViewControllerTester!
 
     override func setUp() {
         super.setUp()
@@ -15,12 +17,13 @@ class TeamsContainerViewController_TestCase: TBATestCase {
                                                                     tbaKit: tbaKit)
         navigationController = MockNavigationController(rootViewController: teamsContainerViewController)
 
-        teamsContainerViewController.viewDidLoad()
+        viewControllerTester = TBAViewControllerTester(withViewController: teamsContainerViewController)
     }
 
     override func tearDown() {
         teamsContainerViewController = nil
         navigationController = nil
+        viewControllerTester = nil
 
         super.tearDown()
     }
@@ -43,30 +46,16 @@ class TeamsContainerViewController_TestCase: TBATestCase {
         }))
     }
 
-    func test_pushTeam() {
-        let team = insertTestTeam()
+    func test_teams_pushTeam() {
+        let team = insertTeam()
 
-        let showDetailViewControllerExpectation = XCTestExpectation(description: "showDetailViewController called")
-        navigationController.showDetailViewControllerCalled = { (vc) in
-            XCTAssert(vc is UINavigationController)
-            let nav = vc as! UINavigationController
-            XCTAssert(nav.viewControllers.first is TeamViewController)
-
-            showDetailViewControllerExpectation.fulfill()
-        }
         teamsContainerViewController.teamSelected(team)
 
-        wait(for: [showDetailViewControllerExpectation], timeout: 1.0)
-    }
-
-    func insertTestTeam() -> Team {
-        // Required: key, name, teamNumber, rookieYear
-        let team = Team.init(entity: Team.entity(), insertInto: persistentContainer.viewContext)
-        team.key = "frc2337"
-        team.name = "General Motors/Premier Tooling Systems/Microsoft/The Chrysler Foundation/Davison Tool & Engineering, L.L.C./The Robot Space/Michigan Department of Education/Kettering University/Taylor Steel/DXC Technology/Complete Scrap/ZF North America & Grand Blanc Community High School"
-        team.teamNumber = 2337
-        team.rookieYear = 2008
-        return team
+        XCTAssert(navigationController.detailViewController is UINavigationController)
+        let nav = navigationController.detailViewController as! UINavigationController
+        XCTAssert(nav.viewControllers.first is TeamViewController)
+        let teamViewController = nav.viewControllers.first as! TeamViewController
+        XCTAssertEqual(teamViewController.team, team)
     }
 
 }

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -54,11 +54,11 @@
 		9221C618209BFF8700477DE2 /* LoadingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9221C617209BFF8700477DE2 /* LoadingTableViewCell.xib */; };
 		9223AC831EE7003C00F54F93 /* CollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */; };
 		9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */; };
+		92269EE1219B9CF300FAA610 /* DistrictViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92269EE0219B9CF300FAA610 /* DistrictViewControllerTests.swift */; };
 		922E9080217BD18400E81447 /* TeamKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922E907F217BD18400E81447 /* TeamKeyTests.swift */; };
 		9236101F2178245C000CC5E9 /* TeamMediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236101E2178245C000CC5E9 /* TeamMediaTests.swift */; };
 		9236102521798655000CC5E9 /* MatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236102421798655000CC5E9 /* MatchTests.swift */; };
 		92361028217D1175000CC5E9 /* AwardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92361027217D1175000CC5E9 /* AwardTests.swift */; };
-		923AEE87216583CA00EF50C8 /* Bundle+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE86216583CA00EF50C8 /* Bundle+Version.swift */; };
 		923AEE8A21658BC400EF50C8 /* Launch_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE8921658BC400EF50C8 /* Launch_UITests.swift */; };
 		923AEE8C21658C5800EF50C8 /* Bundle+Version_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE8B21658C5800EF50C8 /* Bundle+Version_Tests.swift */; };
 		923AEE99216703CB00EF50C8 /* MyTBA_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AEE98216703CB00EF50C8 /* MyTBA_Tests.swift */; };
@@ -69,10 +69,7 @@
 		924602A41ECD27CE0030EDBF /* EventAwardsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924602A31ECD27CE0030EDBF /* EventAwardsViewController.swift */; };
 		924602AB1ECE8B1D0030EDBF /* AwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924602AA1ECE8B1D0030EDBF /* AwardTableViewCell.swift */; };
 		924602AF1ECE8B580030EDBF /* AwardTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 924602AE1ECE8B580030EDBF /* AwardTableViewCell.xib */; };
-		924602B71ECE99F50030EDBF /* String+Prefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924602B61ECE99F50030EDBF /* String+Prefix.swift */; };
-		9249206F20BB0455001CAC5E /* Date+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9249206E20BB0455001CAC5E /* Date+TBA.swift */; };
 		924AFD792171AB1A00D7BE7E /* NoDataView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 924AFD782171AB1A00D7BE7E /* NoDataView.xib */; };
-		924C0E9020BA18C5009066ED /* Int16+Suffix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924C0E8F20BA18C5009066ED /* Int16+Suffix.swift */; };
 		925471F7208CC6F100AD3204 /* EventAllianceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925471F6208CC6F100AD3204 /* EventAllianceTableViewCell.swift */; };
 		925471F9208CC73F00AD3204 /* EventAllianceTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 925471F8208CC73F00AD3204 /* EventAllianceTableViewCell.xib */; };
 		9255EB6D209AC9760006A745 /* RetryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9255EB6C209AC9760006A745 /* RetryService.swift */; };
@@ -85,7 +82,6 @@
 		925908AB21828CC400D7BFCE /* WebcastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908AA21828CC300D7BFCE /* WebcastTests.swift */; };
 		925908AD2184CFA900D7BFCE /* EventAllianceBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908AC2184CFA900D7BFCE /* EventAllianceBackup.swift */; };
 		925908AF2184D32400D7BFCE /* EventStatusPlayoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908AE2184D32400D7BFCE /* EventStatusPlayoff.swift */; };
-		925908B12184F7F900D7BFCE /* NSSet+Only.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908B02184F7F900D7BFCE /* NSSet+Only.swift */; };
 		925908B32184F86700D7BFCE /* NSSet+OnlyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908B22184F86700D7BFCE /* NSSet+OnlyTests.swift */; };
 		925908B52185076100D7BFCE /* EventAllianceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908B42185076100D7BFCE /* EventAllianceTests.swift */; };
 		925908B721863C3E00D7BFCE /* EventAllianceBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908B621863C3E00D7BFCE /* EventAllianceBackupTests.swift */; };
@@ -107,7 +103,6 @@
 		92858F2D208D783E00811614 /* EventTeamStatTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92858F2C208D783E00811614 /* EventTeamStatTableViewCell.swift */; };
 		9287013C20CD70CF0077D6DA /* RemoteConfigService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9287013B20CD70CF0077D6DA /* RemoteConfigService.swift */; };
 		9287013E20CD72EC0077D6DA /* RemoteConfigDefaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9287013D20CD72EC0077D6DA /* RemoteConfigDefaults.plist */; };
-		9287014020CD7C790077D6DA /* RemoteConfig+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9287013F20CD7C790077D6DA /* RemoteConfig+TBA.swift */; };
 		9287014220CD7CCB0077D6DA /* RemoteConfig+TBA_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9287014120CD7CCB0077D6DA /* RemoteConfig+TBA_Tests.swift */; };
 		9287014620CD8C0B0077D6DA /* PersistentContainerOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9287014420CD8C070077D6DA /* PersistentContainerOperation.swift */; };
 		9287014820CD8C4A0077D6DA /* TBAOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9287014720CD8C4A0077D6DA /* TBAOperation.swift */; };
@@ -120,15 +115,13 @@
 		92942DB11E215B06008E79CA /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92942DB01E215B06008E79CA /* EventsViewController.swift */; };
 		92942DBB1E215B8D008E79CA /* MyTBAViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92942DBA1E215B8D008E79CA /* MyTBAViewController.swift */; };
 		92942DDF1E21D2EB008E79CA /* EventViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92942DDE1E21D2EB008E79CA /* EventViewController.swift */; };
-		92942E331E2303A5008E79CA /* Calendar+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92942E321E2303A5008E79CA /* Calendar+TBA.swift */; };
 		92942E361E2A81E8008E79CA /* EventInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92942E351E2A81E8008E79CA /* EventInfoViewController.swift */; };
-		929820CD216966890080C1C8 /* EventsContainerViewController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929820CC216966890080C1C8 /* EventsContainerViewController_Tests.swift */; };
+		929820CD216966890080C1C8 /* EventsContainerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929820CC216966890080C1C8 /* EventsContainerViewControllerTests.swift */; };
 		929820CF216968020080C1C8 /* TBATestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929820CE216968020080C1C8 /* TBATestCase.swift */; };
 		929BBB051EC55742006D3854 /* InfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929BBB041EC55742006D3854 /* InfoTableViewCell.swift */; };
 		929BBB081EC55A22006D3854 /* InfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 929BBB071EC55A22006D3854 /* InfoTableViewCell.xib */; };
 		929DB38C2095640000FB575F /* ReverseSubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DB38B2095640000FB575F /* ReverseSubtitleTableViewCell.swift */; };
 		929DB38E2095640C00FB575F /* ReverseSubtitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 929DB38D2095640C00FB575F /* ReverseSubtitleTableViewCell.xib */; };
-		929F571A2092AAF000E5313A /* URL+Reachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929F57192092AAF000E5313A /* URL+Reachable.swift */; };
 		929F571C2092B77300E5313A /* TBATableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929F571B2092B77300E5313A /* TBATableViewController.swift */; };
 		929F571E2092B7A400E5313A /* TBACollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929F571D2092B7A400E5313A /* TBACollectionViewController.swift */; };
 		929F57202092B7D400E5313A /* TBAViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929F571F2092B7D400E5313A /* TBAViewController.swift */; };
@@ -225,6 +218,17 @@
 		92A5E5A921A1B7830025CC85 /* teams_2017_0.json in Resources */ = {isa = PBXBuildFile; fileRef = 92A5E56621A1B7830025CC85 /* teams_2017_0.json */; };
 		92A5E5AA21A1B7830025CC85 /* TBADistrictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E56721A1B7830025CC85 /* TBADistrictTests.swift */; };
 		92A5E5AB21A1B7830025CC85 /* TBAEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E56821A1B7830025CC85 /* TBAEventTests.swift */; };
+		92A5E5D321A22D550025CC85 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5C821A22D550025CC85 /* UIApplication+URLOpener.swift */; };
+		92A5E5D421A22D550025CC85 /* Bundle+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5C921A22D550025CC85 /* Bundle+Version.swift */; };
+		92A5E5D521A22D550025CC85 /* Calendar+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5CA21A22D550025CC85 /* Calendar+TBA.swift */; };
+		92A5E5D621A22D550025CC85 /* NSSet+Only.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5CB21A22D550025CC85 /* NSSet+Only.swift */; };
+		92A5E5D721A22D550025CC85 /* Date+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5CC21A22D550025CC85 /* Date+TBA.swift */; };
+		92A5E5D821A22D550025CC85 /* RemoteConfig+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5CD21A22D550025CC85 /* RemoteConfig+TBA.swift */; };
+		92A5E5D921A22D550025CC85 /* String+Prefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5CE21A22D550025CC85 /* String+Prefix.swift */; };
+		92A5E5DA21A22D550025CC85 /* UIColor+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5CF21A22D550025CC85 /* UIColor+TBA.swift */; };
+		92A5E5DB21A22D550025CC85 /* UINavigationController+SplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5D021A22D550025CC85 /* UINavigationController+SplitView.swift */; };
+		92A5E5DC21A22D550025CC85 /* URL+Reachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5D121A22D550025CC85 /* URL+Reachable.swift */; };
+		92A5E5DD21A22D550025CC85 /* Int16+Suffix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5D221A22D550025CC85 /* Int16+Suffix.swift */; };
 		92AF4D0C1E330790007E967D /* SelectTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AF4D0B1E330790007E967D /* SelectTableViewController.swift */; };
 		92B076F120FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B076F020FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift */; };
 		92B076F320FF948D00F9B2D7 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B076F220FF948D00F9B2D7 /* TestAppDelegate.swift */; };
@@ -249,11 +253,10 @@
 		92BB8B5C214F12440035AF28 /* TBAUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BB8B5B214F12440035AF28 /* TBAUITestCase.swift */; };
 		92BB8B62214F16710035AF28 /* SettingsViewController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BB8B61214F16710035AF28 /* SettingsViewController_Tests.swift */; };
 		92BB8B64214F17440035AF28 /* URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BB8B63214F17440035AF28 /* URLOpener.swift */; };
-		92BB8B66214F177B0035AF28 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BB8B65214F177B0035AF28 /* UIApplication+URLOpener.swift */; };
 		92C1F2DE216994CF00BD8445 /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2DD216994CF00BD8445 /* CoreDataTestCase.swift */; };
 		92C1F2E02169A3B800BD8445 /* MockNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2DF2169A3B800BD8445 /* MockNavigationController.swift */; };
-		92C1F2E42169AA7200BD8445 /* TeamsContainerViewController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2E32169AA7200BD8445 /* TeamsContainerViewController_Tests.swift */; };
-		92C1F2E62169AB9F00BD8445 /* DistrictsContainerViewController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2E52169AB9F00BD8445 /* DistrictsContainerViewController_Tests.swift */; };
+		92C1F2E42169AA7200BD8445 /* TeamsContainerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2E32169AA7200BD8445 /* TeamsContainerViewControllerTests.swift */; };
+		92C1F2E62169AB9F00BD8445 /* DistrictsContainerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C1F2E52169AB9F00BD8445 /* DistrictsContainerViewControllerTests.swift */; };
 		92C2E937217B907900004B9E /* MatchAllianceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C2E936217B907900004B9E /* MatchAllianceTests.swift */; };
 		92C2E939217B92C500004B9E /* MatchVideoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C2E938217B92C500004B9E /* MatchVideoTests.swift */; };
 		92C9BD352096907E007FB9C8 /* Stateful.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BD342096907E007FB9C8 /* Stateful.swift */; };
@@ -302,7 +305,6 @@
 		92FE68BB20D8A1E8004A1481 /* MyTBASignOutOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FE68BA20D8A1E8004A1481 /* MyTBASignOutOperation.swift */; };
 		92FFE5251E7C994B0037E48C /* EventTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 92FFE5241E7C994B0037E48C /* EventTableViewCell.xib */; };
 		92FFE5271E7C9A1F0037E48C /* EventTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FFE5261E7C9A1F0037E48C /* EventTableViewCell.swift */; };
-		92FFE52C1E7CC60F0037E48C /* UIColor+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FFE52B1E7CC60F0037E48C /* UIColor+TBA.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -371,11 +373,11 @@
 		9221C617209BFF8700477DE2 /* LoadingTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoadingTableViewCell.xib; sourceTree = "<group>"; };
 		9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSource.swift; sourceTree = "<group>"; };
 		9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaCollectionViewCell.swift; sourceTree = "<group>"; };
+		92269EE0219B9CF300FAA610 /* DistrictViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistrictViewControllerTests.swift; sourceTree = "<group>"; };
 		922E907F217BD18400E81447 /* TeamKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamKeyTests.swift; sourceTree = "<group>"; };
 		9236101E2178245C000CC5E9 /* TeamMediaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMediaTests.swift; sourceTree = "<group>"; };
 		9236102421798655000CC5E9 /* MatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchTests.swift; sourceTree = "<group>"; };
 		92361027217D1175000CC5E9 /* AwardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwardTests.swift; sourceTree = "<group>"; };
-		923AEE86216583CA00EF50C8 /* Bundle+Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Bundle+Version.swift"; path = "Extensions/Bundle+Version.swift"; sourceTree = "<group>"; };
 		923AEE8921658BC400EF50C8 /* Launch_UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Launch_UITests.swift; sourceTree = "<group>"; };
 		923AEE8B21658C5800EF50C8 /* Bundle+Version_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Version_Tests.swift"; sourceTree = "<group>"; };
 		923AEE98216703CB00EF50C8 /* MyTBA_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBA_Tests.swift; sourceTree = "<group>"; };
@@ -386,10 +388,7 @@
 		924602A31ECD27CE0030EDBF /* EventAwardsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventAwardsViewController.swift; sourceTree = "<group>"; };
 		924602AA1ECE8B1D0030EDBF /* AwardTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AwardTableViewCell.swift; sourceTree = "<group>"; };
 		924602AE1ECE8B580030EDBF /* AwardTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AwardTableViewCell.xib; sourceTree = "<group>"; };
-		924602B61ECE99F50030EDBF /* String+Prefix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "String+Prefix.swift"; path = "Extensions/String+Prefix.swift"; sourceTree = "<group>"; };
-		9249206E20BB0455001CAC5E /* Date+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Date+TBA.swift"; path = "Extensions/Date+TBA.swift"; sourceTree = "<group>"; };
 		924AFD782171AB1A00D7BE7E /* NoDataView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoDataView.xib; sourceTree = "<group>"; };
-		924C0E8F20BA18C5009066ED /* Int16+Suffix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Int16+Suffix.swift"; path = "Extensions/Int16+Suffix.swift"; sourceTree = "<group>"; };
 		925471F6208CC6F100AD3204 /* EventAllianceTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAllianceTableViewCell.swift; sourceTree = "<group>"; };
 		925471F8208CC73F00AD3204 /* EventAllianceTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EventAllianceTableViewCell.xib; sourceTree = "<group>"; };
 		9255EB6C209AC9760006A745 /* RetryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryService.swift; sourceTree = "<group>"; };
@@ -402,7 +401,6 @@
 		925908AA21828CC300D7BFCE /* WebcastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcastTests.swift; sourceTree = "<group>"; };
 		925908AC2184CFA900D7BFCE /* EventAllianceBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAllianceBackup.swift; sourceTree = "<group>"; };
 		925908AE2184D32400D7BFCE /* EventStatusPlayoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventStatusPlayoff.swift; sourceTree = "<group>"; };
-		925908B02184F7F900D7BFCE /* NSSet+Only.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSSet+Only.swift"; path = "Extensions/NSSet+Only.swift"; sourceTree = "<group>"; };
 		925908B22184F86700D7BFCE /* NSSet+OnlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSSet+OnlyTests.swift"; sourceTree = "<group>"; };
 		925908B42185076100D7BFCE /* EventAllianceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAllianceTests.swift; sourceTree = "<group>"; };
 		925908B621863C3E00D7BFCE /* EventAllianceBackupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAllianceBackupTests.swift; sourceTree = "<group>"; };
@@ -424,7 +422,6 @@
 		92858F2C208D783E00811614 /* EventTeamStatTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTeamStatTableViewCell.swift; sourceTree = "<group>"; };
 		9287013B20CD70CF0077D6DA /* RemoteConfigService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigService.swift; sourceTree = "<group>"; };
 		9287013D20CD72EC0077D6DA /* RemoteConfigDefaults.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = RemoteConfigDefaults.plist; sourceTree = "<group>"; };
-		9287013F20CD7C790077D6DA /* RemoteConfig+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "RemoteConfig+TBA.swift"; path = "Extensions/RemoteConfig+TBA.swift"; sourceTree = "<group>"; };
 		9287014120CD7CCB0077D6DA /* RemoteConfig+TBA_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteConfig+TBA_Tests.swift"; sourceTree = "<group>"; };
 		9287014420CD8C070077D6DA /* PersistentContainerOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentContainerOperation.swift; sourceTree = "<group>"; };
 		9287014720CD8C4A0077D6DA /* TBAOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBAOperation.swift; sourceTree = "<group>"; };
@@ -439,15 +436,13 @@
 		92942DB01E215B06008E79CA /* EventsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
 		92942DBA1E215B8D008E79CA /* MyTBAViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyTBAViewController.swift; sourceTree = "<group>"; };
 		92942DDE1E21D2EB008E79CA /* EventViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventViewController.swift; sourceTree = "<group>"; };
-		92942E321E2303A5008E79CA /* Calendar+TBA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Calendar+TBA.swift"; path = "Extensions/Calendar+TBA.swift"; sourceTree = "<group>"; };
 		92942E351E2A81E8008E79CA /* EventInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventInfoViewController.swift; sourceTree = "<group>"; };
-		929820CC216966890080C1C8 /* EventsContainerViewController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsContainerViewController_Tests.swift; sourceTree = "<group>"; };
+		929820CC216966890080C1C8 /* EventsContainerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsContainerViewControllerTests.swift; sourceTree = "<group>"; };
 		929820CE216968020080C1C8 /* TBATestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBATestCase.swift; sourceTree = "<group>"; };
 		929BBB041EC55742006D3854 /* InfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoTableViewCell.swift; sourceTree = "<group>"; };
 		929BBB071EC55A22006D3854 /* InfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InfoTableViewCell.xib; sourceTree = "<group>"; };
 		929DB38B2095640000FB575F /* ReverseSubtitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseSubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		929DB38D2095640C00FB575F /* ReverseSubtitleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReverseSubtitleTableViewCell.xib; sourceTree = "<group>"; };
-		929F57192092AAF000E5313A /* URL+Reachable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "URL+Reachable.swift"; path = "Extensions/URL+Reachable.swift"; sourceTree = "<group>"; };
 		929F571B2092B77300E5313A /* TBATableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBATableViewController.swift; sourceTree = "<group>"; };
 		929F571D2092B7A400E5313A /* TBACollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBACollectionViewController.swift; sourceTree = "<group>"; };
 		929F571F2092B7D400E5313A /* TBAViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBAViewController.swift; sourceTree = "<group>"; };
@@ -546,6 +541,17 @@
 		92A5E56621A1B7830025CC85 /* teams_2017_0.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = teams_2017_0.json; sourceTree = "<group>"; };
 		92A5E56721A1B7830025CC85 /* TBADistrictTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TBADistrictTests.swift; sourceTree = "<group>"; };
 		92A5E56821A1B7830025CC85 /* TBAEventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TBAEventTests.swift; sourceTree = "<group>"; };
+		92A5E5C821A22D550025CC85 /* UIApplication+URLOpener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+URLOpener.swift"; sourceTree = "<group>"; };
+		92A5E5C921A22D550025CC85 /* Bundle+Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Version.swift"; sourceTree = "<group>"; };
+		92A5E5CA21A22D550025CC85 /* Calendar+TBA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Calendar+TBA.swift"; sourceTree = "<group>"; };
+		92A5E5CB21A22D550025CC85 /* NSSet+Only.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSSet+Only.swift"; sourceTree = "<group>"; };
+		92A5E5CC21A22D550025CC85 /* Date+TBA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+TBA.swift"; sourceTree = "<group>"; };
+		92A5E5CD21A22D550025CC85 /* RemoteConfig+TBA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RemoteConfig+TBA.swift"; sourceTree = "<group>"; };
+		92A5E5CE21A22D550025CC85 /* String+Prefix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Prefix.swift"; sourceTree = "<group>"; };
+		92A5E5CF21A22D550025CC85 /* UIColor+TBA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+TBA.swift"; sourceTree = "<group>"; };
+		92A5E5D021A22D550025CC85 /* UINavigationController+SplitView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+SplitView.swift"; sourceTree = "<group>"; };
+		92A5E5D121A22D550025CC85 /* URL+Reachable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+Reachable.swift"; sourceTree = "<group>"; };
+		92A5E5D221A22D550025CC85 /* Int16+Suffix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int16+Suffix.swift"; sourceTree = "<group>"; };
 		92AF4D0B1E330790007E967D /* SelectTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectTableViewController.swift; sourceTree = "<group>"; };
 		92B076F020FF8E8400F9B2D7 /* MyTBASignOutOperation_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBASignOutOperation_Tests.swift; sourceTree = "<group>"; };
 		92B076F220FF948D00F9B2D7 /* TestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
@@ -570,11 +576,10 @@
 		92BB8B5B214F12440035AF28 /* TBAUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBAUITestCase.swift; sourceTree = "<group>"; };
 		92BB8B61214F16710035AF28 /* SettingsViewController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController_Tests.swift; sourceTree = "<group>"; };
 		92BB8B63214F17440035AF28 /* URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLOpener.swift; sourceTree = "<group>"; };
-		92BB8B65214F177B0035AF28 /* UIApplication+URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIApplication+URLOpener.swift"; path = "Extensions/UIApplication+URLOpener.swift"; sourceTree = "<group>"; };
 		92C1F2DD216994CF00BD8445 /* CoreDataTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CoreDataTestCase.swift; path = "tba-unit-tests/Core Data/CoreDataTestCase.swift"; sourceTree = SOURCE_ROOT; };
 		92C1F2DF2169A3B800BD8445 /* MockNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationController.swift; sourceTree = "<group>"; };
-		92C1F2E32169AA7200BD8445 /* TeamsContainerViewController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamsContainerViewController_Tests.swift; sourceTree = "<group>"; };
-		92C1F2E52169AB9F00BD8445 /* DistrictsContainerViewController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistrictsContainerViewController_Tests.swift; sourceTree = "<group>"; };
+		92C1F2E32169AA7200BD8445 /* TeamsContainerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamsContainerViewControllerTests.swift; sourceTree = "<group>"; };
+		92C1F2E52169AB9F00BD8445 /* DistrictsContainerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistrictsContainerViewControllerTests.swift; sourceTree = "<group>"; };
 		92C2E936217B907900004B9E /* MatchAllianceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchAllianceTests.swift; sourceTree = "<group>"; };
 		92C2E938217B92C500004B9E /* MatchVideoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchVideoTests.swift; sourceTree = "<group>"; };
 		92C9BD342096907E007FB9C8 /* Stateful.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stateful.swift; sourceTree = "<group>"; };
@@ -626,7 +631,6 @@
 		92FE68BA20D8A1E8004A1481 /* MyTBASignOutOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBASignOutOperation.swift; sourceTree = "<group>"; };
 		92FFE5241E7C994B0037E48C /* EventTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EventTableViewCell.xib; sourceTree = "<group>"; };
 		92FFE5261E7C9A1F0037E48C /* EventTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTableViewCell.swift; sourceTree = "<group>"; };
-		92FFE52B1E7CC60F0037E48C /* UIColor+TBA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIColor+TBA.swift"; path = "Extensions/UIColor+TBA.swift"; sourceTree = "<group>"; };
 		A27CA53562D2F2F05B05659A /* Pods-The Blue Alliance.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-The Blue Alliance.debug.xcconfig"; path = "Pods/Target Support Files/Pods-The Blue Alliance/Pods-The Blue Alliance.debug.xcconfig"; sourceTree = "<group>"; };
 		AC390655114E5828E3FE13D0 /* Pods-tba-unit-tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tba-unit-tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-tba-unit-tests/Pods-tba-unit-tests.debug.xcconfig"; sourceTree = "<group>"; };
 		C1B2EE8B87E56B5D1B50E096 /* Pods-tba-ui-tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tba-ui-tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-tba-ui-tests/Pods-tba-ui-tests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1010,7 +1014,7 @@
 				9287014320CD8BF60077D6DA /* Operations */,
 				92F8E354209AAE400094213F /* Services */,
 				92EA0CEF1E2C296300C12A4C /* Protocols */,
-				92942E341E2303AB008E79CA /* Extensions */,
+				92A5E5C721A22D550025CC85 /* Extensions */,
 				92FFE5221E7C994B0037E48C /* View Elements */,
 				92942DAD1E215722008E79CA /* View Controllers */,
 				92A5E4F721A1B7470025CC85 /* Frameworks */,
@@ -1103,27 +1107,10 @@
 			path = Base;
 			sourceTree = "<group>";
 		};
-		92942E341E2303AB008E79CA /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				923AEE86216583CA00EF50C8 /* Bundle+Version.swift */,
-				92942E321E2303A5008E79CA /* Calendar+TBA.swift */,
-				9249206E20BB0455001CAC5E /* Date+TBA.swift */,
-				924C0E8F20BA18C5009066ED /* Int16+Suffix.swift */,
-				924602B61ECE99F50030EDBF /* String+Prefix.swift */,
-				92FFE52B1E7CC60F0037E48C /* UIColor+TBA.swift */,
-				929F57192092AAF000E5313A /* URL+Reachable.swift */,
-				9287013F20CD7C790077D6DA /* RemoteConfig+TBA.swift */,
-				92BB8B65214F177B0035AF28 /* UIApplication+URLOpener.swift */,
-				925908B02184F7F900D7BFCE /* NSSet+Only.swift */,
-			);
-			name = Extensions;
-			sourceTree = "<group>";
-		};
 		929820CB2169667A0080C1C8 /* Events */ = {
 			isa = PBXGroup;
 			children = (
-				929820CC216966890080C1C8 /* EventsContainerViewController_Tests.swift */,
+				929820CC216966890080C1C8 /* EventsContainerViewControllerTests.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -1368,6 +1355,24 @@
 			path = data;
 			sourceTree = "<group>";
 		};
+		92A5E5C721A22D550025CC85 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				92A5E5C821A22D550025CC85 /* UIApplication+URLOpener.swift */,
+				92A5E5C921A22D550025CC85 /* Bundle+Version.swift */,
+				92A5E5CA21A22D550025CC85 /* Calendar+TBA.swift */,
+				92A5E5CB21A22D550025CC85 /* NSSet+Only.swift */,
+				92A5E5CC21A22D550025CC85 /* Date+TBA.swift */,
+				92A5E5CD21A22D550025CC85 /* RemoteConfig+TBA.swift */,
+				92A5E5CE21A22D550025CC85 /* String+Prefix.swift */,
+				92A5E5CF21A22D550025CC85 /* UIColor+TBA.swift */,
+				92A5E5D021A22D550025CC85 /* UINavigationController+SplitView.swift */,
+				92A5E5D121A22D550025CC85 /* URL+Reachable.swift */,
+				92A5E5D221A22D550025CC85 /* Int16+Suffix.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		92B076EF20FF8DDC00F9B2D7 /* myTBA */ = {
 			isa = PBXGroup;
 			children = (
@@ -1443,7 +1448,7 @@
 		92C1F2E12169AA5D00BD8445 /* Teams */ = {
 			isa = PBXGroup;
 			children = (
-				92C1F2E32169AA7200BD8445 /* TeamsContainerViewController_Tests.swift */,
+				92C1F2E32169AA7200BD8445 /* TeamsContainerViewControllerTests.swift */,
 			);
 			path = Teams;
 			sourceTree = "<group>";
@@ -1451,7 +1456,8 @@
 		92C1F2E22169AA6000BD8445 /* Districts */ = {
 			isa = PBXGroup;
 			children = (
-				92C1F2E52169AB9F00BD8445 /* DistrictsContainerViewController_Tests.swift */,
+				92C1F2E52169AB9F00BD8445 /* DistrictsContainerViewControllerTests.swift */,
+				92269EE0219B9CF300FAA610 /* DistrictViewControllerTests.swift */,
 			);
 			path = Districts;
 			sourceTree = "<group>";
@@ -2082,8 +2088,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92A5E5DD21A22D550025CC85 /* Int16+Suffix.swift in Sources */,
 				92DF35DE217D435D00B5246B /* DistrictRanking.swift in Sources */,
 				92A5E51221A1B7470025CC85 /* MyTBASubscription.swift in Sources */,
+				92A5E5D421A22D550025CC85 /* Bundle+Version.swift in Sources */,
 				929F57282092BA6500E5313A /* Observable.swift in Sources */,
 				92F8E358209AB3B50094213F /* Provider.swift in Sources */,
 				92D855D41EC68F4200572F27 /* TeamsViewController.swift in Sources */,
@@ -2092,6 +2100,7 @@
 				92DF35EE217D438400B5246B /* EventTeamStat.swift in Sources */,
 				92DF35DF217D435D00B5246B /* DistrictEventPoints.swift in Sources */,
 				92D855E01EC6BA3900572F27 /* TeamViewController.swift in Sources */,
+				92A5E5D621A22D550025CC85 /* NSSet+Only.swift in Sources */,
 				1416D50A218E422400F1A4A3 /* EventInsights.swift in Sources */,
 				92942D961E2154DA008E79CA /* AppDelegate.swift in Sources */,
 				92DF35ED217D438400B5246B /* EventStatusQual.swift in Sources */,
@@ -2106,7 +2115,6 @@
 				92DF3608217D43CB00B5246B /* Team.swift in Sources */,
 				925908AF2184D32400D7BFCE /* EventStatusPlayoff.swift in Sources */,
 				92DF3602217D43B300B5246B /* Subscription.swift in Sources */,
-				925908B12184F7F900D7BFCE /* NSSet+Only.swift in Sources */,
 				9274A3F81F3520B900FAADF0 /* TeamSummaryViewController.swift in Sources */,
 				92DF3607217D43CB00B5246B /* TeamKey.swift in Sources */,
 				92FE68BB20D8A1E8004A1481 /* MyTBASignOutOperation.swift in Sources */,
@@ -2118,7 +2126,6 @@
 				1405237C1ED33F500072FB91 /* MatchViewController.swift in Sources */,
 				145C57B51ED377EB004955B2 /* MatchTableViewCell.swift in Sources */,
 				929F571C2092B77300E5313A /* TBATableViewController.swift in Sources */,
-				92BB8B66214F177B0035AF28 /* UIApplication+URLOpener.swift in Sources */,
 				924602AB1ECE8B1D0030EDBF /* AwardTableViewCell.swift in Sources */,
 				92D855D71EC695C400572F27 /* TeamTableViewCell.swift in Sources */,
 				92A5E51421A1B7470025CC85 /* MyTBAFavorite.swift in Sources */,
@@ -2131,28 +2138,29 @@
 				929FCDA21EC8068800A38E46 /* DistrictViewController.swift in Sources */,
 				92B5565E21601D9000C1D9A3 /* MatchView.swift in Sources */,
 				92A5E52021A1B7470025CC85 /* TBAEvent.swift in Sources */,
-				9287014020CD7C790077D6DA /* RemoteConfig+TBA.swift in Sources */,
 				14796946215EB0B90075AF4E /* RankingCellViewModel.swift in Sources */,
 				92DF35E1217D435D00B5246B /* AwardRecipient.swift in Sources */,
 				14B6726A21517A7E00FDDAB2 /* RealtimeDatabaseService.swift in Sources */,
+				92A5E5D521A22D550025CC85 /* Calendar+TBA.swift in Sources */,
 				92688C2B2090091D00D12B7B /* ReactNativeService.swift in Sources */,
 				92DF35E0217D435D00B5246B /* Award.swift in Sources */,
-				923AEE87216583CA00EF50C8 /* Bundle+Version.swift in Sources */,
 				925908AD2184CFA900D7BFCE /* EventAllianceBackup.swift in Sources */,
 				9218462D20CDBBDB00AAB7F8 /* RemoteConfigServiceOperation.swift in Sources */,
+				92A5E5D921A22D550025CC85 /* String+Prefix.swift in Sources */,
+				92A5E5DC21A22D550025CC85 /* URL+Reachable.swift in Sources */,
 				92858F2D208D783E00811614 /* EventTeamStatTableViewCell.swift in Sources */,
 				145C57BD1ED3C3AA004955B2 /* PlayerView.swift in Sources */,
 				1450778D21824E2F00C61D2D /* EventKey.swift in Sources */,
 				14796942215EA5AE0075AF4E /* AwardCellViewModel.swift in Sources */,
 				9291F7FC1EE6FC7D00EEB86B /* TeamMediaCollectionViewController.swift in Sources */,
+				92A5E5DB21A22D550025CC85 /* UINavigationController+SplitView.swift in Sources */,
 				92DF3610217D43EC00B5246B /* Playable.swift in Sources */,
-				924C0E9020BA18C5009066ED /* Int16+Suffix.swift in Sources */,
 				92DF35FE217D43A200B5246B /* TeamMedia.swift in Sources */,
 				920DF7CF20954B5D0041B487 /* DistrictBreakdownViewController.swift in Sources */,
-				924602B71ECE99F50030EDBF /* String+Prefix.swift in Sources */,
 				92942E361E2A81E8008E79CA /* EventInfoViewController.swift in Sources */,
 				92DF35F9217D439500B5246B /* MatchAlliance.swift in Sources */,
 				304ED0421EF1D2D300E31791 /* RankingTableViewCell.swift in Sources */,
+				92A5E5D821A22D550025CC85 /* RemoteConfig+TBA.swift in Sources */,
 				92DF35F1217D438400B5246B /* EventStatus.swift in Sources */,
 				92B55623215D688600C1D9A3 /* TeamEventsViewController.swift in Sources */,
 				92B55625215D69DE00C1D9A3 /* WeekEventsViewController.swift in Sources */,
@@ -2171,8 +2179,10 @@
 				145C57BB1ED3C178004955B2 /* MatchBreakdownViewController.swift in Sources */,
 				920DF7CD20954B430041B487 /* TeamAtDistrictViewController.swift in Sources */,
 				92942DBB1E215B8D008E79CA /* MyTBAViewController.swift in Sources */,
+				92A5E5DA21A22D550025CC85 /* UIColor+TBA.swift in Sources */,
 				929F57222092B80B00E5313A /* ContainerViewController.swift in Sources */,
 				92E6DB8B20C4609900396010 /* DistrictTeamSummaryViewController.swift in Sources */,
+				92A5E5D321A22D550025CC85 /* UIApplication+URLOpener.swift in Sources */,
 				927292521EE4A48C0027CE7C /* EventTeamStatsViewController.swift in Sources */,
 				14796948215EBD6C0075AF4E /* EventCellViewModel.swift in Sources */,
 				92A5E51121A1B7470025CC85 /* MyTBARegister.swift in Sources */,
@@ -2203,8 +2213,8 @@
 				9274A3F51F35202200FAADF0 /* TeamAtEventViewController.swift in Sources */,
 				92A5E51521A1B7470025CC85 /* MyTBAModel.swift in Sources */,
 				92B55627215D6A9B00C1D9A3 /* DistrictEventsViewController.swift in Sources */,
-				92FFE52C1E7CC60F0037E48C /* UIColor+TBA.swift in Sources */,
 				9287013C20CD70CF0077D6DA /* RemoteConfigService.swift in Sources */,
+				92A5E5D721A22D550025CC85 /* Date+TBA.swift in Sources */,
 				925471F7208CC6F100AD3204 /* EventAllianceTableViewCell.swift in Sources */,
 				92DF35F3217D438400B5246B /* WLT.swift in Sources */,
 				9257DF4E208C0D1200F7E2BA /* EventAlliancesViewController.swift in Sources */,
@@ -2215,19 +2225,16 @@
 				9221C616209BFF7D00477DE2 /* LoadingTableViewCell.swift in Sources */,
 				92942DB11E215B06008E79CA /* EventsViewController.swift in Sources */,
 				92CFF55D1EB548E3008D2348 /* TableViewDataSource.swift in Sources */,
-				92942E331E2303A5008E79CA /* Calendar+TBA.swift in Sources */,
 				929F571E2092B7A400E5313A /* TBACollectionViewController.swift in Sources */,
 				92B55621215D37C900C1D9A3 /* YearSelectViewController.swift in Sources */,
 				929FCD9A1EC7F52700A38E46 /* DistrictsViewController.swift in Sources */,
 				92DF35EC217D438400B5246B /* Event.swift in Sources */,
 				1479694A215EBE460075AF4E /* EventAllianceCellViewModel.swift in Sources */,
 				1405237A1ED33E040072FB91 /* MatchesViewController.swift in Sources */,
-				9249206F20BB0455001CAC5E /* Date+TBA.swift in Sources */,
 				92A5E51621A1B7470025CC85 /* MyTBASubscribable.swift in Sources */,
 				92DF360F217D43EC00B5246B /* NSManagedObjectContext+Extension.swift in Sources */,
 				9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */,
 				92B076F320FF948D00F9B2D7 /* TestAppDelegate.swift in Sources */,
-				929F571A2092AAF000E5313A /* URL+Reachable.swift in Sources */,
 				9255EB6D209AC9760006A745 /* RetryService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2247,7 +2254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				924459C620CB796B0007570D /* EventTests.swift in Sources */,
-				929820CD216966890080C1C8 /* EventsContainerViewController_Tests.swift in Sources */,
+				929820CD216966890080C1C8 /* EventsContainerViewControllerTests.swift in Sources */,
 				92A4147C216DA76400E459A5 /* ReactNativeService_Tests.swift in Sources */,
 				927C93B2217D64300027ABEB /* DistrictEventPointsTests.swift in Sources */,
 				14B6726C21528D6600FDDAB2 /* RealtimeDatabaseService_Tests.swift in Sources */,
@@ -2285,6 +2292,7 @@
 				92BB717C20CE116C0081F4E5 /* TBAOperation_Tests.swift in Sources */,
 				929820CF216968020080C1C8 /* TBATestCase.swift in Sources */,
 				925908B32184F86700D7BFCE /* NSSet+OnlyTests.swift in Sources */,
+				92269EE1219B9CF300FAA610 /* DistrictViewControllerTests.swift in Sources */,
 				92361028217D1175000CC5E9 /* AwardTests.swift in Sources */,
 				925908A921827B3A00D7BFCE /* TeamTests.swift in Sources */,
 				92A5E5AA21A1B7830025CC85 /* TBADistrictTests.swift in Sources */,
@@ -2303,9 +2311,9 @@
 				14B424F62167B01700E1904C /* Calendar+TBA_Tests.swift in Sources */,
 				928030E4219780540099CB65 /* EventAllianceTableViewCellTests.swift in Sources */,
 				9236101F2178245C000CC5E9 /* TeamMediaTests.swift in Sources */,
-				92C1F2E42169AA7200BD8445 /* TeamsContainerViewController_Tests.swift in Sources */,
+				92C1F2E42169AA7200BD8445 /* TeamsContainerViewControllerTests.swift in Sources */,
 				14B520F7218CA28B00F2EF4F /* EventStatusAllianceTests.swift in Sources */,
-				92C1F2E62169AB9F00BD8445 /* DistrictsContainerViewController_Tests.swift in Sources */,
+				92C1F2E62169AB9F00BD8445 /* DistrictsContainerViewControllerTests.swift in Sources */,
 				92A5E56B21A1B7830025CC85 /* TBAKitTests.swift in Sources */,
 				92C1F2DE216994CF00BD8445 /* CoreDataTestCase.swift in Sources */,
 				92BB8B62214F16710035AF28 /* SettingsViewController_Tests.swift in Sources */,

--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -270,7 +270,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupGoogleAuthentication()
     }
 
-    private static func setupAppearance() {
+    static func setupAppearance() {
         let navigationBarAppearance = UINavigationBar.appearance()
 
         navigationBarAppearance.barTintColor = UIColor.primaryBlue

--- a/the-blue-alliance-ios/App Delegate/TestAppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/TestAppDelegate.swift
@@ -5,6 +5,7 @@ import Foundation
 class TestAppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        AppDelegate.setupAppearance()
         // Setup our Firebase app - make sure this is called before other Firebase setup
         FirebaseApp.configure()
         return true

--- a/the-blue-alliance-ios/Extensions/UINavigationController+SplitView.swift
+++ b/the-blue-alliance-ios/Extensions/UINavigationController+SplitView.swift
@@ -1,0 +1,16 @@
+import Foundation
+import UIKit
+
+extension UINavigationController {
+
+    func setupSplitViewLeftBarButtonItem(viewController: UIViewController) {
+        if viewControllers.index(of: viewController) == 0 {
+            viewController.navigationItem.leftBarButtonItem = viewController.splitViewController?.displayModeButtonItem
+            viewController.navigationItem.leftItemsSupplementBackButton = true
+        } else {
+            viewController.navigationItem.leftBarButtonItem = nil
+            viewController.navigationItem.leftItemsSupplementBackButton = false
+        }
+    }
+
+}

--- a/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
@@ -11,7 +11,7 @@ protocol SelectTableViewControllerDelegate: AnyObject {
 
 class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TBATableViewController, Refreshable {
 
-    private let current: Delegate.OptionType?
+    private(set) var current: Delegate.OptionType?
     var options: [Delegate.OptionType] {
         didSet {
             DispatchQueue.main.async {

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictEventsViewController.swift
@@ -68,15 +68,16 @@ class DistrictEventsViewController: EventsViewController {
     // MARK: - EventsViewControllerDataSourceConfiguration
 
     override var firstSortDescriptor: NSSortDescriptor {
-        return NSSortDescriptor(key: "week", ascending: true)
+        return NSSortDescriptor(key: #keyPath(Event.week), ascending: true)
     }
 
     override var sectionNameKeyPath: String {
-        return "week"
+        return #keyPath(Event.week)
     }
 
     override var fetchRequestPredicate: NSPredicate {
-        return NSPredicate(format: "district == %@", district)
+        return NSPredicate(format: "%K == %@",
+                           #keyPath(Event.district.key), district.key!)
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictViewController.swift
@@ -4,9 +4,12 @@ import UIKit
 
 class DistrictViewController: ContainerViewController {
 
-    private let district: District
+    private(set) var district: District
     private let urlOpener: URLOpener
     private let userDefaults: UserDefaults
+
+    private(set) var eventsViewController: DistrictEventsViewController
+    private(set) var rankingsViewController: DistrictRankingsViewController
 
     // MARK: - Init
 
@@ -15,8 +18,8 @@ class DistrictViewController: ContainerViewController {
         self.urlOpener = urlOpener
         self.userDefaults = userDefaults
 
-        let eventsViewController = DistrictEventsViewController(district: district, persistentContainer: persistentContainer, tbaKit: tbaKit)
-        let rankingsViewController = DistrictRankingsViewController(district: district, persistentContainer: persistentContainer, tbaKit: tbaKit)
+        eventsViewController = DistrictEventsViewController(district: district, persistentContainer: persistentContainer, tbaKit: tbaKit)
+        rankingsViewController = DistrictRankingsViewController(district: district, persistentContainer: persistentContainer, tbaKit: tbaKit)
 
         super.init(viewControllers: [eventsViewController, rankingsViewController],
                    segmentedControlTitles: ["Events", "Rankings"],
@@ -38,11 +41,7 @@ class DistrictViewController: ContainerViewController {
 
         title = "\(district.year!.stringValue) \(district.name!) Districts"
 
-        // TODO: Why do we do this? Has to do with the split view I know
-        if navigationController?.viewControllers.index(of: self) == 0 {
-            navigationItem.leftBarButtonItem = splitViewController?.displayModeButtonItem
-            navigationItem.leftItemsSupplementBackButton = true
-        }
+        navigationController?.setupSplitViewLeftBarButtonItem(viewController: self)
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictBreakdownViewController.swift
@@ -19,12 +19,6 @@ class DistrictBreakdownViewController: TBATableViewController, Observable {
         self.ranking = ranking
 
         super.init(persistentContainer: persistentContainer, tbaKit: tbaKit)
-
-        contextObserver.observeObject(object: ranking, state: .updated) { [unowned self] (_, _) in
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
-            }
-        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -37,6 +31,12 @@ class DistrictBreakdownViewController: TBATableViewController, Observable {
         super.viewDidLoad()
 
         tableView.registerReusableCell(ReverseSubtitleTableViewCell.self)
+
+        contextObserver.observeObject(object: ranking, state: .updated) { [unowned self] (_, _) in
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
+        }
     }
 
 

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/DistrictTeamSummaryViewController.swift
@@ -25,12 +25,6 @@ class DistrictTeamSummaryViewController: TBATableViewController {
         self.ranking = ranking
 
         super.init(persistentContainer: persistentContainer, tbaKit: tbaKit)
-
-        contextObserver.observeObject(object: ranking, state: .updated) { [unowned self] (_, _) in
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
-            }
-        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -43,6 +37,12 @@ class DistrictTeamSummaryViewController: TBATableViewController {
         super.viewDidLoad()
 
         tableView.registerReusableCell(ReverseSubtitleTableViewCell.self)
+
+        contextObserver.observeObject(object: ranking, state: .updated) { [unowned self] (_, _) in
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
+        }
     }
 
     // MARK: - Table view data source

--- a/the-blue-alliance-ios/View Controllers/Districts/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/Team@District/TeamAtDistrictViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 
 class TeamAtDistrictViewController: ContainerViewController {
 
-    private let ranking: DistrictRanking
+    private(set) var ranking: DistrictRanking
 
     private var summaryViewController: DistrictTeamSummaryViewController!
 

--- a/the-blue-alliance-ios/View Controllers/Events/EventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class EventViewController: ContainerViewController {
 
-    private let event: Event
+    private(set) var event: Event
     private let userDefaults: UserDefaults
 
     // MARK: - Init
@@ -39,12 +39,7 @@ class EventViewController: ContainerViewController {
 
         title = event.friendlyNameWithYear
 
-        // TODO: Document what this is, and see if we can move it... literally anywhere else
-        // Because, for what it's worth, I'm *pretty sure* this shouldn't be here, unless maybe iPad?
-        if navigationController?.viewControllers.index(of: self) == 0 {
-            navigationItem.leftBarButtonItem = splitViewController?.displayModeButtonItem
-            navigationItem.leftItemsSupplementBackButton = true
-        }
+        navigationController?.setupSplitViewLeftBarButtonItem(viewController: self)
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -8,8 +8,8 @@ protocol YearSelectViewControllerDelegate: AnyObject {
 
 class YearSelectViewController: ContainerViewController {
 
-    private let year: Int
-    private let week: Event?
+    private(set) var year: Int
+    private(set) var week: Event?
 
     private let selectViewController: SelectTableViewController<YearSelectViewController>
     private var eventWeekSelectViewController: EventWeekSelectViewController?

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class TeamViewController: ContainerViewController, Observable {
 
-    private let team: Team
+    private(set) var team: Team
 
     private let eventsViewController: TeamEventsViewController
     private let mediaViewController: TeamMediaCollectionViewController
@@ -71,6 +71,8 @@ class TeamViewController: ContainerViewController, Observable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        navigationController?.setupSplitViewLeftBarButtonItem(viewController: self)
 
         if traitCollection.forceTouchCapability == .available {
             registerForPreviewing(with: self, sourceView: mediaViewController.collectionView)


### PR DESCRIPTION
For the most part, renames some test classes, adds TBAViewControllerTeseter to drive view lifecycle methods, abstracted the iPad left bar button item for root detail views

Snapshot testing in these classes is kinda a pain because we can't get the navigation bar, which is part of what we want.