### PR TITLE
Add Event dateString tests

### DIFF
--- a/tba-unit-tests/Core Data/CoreDataTestCase.swift
+++ b/tba-unit-tests/Core Data/CoreDataTestCase.swift
@@ -57,9 +57,6 @@ class CoreDataTestCase: FBSnapshotTestCase {
     }
 
     func insertEvent(year: Int = 2015) -> Event {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
         let model = TBAEvent(key: "\(year)qcmo",
                              name: "FRC Festival de Robotique - Montreal Regional",
                              eventCode: "qcmo",
@@ -68,8 +65,8 @@ class CoreDataTestCase: FBSnapshotTestCase {
                              city: nil,
                              stateProv: nil,
                              country: nil,
-                             startDate: dateFormatter.date(from: "\(year)-03-18")!,
-                             endDate: dateFormatter.date(from: "\(year)-03-21")!,
+                             startDate: Event.dateFormatter.date(from: "\(year)-03-18")!,
+                             endDate: Event.dateFormatter.date(from: "\(year)-03-21")!,
                              year: year,
                              shortName: "Festival de Robotique - Montreal",
                              eventTypeString: "Reginal",
@@ -95,9 +92,6 @@ class CoreDataTestCase: FBSnapshotTestCase {
     }
 
     func insertDistrictEvent(eventKey: String = "2018miket") -> Event {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
         let district = TBADistrict(abbreviation: "fim", name: "FIRST In Michigan", key: "2018fim", year: 2018)
         let model = TBAEvent(key: eventKey,
                              name: "FIM District Kettering University Event #1",
@@ -107,8 +101,8 @@ class CoreDataTestCase: FBSnapshotTestCase {
                              city: "Flint",
                              stateProv: "MI",
                              country: "USA",
-                             startDate: dateFormatter.date(from: "2018-03-01")!,
-                             endDate: dateFormatter.date(from: "2018-03-03")!,
+                             startDate: Event.dateFormatter.date(from: "2018-03-01")!,
+                             endDate: Event.dateFormatter.date(from: "2018-03-03")!,
                              year: 2018,
                              shortName: "Kettering University #1",
                              eventTypeString: "District",

--- a/tba-unit-tests/Core Data/District/DistrictRankingTests.swift
+++ b/tba-unit-tests/Core Data/District/DistrictRankingTests.swift
@@ -93,20 +93,17 @@ class DistrictRankingTestCase: CoreDataTestCase {
     }
 
     func test_sortedEventPoints() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
         // Three Events that all start at different dates
         let eventOne = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        eventOne.startDate = dateFormatter.date(from: "2018-03-01")!
+        eventOne.startDate = Event.dateFormatter.date(from: "2018-03-01")!
         eventOne.key = "2018miket"
 
         let eventTwo = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        eventTwo.startDate = dateFormatter.date(from: "2018-03-02")!
+        eventTwo.startDate = Event.dateFormatter.date(from: "2018-03-02")!
         eventTwo.key = "2018mike2"
 
         let eventThree = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        eventThree.startDate = dateFormatter.date(from: "2018-03-03")!
+        eventThree.startDate = Event.dateFormatter.date(from: "2018-03-03")!
         eventThree.key = "2018mike3"
 
         let ranking = DistrictRanking.init(entity: DistrictRanking.entity(), insertInto: persistentContainer.viewContext)

--- a/tba-unit-tests/Core Data/District/DistrictTests.swift
+++ b/tba-unit-tests/Core Data/District/DistrictTests.swift
@@ -52,11 +52,8 @@ class DistrictTestCase: CoreDataTestCase {
         let modelDistrict = TBADistrict(abbreviation: "fim", name: "FIRST In Michigan", key: "2018fim", year: 2018)
         let district = District.insert(modelDistrict, in: persistentContainer.viewContext)
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
-        let modelEventOne = TBAEvent(key: "2018miket", name: "Event 1", eventCode: "miket", eventType: 1, startDate: dateFormatter.date(from: "2018-03-01")!, endDate: dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
-        let modelEventTwo = TBAEvent(key: "2018mike2", name: "Event 2", eventCode: "mike2", eventType: 1, startDate: dateFormatter.date(from: "2018-03-01")!, endDate: dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
+        let modelEventOne = TBAEvent(key: "2018miket", name: "Event 1", eventCode: "miket", eventType: 1, startDate: Event.dateFormatter.date(from: "2018-03-01")!, endDate: Event.dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
+        let modelEventTwo = TBAEvent(key: "2018mike2", name: "Event 2", eventCode: "mike2", eventType: 1, startDate: Event.dateFormatter.date(from: "2018-03-01")!, endDate: Event.dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
 
         district.insert([modelEventOne, modelEventTwo])
 

--- a/tba-unit-tests/Core Data/Event/EventTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventTests.swift
@@ -647,4 +647,24 @@ class EventTestCase: CoreDataTestCase {
         XCTAssertEqual(Event.notificationTypes.count, 7)
     }
 
+    func test_dateString() {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        let sameDay = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
+        sameDay.startDate = dateFormatter.date(from: "2018-03-05")!
+        sameDay.endDate = dateFormatter.date(from: "2018-03-05")!
+        XCTAssertEqual(sameDay.dateString(), "Mar 05, 2018")
+
+        let sameYear = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
+        sameYear.startDate = dateFormatter.date(from: "2018-03-01")!
+        sameYear.endDate = dateFormatter.date(from: "2018-03-03")!
+        XCTAssertEqual(sameYear.dateString(), "Mar 01 to Mar 03, 2018")
+
+        let differentYear = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
+        differentYear.startDate = dateFormatter.date(from: "2018-12-31")!
+        differentYear.endDate = dateFormatter.date(from: "2019-01-01")!
+        XCTAssertEqual(differentYear.dateString(), "Dec 31, 2018 to Jan 01, 2019")
+    }
+
 }

--- a/tba-unit-tests/Core Data/Event/EventTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventTests.swift
@@ -6,11 +6,8 @@ class EventTestCase: CoreDataTestCase {
     let calendar: Calendar = Calendar.current
 
     func test_insert_year() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
-        let modelEventOne = TBAEvent(key: "2018miket", name: "name", eventCode: "code", eventType: 1, startDate: dateFormatter.date(from: "2018-03-01")!, endDate: dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
-        let modelEventTwo = TBAEvent(key: "2018mike2", name: "name", eventCode: "code", eventType: 1, startDate: dateFormatter.date(from: "2018-03-01")!, endDate: dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
+        let modelEventOne = TBAEvent(key: "2018miket", name: "name", eventCode: "code", eventType: 1, startDate: Event.dateFormatter.date(from: "2018-03-01")!, endDate: Event.dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
+        let modelEventTwo = TBAEvent(key: "2018mike2", name: "name", eventCode: "code", eventType: 1, startDate: Event.dateFormatter.date(from: "2018-03-01")!, endDate: Event.dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
 
         Event.insert([modelEventOne, modelEventTwo], year: 2018, in: persistentContainer.viewContext)
         let eventsFirst = Event.fetch(in: persistentContainer.viewContext) {
@@ -42,9 +39,6 @@ class EventTestCase: CoreDataTestCase {
     }
 
     func test_insert() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
         let district = TBADistrict(abbreviation: "fim", name: "FIRST In Michigan", key: "2018fim", year: 2018)
         let eventModel = TBAEvent(key: "2018miket",
                                   name: "Name",
@@ -54,8 +48,8 @@ class EventTestCase: CoreDataTestCase {
                                   city: "city",
                                   stateProv: "state",
                                   country: "country",
-                                  startDate: dateFormatter.date(from: "2018-03-01")!,
-                                  endDate: dateFormatter.date(from: "2018-03-03")!,
+                                  startDate: Event.dateFormatter.date(from: "2018-03-01")!,
+                                  endDate: Event.dateFormatter.date(from: "2018-03-03")!,
                                   year: 2018,
                                   shortName: "short name",
                                   eventTypeString: "District",
@@ -647,24 +641,52 @@ class EventTestCase: CoreDataTestCase {
         XCTAssertEqual(Event.notificationTypes.count, 7)
     }
 
-    func test_dateString() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
+    func test_dateString_noDates() {
+        let noDates = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
+        XCTAssertNil(noDates.dateString())
 
+        noDates.startDate = Event.dateFormatter.date(from: "2018-03-05")!
+        XCTAssertNil(noDates.dateString())
+        noDates.startDate = nil
+
+        noDates.endDate = Event.dateFormatter.date(from: "2018-03-05")!
+        XCTAssertNil(noDates.dateString())
+
+        noDates.startDate = Event.dateFormatter.date(from: "2018-03-05")!
+        XCTAssertNotNil(noDates.dateString())
+    }
+
+    func test_dateString() {
         let sameDay = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        sameDay.startDate = dateFormatter.date(from: "2018-03-05")!
-        sameDay.endDate = dateFormatter.date(from: "2018-03-05")!
-        XCTAssertEqual(sameDay.dateString(), "Mar 05, 2018")
+        sameDay.startDate = Event.dateFormatter.date(from: "2018-03-05")!
+        sameDay.endDate = Event.dateFormatter.date(from: "2018-03-05")!
+        XCTAssertEqual(sameDay.dateString(), "Mar 05")
 
         let sameYear = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        sameYear.startDate = dateFormatter.date(from: "2018-03-01")!
-        sameYear.endDate = dateFormatter.date(from: "2018-03-03")!
-        XCTAssertEqual(sameYear.dateString(), "Mar 01 to Mar 03, 2018")
+        sameYear.startDate = Event.dateFormatter.date(from: "2018-03-01")!
+        sameYear.endDate = Event.dateFormatter.date(from: "2018-03-03")!
+        XCTAssertEqual(sameYear.dateString(), "Mar 01 to Mar 03")
 
         let differentYear = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        differentYear.startDate = dateFormatter.date(from: "2018-12-31")!
-        differentYear.endDate = dateFormatter.date(from: "2019-01-01")!
-        XCTAssertEqual(differentYear.dateString(), "Dec 31, 2018 to Jan 01, 2019")
+        differentYear.startDate = Event.dateFormatter.date(from: "2018-12-31")!
+        differentYear.endDate = Event.dateFormatter.date(from: "2019-01-01")!
+        XCTAssertEqual(differentYear.dateString(), "Dec 31 to Jan 01, 2019")
+    }
+
+    func test_dateString_timezone() {
+        let timeZone = TimeZone(abbreviation: "UTC")!
+        NSTimeZone.default = timeZone
+
+        let sameYear = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
+        sameYear.startDate = Event.dateFormatter.date(from: "2018-03-01")!
+        sameYear.endDate = Event.dateFormatter.date(from: "2018-03-03")!
+        sameYear.timezone = "America/New_York"
+
+        XCTAssertEqual(sameYear.dateString(), "Mar 01 to Mar 03")
+
+        addTeardownBlock {
+            NSTimeZone.resetSystemTimeZone()
+        }
     }
 
 }

--- a/tba-unit-tests/Core Data/Team/TeamTests.swift
+++ b/tba-unit-tests/Core Data/Team/TeamTests.swift
@@ -98,11 +98,8 @@ class TeamTestCase: CoreDataTestCase {
         let teamModel = TBATeam(key: "frc7332", teamNumber: 7332, name: "The Rawrbotz", rookieYear: 2010)
         let team = Team.insert(teamModel, in: persistentContainer.viewContext)
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
-        let modelEventOne = TBAEvent(key: "2018miket", name: "Event 1", eventCode: "miket", eventType: 1, startDate: dateFormatter.date(from: "2018-03-01")!, endDate: dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
-        let modelEventTwo = TBAEvent(key: "2018mike2", name: "Event 2", eventCode: "mike2", eventType: 1, startDate: dateFormatter.date(from: "2018-03-01")!, endDate: dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
+        let modelEventOne = TBAEvent(key: "2018miket", name: "Event 1", eventCode: "miket", eventType: 1, startDate: Event.dateFormatter.date(from: "2018-03-01")!, endDate: Event.dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
+        let modelEventTwo = TBAEvent(key: "2018mike2", name: "Event 2", eventCode: "mike2", eventType: 1, startDate: Event.dateFormatter.date(from: "2018-03-01")!, endDate: Event.dateFormatter.date(from: "2018-03-03")!, year: 2018, eventTypeString: "District", divisionKeys: [])
 
         team.insert([modelEventOne, modelEventTwo])
 

--- a/tba-unit-tests/Frameworks/TBAKit/TBAEventTests.swift
+++ b/tba-unit-tests/Frameworks/TBAKit/TBAEventTests.swift
@@ -4,11 +4,8 @@ import XCTest
 class TBAEventTests: TBAKitTestCase {
 
     func test_event_init() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
-        let startDate = dateFormatter.date(from: "2018-03-01")!
-        let endDate = dateFormatter.date(from: "2018-03-03")!
+        let startDate = Event.dateFormatter.date(from: "2018-03-01")!
+        let endDate = Event.dateFormatter.date(from: "2018-03-03")!
 
         let event = TBAEvent(key: "2018miket", name: "Kettering District", eventCode: "miket", eventType: 1, startDate: startDate, endDate: endDate, year: 2018, eventTypeString: "District", divisionKeys: [])
 

--- a/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
@@ -40,9 +40,6 @@ class DistrictViewControllerTests: TBATestCase {
     }
 
     private func insertDistrictEvents(district: District) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
         let eventOne = TBAEvent(key: "2018miket",
                                 name: "FIM District Kettering University Event #1",
                                 eventCode: "miket",
@@ -51,8 +48,8 @@ class DistrictViewControllerTests: TBATestCase {
                                 city: nil,
                                 stateProv: nil,
                                 country: nil,
-                                startDate: dateFormatter.date(from: "2018-03-01")!,
-                                endDate: dateFormatter.date(from: "2018-03-03")!,
+                                startDate: Event.dateFormatter.date(from: "2018-03-01")!,
+                                endDate: Event.dateFormatter.date(from: "2018-03-03")!,
                                 year: 2018,
                                 shortName: "Kettering University #1",
                                 eventTypeString: "District",
@@ -82,8 +79,8 @@ class DistrictViewControllerTests: TBATestCase {
                                 city: nil,
                                 stateProv: nil,
                                 country: nil,
-                                startDate: dateFormatter.date(from: "2018-03-08")!,
-                                endDate: dateFormatter.date(from: "2018-03-10")!,
+                                startDate: Event.dateFormatter.date(from: "2018-03-08")!,
+                                endDate: Event.dateFormatter.date(from: "2018-03-10")!,
                                 year: 2018,
                                 shortName: "Kettering University #2",
                                 eventTypeString: "District",

--- a/the-blue-alliance-ios/Core Data/Event/Event.swift
+++ b/the-blue-alliance-ios/Core Data/Event/Event.swift
@@ -16,6 +16,12 @@ public enum EventType: Int {
 
 extension Event: Locatable, Managed {
 
+    static var dateFormatter: DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter
+    }
+
     /**
      Insert Events for a year with values from TBAKit Event models in to the managed object context.
 
@@ -371,7 +377,7 @@ extension Event: Locatable, Managed {
     }
 
     public func dateString() -> String? {
-        if self.startDate == nil || self.endDate == nil {
+        guard let startDate = startDate, let endDate = endDate else {
             return nil
         }
 
@@ -383,25 +389,13 @@ extension Event: Locatable, Managed {
         let longDateFormatter = DateFormatter()
         longDateFormatter.dateFormat = "MMM dd, y"
 
-        let startDate = Date(timeIntervalSince1970: self.startDate!.timeIntervalSince1970)
-        let endDate = Date(timeIntervalSince1970: self.endDate!.timeIntervalSince1970)
-
-        if let timezone = timezone {
-            let tz = TimeZone(identifier: timezone)
-            shortDateFormatter.timeZone = tz
-            longDateFormatter.timeZone = tz
-        }
-
-        var dateText: String?
         if startDate == endDate {
-            dateText = longDateFormatter.string(from: Date(timeIntervalSince1970: endDate.timeIntervalSince1970))
+            return shortDateFormatter.string(from: endDate)
         } else if calendar.component(.year, from: startDate) == calendar.component(.year, from: endDate) {
-            dateText = "\(shortDateFormatter.string(from: startDate)) to \(longDateFormatter.string(from: endDate))"
+            return "\(shortDateFormatter.string(from: startDate)) to \(shortDateFormatter.string(from: endDate))"
         } else {
-            dateText = "\(longDateFormatter.string(from: startDate)) to \(longDateFormatter.string(from: endDate))"
+            return "\(shortDateFormatter.string(from: startDate)) to \(longDateFormatter.string(from: endDate))"
         }
-
-        return dateText
     }
 
     public var weekString: String {

--- a/the-blue-alliance-ios/Core Data/Event/Event.swift
+++ b/the-blue-alliance-ios/Core Data/Event/Event.swift
@@ -396,7 +396,7 @@ extension Event: Locatable, Managed {
         if startDate == endDate {
             dateText = longDateFormatter.string(from: Date(timeIntervalSince1970: endDate.timeIntervalSince1970))
         } else if calendar.component(.year, from: startDate) == calendar.component(.year, from: endDate) {
-            dateText = "\(shortDateFormatter.string(from: startDate)) to \(shortDateFormatter.string(from: endDate))"
+            dateText = "\(shortDateFormatter.string(from: startDate)) to \(longDateFormatter.string(from: endDate))"
         } else {
             dateText = "\(longDateFormatter.string(from: startDate)) to \(longDateFormatter.string(from: endDate))"
         }


### PR DESCRIPTION
Adds tests for `Event.dateString` - which is failing on CI because of time zones.