### PR TITLE
React Native improvements

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		925908B32184F86700D7BFCE /* NSSet+OnlyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908B22184F86700D7BFCE /* NSSet+OnlyTests.swift */; };
 		925908B52185076100D7BFCE /* EventAllianceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908B42185076100D7BFCE /* EventAllianceTests.swift */; };
 		925908B721863C3E00D7BFCE /* EventAllianceBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925908B621863C3E00D7BFCE /* EventAllianceBackupTests.swift */; };
+		9266825221B058DA0077C75C /* TBAReactNativeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9266825121B058DA0077C75C /* TBAReactNativeViewController.swift */; };
 		9266A1C621AA0A3000545867 /* MyTBATestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9266A1C521AA0A3000545867 /* MyTBATestCase.swift */; };
 		9266A1CF21AA0E8500545867 /* register_401.json in Resources */ = {isa = PBXBuildFile; fileRef = 9266A1C921AA0E8500545867 /* register_401.json */; };
 		9266A1D021AA0E8500545867 /* favorites_list.json in Resources */ = {isa = PBXBuildFile; fileRef = 9266A1CA21AA0E8500545867 /* favorites_list.json */; };
@@ -428,6 +429,7 @@
 		925908B22184F86700D7BFCE /* NSSet+OnlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSSet+OnlyTests.swift"; sourceTree = "<group>"; };
 		925908B42185076100D7BFCE /* EventAllianceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAllianceTests.swift; sourceTree = "<group>"; };
 		925908B621863C3E00D7BFCE /* EventAllianceBackupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAllianceBackupTests.swift; sourceTree = "<group>"; };
+		9266825121B058DA0077C75C /* TBAReactNativeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBAReactNativeViewController.swift; sourceTree = "<group>"; };
 		9266A1C521AA0A3000545867 /* MyTBATestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBATestCase.swift; sourceTree = "<group>"; };
 		9266A1C921AA0E8500545867 /* register_401.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = register_401.json; sourceTree = "<group>"; };
 		9266A1CA21AA0E8500545867 /* favorites_list.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = favorites_list.json; sourceTree = "<group>"; };
@@ -1192,6 +1194,7 @@
 			isa = PBXGroup;
 			children = (
 				929F571F2092B7D400E5313A /* TBAViewController.swift */,
+				9266825121B058DA0077C75C /* TBAReactNativeViewController.swift */,
 				929F571B2092B77300E5313A /* TBATableViewController.swift */,
 				929F571D2092B7A400E5313A /* TBACollectionViewController.swift */,
 				929F572D2092BBCB00E5313A /* Data Sources */,
@@ -2393,6 +2396,7 @@
 				92A5E51621A1B7470025CC85 /* MyTBASubscribable.swift in Sources */,
 				92DF360F217D43EC00B5246B /* NSManagedObjectContext+Extension.swift in Sources */,
 				9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */,
+				9266825221B058DA0077C75C /* TBAReactNativeViewController.swift in Sources */,
 				92B076F320FF948D00F9B2D7 /* TestAppDelegate.swift in Sources */,
 				9255EB6D209AC9760006A745 /* RetryService.swift in Sources */,
 			);

