### PR TITLE
Fix Match view controller crashes assuming Matches have Events

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchBreakdownViewController.swift
@@ -191,8 +191,12 @@ extension MatchBreakdownViewController: Refreshable {
 
                 if let modelMatch = modelMatch {
                     // TODO: Match can never be deleted
-                    let event = backgroundContext.object(with: self.match.event!.objectID) as! Event
-                    event.insert(modelMatch)
+                    if let event = self.match.event {
+                        let event = backgroundContext.object(with: event.objectID) as! Event
+                        event.insert(modelMatch)
+                    } else {
+                        Match.insert(modelMatch, in: backgroundContext)
+                    }
 
                     if backgroundContext.saveOrRollback() {
                         self.tbaKit.setLastModified(request!)


### PR DESCRIPTION
Apparently we didn't hit all of the references assuming a Match has an Event attached to it - this might fix some of our flaky tests as well