--- a/the-blue-alliance-ios/Extensions/URL+Reachable.swift
+++ b/the-blue-alliance-ios/Extensions/URL+Reachable.swift
@@ -8,7 +8,7 @@ extension Optional where Wrapped == URL {
         // Check URL type
         switch self {
         case .some(let url):
-            if url.isFileURL, let reachable = try? url.checkResourceIsReachable(), reachable == true {
+            if url.isFileURL, (try? url.checkResourceIsReachable()) ?? false {
                 return url
             } else if url.checkRemoteURLIsReachable() == true {
                 return url

--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -103,7 +103,6 @@ extension Refreshable {
                 }
             }
         }
-
         return (!hasSuccessfullyRefreshed || isDataStale || isDataSourceEmpty) && !isRefreshing
     }
 

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAReactNativeViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAReactNativeViewController.swift
@@ -1,0 +1,178 @@
+import CoreData
+import Crashlytics
+import Foundation
+import React
+import UIKit
+
+protocol TBAReactNativeViewControllerDelegate: AnyObject {
+    var appProperties: [String: Any]? { get }
+}
+
+class TBAReactNativeViewController: TBAViewController {
+
+    // MARK: - React Native
+
+    var moduleName: String
+
+    // MARK: - TBAReactNativeVC
+
+    private var rootView: RCTRootView?
+    weak var delegate: TBAReactNativeViewControllerDelegate?
+
+    // MARK: - Init
+
+    init(moduleName: String, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.moduleName = moduleName
+
+        super.init(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(handleReactNativeErrorNotification(_:)), name: NSNotification.Name.RCTJavaScriptDidFailToLoad, object: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        attemptToSetupRootView()
+    }
+
+    // MARK: - TBAViewController overrides
+
+    override func reloadData() {
+        if let rootView = rootView {
+            // View is loaded - we need to update our info now
+            if let appProperties = delegate?.appProperties {
+                // Update our data with new data
+                rootView.appProperties = appProperties
+            } else if hasNoDataAfterRefresh {
+                // Existing data is gone - show no data
+                showNoDataView()
+                self.rootView = nil
+            } else {
+                assertionFailure("Unhandled edge case around showing React Native data we should fix")
+            }
+        } else {
+            // Attempt to load our view - otherwise, show no data and disable refreshing
+            attemptToSetupRootView()
+        }
+    }
+
+    // MARK: - Private Methods
+
+    var hasNoDataAfterRefresh: Bool {
+        guard let vc = self as? Stateful & Refreshable else {
+            assertionFailure("TBAReactNativeViewController superclasses should conform to Stateful + Refreshable")
+            return false
+        }
+        return vc.hasSuccessfullyRefreshed && vc.isDataSourceEmpty
+    }
+
+    /**
+     Attempt to load our root React Native view and insert it in to our hiearchy. If we can't setup a root view, we'll
+     add a no data view, if applicable.
+     */
+    private func attemptToSetupRootView(disableRefreshing: Bool = false) {
+        // Attempt to load our view and insert it in to our hiearchy, if we have the data
+        if let rootView = createRootView() {
+            addRootViewToHiearchy(rootView)
+            self.rootView = rootView
+        } else if hasNoDataAfterRefresh {
+            showNoDataView(disableRefreshing: disableRefreshing)
+        }
+    }
+
+    /**
+     Create a React Native root view for the supplied module/data.
+     Will fail if we don't have any data or can't create the view.
+     */
+    private func createRootView() -> RCTRootView? {
+        guard let initialProperties = delegate?.appProperties else {
+            return nil
+        }
+        guard let sourceURL = sourceURL else {
+            return nil
+        }
+        guard let rootView = RCTRootView(bundleURL: sourceURL, moduleName: moduleName, initialProperties: initialProperties, launchOptions: [:]) else {
+            return nil
+        }
+        rootView.delegate = self
+        rootView.sizeFlexibility = .height
+        return rootView
+    }
+
+    private func addRootViewToHiearchy(_ rootView: RCTRootView) {
+        scrollView.addSubview(rootView)
+        rootView.autoMatch(.width, to: .width, of: scrollView)
+        rootView.autoPinEdgesToSuperviewEdges()
+    }
+
+    private func showNoDataView(disableRefreshing: Bool = false) {
+        guard let vc = self as? Stateful & Refreshable else {
+            return
+        }
+        if let rootView = rootView {
+            rootView.removeFromSuperview()
+        }
+        vc.showNoDataView()
+        if disableRefreshing {
+            vc.disableRefreshing()
+        }
+    }
+
+    // MARK: - Notifications
+
+    @objc func handleReactNativeErrorNotification(_ sender: NSNotification) {
+        if let error = sender.userInfo?["error"] as? Error {
+            Crashlytics.sharedInstance().recordError(error)
+        }
+        showNoDataView(disableRefreshing: true)
+    }
+
+    // MARK: - React Native
+
+    var sourceURL: URL? {
+        #if DEBUG
+        return debugSourceURL
+        #else
+        return prodSourceURL
+        #endif
+    }
+
+    /**
+     URL to use for React Native bundle in when running in Debug configuration.
+     If local server is up and running, will use local server. Otherwise, we'll attempt to use the production bundle.
+     */
+    fileprivate var debugSourceURL: URL? {
+        let debugSourceURL = URL(string: "http://localhost:8081/index.ios.bundle")
+        if let debugSourceURL = debugSourceURL.reachableURL {
+            return debugSourceURL
+        }
+        return prodSourceURL
+    }
+
+    var prodSourceURL: URL? {
+        // Try to get our documents directory - this shouldn't fail, but just in case...
+        guard let documentsDirectory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true) else {
+            return nil
+        }
+
+        let fallbackURL = Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+        // Check if downloaded bundle (/Documents/ios/main.jsbundle) exists - otherwise use our bundled/shipped bundle
+        let bundleURL = documentsDirectory.appendingPathComponent(ReactNativeService.BundleName.downloaded.rawValue)
+        return (try? bundleURL.checkResourceIsReachable()) ?? false ? bundleURL : fallbackURL
+    }
+
+}
+
+extension TBAReactNativeViewController: RCTRootViewDelegate {
+
+    func rootViewDidChangeIntrinsicSize(_ rootView: RCTRootView!) {
+        rootView.autoSetDimension(.height, toSize: rootView.intrinsicContentSize.height)
+    }
+
+}

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAViewController.swift
@@ -50,7 +50,7 @@ class TBAViewController: UIViewController, DataController {
     }
 
     // TODO: https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/133
-    func reloadViewAfterRefresh() {
+    func reloadData() {
         fatalError("Implement this downstream")
     }
 
@@ -74,7 +74,7 @@ extension Refreshable where Self: TBAViewController {
     func noDataReload() {
         // TODO: https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/133
         DispatchQueue.main.async {
-            self.reloadViewAfterRefresh()
+            self.reloadData()
         }
     }
 

--- a/the-blue-alliance-ios/View Controllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchInfoViewController.swift
@@ -177,7 +177,7 @@ class MatchInfoViewController: TBAViewController, Observable {
         }
     }
 
-    override func reloadViewAfterRefresh() {
+    override func reloadData() {
         // We'll always have a match, so we shouldn't need to show a no data state
     }
 


### PR DESCRIPTION
- The `try?`s we were using the return values for weren't getting checked properly, which fixes a handful of bugs
- Removed the `ReactNative` protocol (god bless) in favor of having all that logic self-contained in `TBAReactNativeViewController`
- Only delete our bundle if we're successfully unpacked it - this means a React Native bundle could sit around for whatever the `retryTime` is on that `ReactNativeService`, but that's like 15min of having a few MB sitting around - not a big deal.
- Added `TBAReactNativeViewController`, which handles the view lifecycle of React Native views MUCH better (closes #261)
- Made `sourceURL` for React Native optional, since this was either buggy or crashing in debug builds - we should probably add more safety, but this should work for now
- Renamed `reloadViewAfterRefresh` to `reloadData`, since it makes more sense kinda...

Should fix the issues we're seeing in #330