### PR TITLE
Add RP dots to score listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ tba-unit-tests/FailureDiffs
 # Ignore some Metadata from Fastlane with sensitive information
 fastlane/metadata/trade_representative_contact_information
 fastlane/metadata/review_information
+
+# rbenv
+.ruby-version

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
@@ -79,7 +79,7 @@ class MatchSummaryView: UIView {
     private func removeTeams() {
         for stackView in [redStackView, blueStackView] as [UIStackView] {
             for view in stackView.arrangedSubviews {
-                if [redScoreLabel, blueScoreLabel].contains(view) {
+                if [redScoreLabel, redRPLabel, blueScoreLabel, blueRPLabel].contains(view) {
                     continue
                 }
                 view.removeFromSuperview()

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
@@ -35,8 +35,13 @@ class MatchSummaryView: UIView {
         }
     }
     @IBOutlet weak var blueScoreLabel: UILabel!
+    
+    @IBOutlet weak var redRPLabel: UILabel!
+    
+    @IBOutlet weak var blueRPLabel: UILabel!
 
     @IBOutlet weak var timeLabel: UILabel!
+    
 
     // MARK: - Init
 
@@ -97,12 +102,14 @@ class MatchSummaryView: UIView {
             redStackView.insertArrangedSubview(teamLabel, at: 0)
         }
         redScoreLabel.text = viewModel.redScore
+        redRPLabel.text = viewModel.redRP
 
         for teamKey in viewModel.blueAlliance {
             let teamLabel = label(for: teamKey, baseTeamKey: viewModel.baseTeamKey)
             blueStackView.insertArrangedSubview(teamLabel, at: 0)
         }
         blueScoreLabel.text = viewModel.blueScore
+        blueRPLabel.text = viewModel.blueRP
 
         timeLabel.isHidden = viewModel.hasScores
         timeLabel.text = viewModel.timeString

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
@@ -27,6 +27,7 @@ class MatchSummaryView: UIView {
         }
     }
     @IBOutlet weak var redScoreLabel: UILabel!
+    @IBOutlet private weak var redRPStackView: UIStackView!
 
     @IBOutlet weak private var blueStackView: UIStackView!
     @IBOutlet weak var blueContainerView: UIView! {
@@ -35,6 +36,7 @@ class MatchSummaryView: UIView {
         }
     }
     @IBOutlet weak var blueScoreLabel: UILabel!
+    @IBOutlet private weak var blueRPStackView: UIStackView!
     
     @IBOutlet weak var redRPLabel: UILabel!
     
@@ -79,9 +81,17 @@ class MatchSummaryView: UIView {
     private func removeTeams() {
         for stackView in [redStackView, blueStackView] as [UIStackView] {
             for view in stackView.arrangedSubviews {
-                if [redScoreLabel, redRPLabel, blueScoreLabel, blueRPLabel].contains(view) {
+                if [redScoreLabel, blueScoreLabel].contains(view) {
                     continue
                 }
+                view.removeFromSuperview()
+            }
+        }
+    }
+    
+    private func removeRPs() {
+        for stackView in [redRPStackView, blueRPStackView] as [UIStackView] {
+            for view in stackView.arrangedSubviews {
                 view.removeFromSuperview()
             }
         }
@@ -96,20 +106,25 @@ class MatchSummaryView: UIView {
         playIconImageView.isHidden = viewModel.hasVideos
 
         removeTeams()
+        removeRPs()
 
         for teamKey in viewModel.redAlliance {
-            let teamLabel = label(for: teamKey, baseTeamKey: viewModel.baseTeamKey)
-            redStackView.insertArrangedSubview(teamLabel, at: 0)
+            let redTeamLabel = teamLabel(for: teamKey, baseTeamKey: viewModel.baseTeamKey)
+            redStackView.insertArrangedSubview(redTeamLabel, at: 0)
         }
         redScoreLabel.text = viewModel.redScore
-        redRPLabel.text = viewModel.redRP
+
+        // Add red RP to view
+        addRPToView(stackView: redRPStackView, rpString: viewModel.redRPString)
 
         for teamKey in viewModel.blueAlliance {
-            let teamLabel = label(for: teamKey, baseTeamKey: viewModel.baseTeamKey)
-            blueStackView.insertArrangedSubview(teamLabel, at: 0)
+            let blueTeamLabel = teamLabel(for: teamKey, baseTeamKey: viewModel.baseTeamKey)
+            blueStackView.insertArrangedSubview(blueTeamLabel, at: 0)
         }
         blueScoreLabel.text = viewModel.blueScore
-        blueRPLabel.text = viewModel.blueRP
+        
+        // Add blue RP to view
+        addRPToView(stackView: blueRPStackView, rpString: viewModel.blueRPString)
 
         timeLabel.isHidden = viewModel.hasScores
         timeLabel.text = viewModel.timeString
@@ -122,12 +137,24 @@ class MatchSummaryView: UIView {
             blueScoreLabel.font = winnerFont
         }
     }
+    
+    private func addRPToView(stackView: UIStackView, rpString: String) {
+        let rpLabel = label(text: rpString, isBold: true)
+        stackView.insertArrangedSubview(rpLabel, at: 0)
+    }
+    
+    private func teamLabel(for teamKey: String, baseTeamKey: String?) -> UILabel {
+        let text: String = "\(Team.trimFRCPrefix(teamKey))"
+        let isBold: Bool = (teamKey == baseTeamKey)
+        
+        return label(text: text, isBold: isBold)
+    }
 
-    private func label(for teamKey: String, baseTeamKey: String?) -> UILabel {
+    private func label(text: String, isBold: Bool) -> UILabel {
         let label = UILabel()
-        label.text = "\(Team.trimFRCPrefix(teamKey))"
+        label.text = text
         var font: UIFont = .systemFont(ofSize: 14)
-        if teamKey == baseTeamKey {
+        if isBold {
             font = .boldSystemFont(ofSize: 14)
         }
         label.font = font

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
@@ -66,7 +66,7 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="278" height="32.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="114" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r4c-pQ-IQY">
-                                                            <rect key="frame" x="0.0" y="0.0" width="138" height="32.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="278" height="32.5"/>
                                                             <color key="backgroundColor" red="1" green="0.86666666670000003" blue="0.86666666670000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="150" id="rJJ-xb-K6o"/>
@@ -79,12 +79,6 @@
                                                                     <exclude reference="rJJ-xb-K6o"/>
                                                                 </mask>
                                                             </variation>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abb-wu-aTo">
-                                                            <rect key="frame" x="140" y="0.0" width="138" height="32.5"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
@@ -117,7 +111,7 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="278" height="32.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5774" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BIa-h9-yIu">
-                                                            <rect key="frame" x="0.0" y="0.0" width="138" height="32.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="278" height="32.5"/>
                                                             <color key="backgroundColor" red="0.86666666670000003" green="0.86274509799999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="150" id="tIL-6y-jGh"/>
@@ -130,12 +124,6 @@
                                                                     <exclude reference="tIL-6y-jGh"/>
                                                                 </mask>
                                                             </variation>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1H-ng-Fye">
-                                                            <rect key="frame" x="140" y="0.0" width="138" height="32.5"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
@@ -187,16 +175,32 @@
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abb-wu-aTo">
+                    <rect key="frame" x="90" y="2" width="11.5" height="14.5"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1H-ng-Fye">
+                    <rect key="frame" x="88" y="32.5" width="11.5" height="14.5"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="N94-SY-H14" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9Mn-zS-QSy"/>
+                <constraint firstItem="abb-wu-aTo" firstAttribute="leading" secondItem="r4c-pQ-IQY" secondAttribute="leading" constant="2" id="Ck1-7V-MCU"/>
+                <constraint firstItem="J1H-ng-Fye" firstAttribute="leading" secondItem="BIa-h9-yIu" secondAttribute="leading" id="HfX-9p-ahb"/>
                 <constraint firstItem="eE4-4s-f1F" firstAttribute="width" secondItem="D1e-rS-9fu" secondAttribute="width" multiplier="4" constant="8" id="KTT-wp-8cv"/>
+                <constraint firstItem="abb-wu-aTo" firstAttribute="top" secondItem="r4c-pQ-IQY" secondAttribute="top" constant="2" id="PAR-sP-zbU"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="U1g-rV-upl"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="VKx-dT-xzk"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="YJ5-os-Eee"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="bjR-Wi-7l3"/>
                 <constraint firstItem="N94-SY-H14" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="cCj-PU-3HE"/>
+                <constraint firstItem="J1H-ng-Fye" firstAttribute="top" secondItem="BIa-h9-yIu" secondAttribute="top" id="cuz-s9-c7N"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="top" secondItem="N94-SY-H14" secondAttribute="top" id="s3l-bR-jjR"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
@@ -4,7 +4,6 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -13,12 +12,14 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MatchSummaryView" customModule="The_Blue_Alliance" customModuleProvider="target">
             <connections>
                 <outlet property="blueContainerView" destination="ujk-xM-7ok" id="OqU-mA-Q5D"/>
+                <outlet property="blueRPLabel" destination="J1H-ng-Fye" id="ePO-J8-Jh4"/>
                 <outlet property="blueScoreLabel" destination="BIa-h9-yIu" id="MF0-LK-IzD"/>
                 <outlet property="blueStackView" destination="C6h-fR-VJi" id="vRF-WK-RJv"/>
                 <outlet property="matchInfoStackView" destination="Jmu-Uu-boJ" id="eyv-AC-M1I"/>
                 <outlet property="matchNumberLabel" destination="yPd-Gy-NoB" id="BhK-va-myy"/>
                 <outlet property="playIconImageView" destination="mRu-M0-eMP" id="Eh2-vo-Ze0"/>
                 <outlet property="redContainerView" destination="mpK-JO-dy3" id="nrm-lE-A5y"/>
+                <outlet property="redRPLabel" destination="abb-wu-aTo" id="hRE-2R-o2u"/>
                 <outlet property="redScoreLabel" destination="r4c-pQ-IQY" id="4z0-go-u4f"/>
                 <outlet property="redStackView" destination="Ifh-sb-xaX" id="wM1-3g-BXu"/>
                 <outlet property="summaryView" destination="iN0-l3-epB" id="uEA-0I-L6n"/>
@@ -65,7 +66,7 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="278" height="32.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="114" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r4c-pQ-IQY">
-                                                            <rect key="frame" x="0.0" y="0.0" width="278" height="32.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="138" height="32.5"/>
                                                             <color key="backgroundColor" red="1" green="0.86666666670000003" blue="0.86666666670000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="150" id="rJJ-xb-K6o"/>
@@ -78,6 +79,12 @@
                                                                     <exclude reference="rJJ-xb-K6o"/>
                                                                 </mask>
                                                             </variation>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abb-wu-aTo">
+                                                            <rect key="frame" x="140" y="0.0" width="138" height="32.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
@@ -192,6 +199,14 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="131.19999999999999" y="-117.39130434782609"/>
         </view>
+        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="J1H-ng-Fye">
+            <rect key="frame" x="0.0" y="0.0" width="42" height="21"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+            <nil key="textColor"/>
+            <nil key="highlightedColor"/>
+            <point key="canvasLocation" x="99" y="-117"/>
+        </label>
     </objects>
     <resources>
         <image name="ic_action_play_over_video" width="24" height="24"/>

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
@@ -117,7 +117,7 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="278" height="32.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5774" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BIa-h9-yIu">
-                                                            <rect key="frame" x="0.0" y="0.0" width="278" height="32.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="138" height="32.5"/>
                                                             <color key="backgroundColor" red="0.86666666670000003" green="0.86274509799999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="150" id="tIL-6y-jGh"/>
@@ -130,6 +130,12 @@
                                                                     <exclude reference="tIL-6y-jGh"/>
                                                                 </mask>
                                                             </variation>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1H-ng-Fye">
+                                                            <rect key="frame" x="140" y="0.0" width="138" height="32.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
@@ -199,14 +205,6 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="131.19999999999999" y="-117.39130434782609"/>
         </view>
-        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="J1H-ng-Fye">
-            <rect key="frame" x="0.0" y="0.0" width="42" height="21"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-            <nil key="textColor"/>
-            <nil key="highlightedColor"/>
-            <point key="canvasLocation" x="99" y="-117"/>
-        </label>
     </objects>
     <resources>
         <image name="ic_action_play_over_video" width="24" height="24"/>

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
@@ -176,13 +176,13 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abb-wu-aTo">
-                    <rect key="frame" x="90" y="2" width="11.5" height="14.5"/>
+                    <rect key="frame" x="89" y="-2" width="11.5" height="14.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1H-ng-Fye">
-                    <rect key="frame" x="88" y="32.5" width="11.5" height="14.5"/>
+                    <rect key="frame" x="89" y="30.5" width="11.5" height="14.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -191,16 +191,16 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="N94-SY-H14" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9Mn-zS-QSy"/>
-                <constraint firstItem="abb-wu-aTo" firstAttribute="leading" secondItem="r4c-pQ-IQY" secondAttribute="leading" constant="2" id="Ck1-7V-MCU"/>
-                <constraint firstItem="J1H-ng-Fye" firstAttribute="leading" secondItem="BIa-h9-yIu" secondAttribute="leading" id="HfX-9p-ahb"/>
+                <constraint firstItem="abb-wu-aTo" firstAttribute="leading" secondItem="r4c-pQ-IQY" secondAttribute="leading" constant="1" id="Ck1-7V-MCU"/>
+                <constraint firstItem="J1H-ng-Fye" firstAttribute="leading" secondItem="BIa-h9-yIu" secondAttribute="leading" constant="1" id="HfX-9p-ahb"/>
                 <constraint firstItem="eE4-4s-f1F" firstAttribute="width" secondItem="D1e-rS-9fu" secondAttribute="width" multiplier="4" constant="8" id="KTT-wp-8cv"/>
-                <constraint firstItem="abb-wu-aTo" firstAttribute="top" secondItem="r4c-pQ-IQY" secondAttribute="top" constant="2" id="PAR-sP-zbU"/>
+                <constraint firstItem="abb-wu-aTo" firstAttribute="top" secondItem="r4c-pQ-IQY" secondAttribute="top" constant="-2" id="PAR-sP-zbU"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="U1g-rV-upl"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="VKx-dT-xzk"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="YJ5-os-Eee"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="bjR-Wi-7l3"/>
                 <constraint firstItem="N94-SY-H14" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="cCj-PU-3HE"/>
-                <constraint firstItem="J1H-ng-Fye" firstAttribute="top" secondItem="BIa-h9-yIu" secondAttribute="top" id="cuz-s9-c7N"/>
+                <constraint firstItem="J1H-ng-Fye" firstAttribute="top" secondItem="BIa-h9-yIu" secondAttribute="top" constant="-2" id="cuz-s9-c7N"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="top" secondItem="N94-SY-H14" secondAttribute="top" id="s3l-bR-jjR"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
@@ -178,7 +178,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D8q-gZ-JhX" userLabel="Red RP View">
-                    <rect key="frame" x="88" y="0.0" width="11.5" height="14.5"/>
+                    <rect key="frame" x="89" y="-3" width="11.5" height="14.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abb-wu-aTo">
                             <rect key="frame" x="0.0" y="0.0" width="11.5" height="14.5"/>
@@ -190,7 +190,7 @@
                     <viewLayoutGuide key="safeArea" id="aOv-nb-YVi"/>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lwC-KQ-hCX" userLabel="Blue RP View">
-                    <rect key="frame" x="88" y="32.5" width="11.5" height="14.5"/>
+                    <rect key="frame" x="89" y="29.5" width="11.5" height="14.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1H-ng-Fye">
                             <rect key="frame" x="0.0" y="0.0" width="11.5" height="14.5"/>
@@ -205,16 +205,16 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="N94-SY-H14" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9Mn-zS-QSy"/>
-                <constraint firstItem="lwC-KQ-hCX" firstAttribute="top" secondItem="BIa-h9-yIu" secondAttribute="top" id="JCe-fN-3gP"/>
+                <constraint firstItem="lwC-KQ-hCX" firstAttribute="top" secondItem="BIa-h9-yIu" secondAttribute="top" constant="-3" id="JCe-fN-3gP"/>
                 <constraint firstItem="eE4-4s-f1F" firstAttribute="width" secondItem="D1e-rS-9fu" secondAttribute="width" multiplier="4" constant="8" id="KTT-wp-8cv"/>
-                <constraint firstItem="D8q-gZ-JhX" firstAttribute="leading" secondItem="r4c-pQ-IQY" secondAttribute="leading" id="Pid-dp-p9I"/>
+                <constraint firstItem="D8q-gZ-JhX" firstAttribute="leading" secondItem="r4c-pQ-IQY" secondAttribute="leading" constant="1" id="Pid-dp-p9I"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="U1g-rV-upl"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="VKx-dT-xzk"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="YJ5-os-Eee"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="bjR-Wi-7l3"/>
                 <constraint firstItem="N94-SY-H14" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="cCj-PU-3HE"/>
-                <constraint firstItem="D8q-gZ-JhX" firstAttribute="top" secondItem="r4c-pQ-IQY" secondAttribute="top" id="pzX-yJ-prr"/>
-                <constraint firstItem="lwC-KQ-hCX" firstAttribute="leading" secondItem="BIa-h9-yIu" secondAttribute="leading" id="qm0-wk-9wr"/>
+                <constraint firstItem="D8q-gZ-JhX" firstAttribute="top" secondItem="r4c-pQ-IQY" secondAttribute="top" constant="-3" id="pzX-yJ-prr"/>
+                <constraint firstItem="lwC-KQ-hCX" firstAttribute="leading" secondItem="BIa-h9-yIu" secondAttribute="leading" constant="1" id="qm0-wk-9wr"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="top" secondItem="N94-SY-H14" secondAttribute="top" id="s3l-bR-jjR"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="blueContainerView" destination="ujk-xM-7ok" id="OqU-mA-Q5D"/>
                 <outlet property="blueRPLabel" destination="J1H-ng-Fye" id="ePO-J8-Jh4"/>
+                <outlet property="blueRPStackView" destination="lwC-KQ-hCX" id="FhZ-o6-tfS"/>
                 <outlet property="blueScoreLabel" destination="BIa-h9-yIu" id="MF0-LK-IzD"/>
                 <outlet property="blueStackView" destination="C6h-fR-VJi" id="vRF-WK-RJv"/>
                 <outlet property="matchInfoStackView" destination="Jmu-Uu-boJ" id="eyv-AC-M1I"/>
@@ -20,6 +21,7 @@
                 <outlet property="playIconImageView" destination="mRu-M0-eMP" id="Eh2-vo-Ze0"/>
                 <outlet property="redContainerView" destination="mpK-JO-dy3" id="nrm-lE-A5y"/>
                 <outlet property="redRPLabel" destination="abb-wu-aTo" id="hRE-2R-o2u"/>
+                <outlet property="redRPStackView" destination="D8q-gZ-JhX" id="nLS-7d-t3K"/>
                 <outlet property="redScoreLabel" destination="r4c-pQ-IQY" id="4z0-go-u4f"/>
                 <outlet property="redStackView" destination="Ifh-sb-xaX" id="wM1-3g-BXu"/>
                 <outlet property="summaryView" destination="iN0-l3-epB" id="uEA-0I-L6n"/>
@@ -175,32 +177,44 @@
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abb-wu-aTo">
-                    <rect key="frame" x="89" y="-2" width="11.5" height="14.5"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1H-ng-Fye">
-                    <rect key="frame" x="89" y="30.5" width="11.5" height="14.5"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D8q-gZ-JhX" userLabel="Red RP View">
+                    <rect key="frame" x="88" y="0.0" width="11.5" height="14.5"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abb-wu-aTo">
+                            <rect key="frame" x="0.0" y="0.0" width="11.5" height="14.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <viewLayoutGuide key="safeArea" id="aOv-nb-YVi"/>
+                </stackView>
+                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lwC-KQ-hCX" userLabel="Blue RP View">
+                    <rect key="frame" x="88" y="32.5" width="11.5" height="14.5"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="••" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1H-ng-Fye">
+                            <rect key="frame" x="0.0" y="0.0" width="11.5" height="14.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <viewLayoutGuide key="safeArea" id="MDd-GC-vmQ"/>
+                </stackView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="N94-SY-H14" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9Mn-zS-QSy"/>
-                <constraint firstItem="abb-wu-aTo" firstAttribute="leading" secondItem="r4c-pQ-IQY" secondAttribute="leading" constant="1" id="Ck1-7V-MCU"/>
-                <constraint firstItem="J1H-ng-Fye" firstAttribute="leading" secondItem="BIa-h9-yIu" secondAttribute="leading" constant="1" id="HfX-9p-ahb"/>
+                <constraint firstItem="lwC-KQ-hCX" firstAttribute="top" secondItem="BIa-h9-yIu" secondAttribute="top" id="JCe-fN-3gP"/>
                 <constraint firstItem="eE4-4s-f1F" firstAttribute="width" secondItem="D1e-rS-9fu" secondAttribute="width" multiplier="4" constant="8" id="KTT-wp-8cv"/>
-                <constraint firstItem="abb-wu-aTo" firstAttribute="top" secondItem="r4c-pQ-IQY" secondAttribute="top" constant="-2" id="PAR-sP-zbU"/>
+                <constraint firstItem="D8q-gZ-JhX" firstAttribute="leading" secondItem="r4c-pQ-IQY" secondAttribute="leading" id="Pid-dp-p9I"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="U1g-rV-upl"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="VKx-dT-xzk"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="YJ5-os-Eee"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="bjR-Wi-7l3"/>
                 <constraint firstItem="N94-SY-H14" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="cCj-PU-3HE"/>
-                <constraint firstItem="J1H-ng-Fye" firstAttribute="top" secondItem="BIa-h9-yIu" secondAttribute="top" constant="-2" id="cuz-s9-c7N"/>
+                <constraint firstItem="D8q-gZ-JhX" firstAttribute="top" secondItem="r4c-pQ-IQY" secondAttribute="top" id="pzX-yJ-prr"/>
+                <constraint firstItem="lwC-KQ-hCX" firstAttribute="leading" secondItem="BIa-h9-yIu" secondAttribute="leading" id="qm0-wk-9wr"/>
                 <constraint firstItem="D1e-rS-9fu" firstAttribute="top" secondItem="N94-SY-H14" secondAttribute="top" id="s3l-bR-jjR"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -8,16 +8,17 @@ struct MatchViewModel {
 
     let redAlliance: [String]
     let redScore: String?
-    let redRP: String?
 
     let blueAlliance: [String]
     let blueScore: String?
-    let blueRP: String?
 
     let timeString: String
 
     let redAllianceWon: Bool
     let blueAllianceWon: Bool
+    
+    let redRPString: String
+    let blueRPString: String
 
     let baseTeamKey: String?
 
@@ -30,11 +31,9 @@ struct MatchViewModel {
 
         redAlliance = match.redAllianceTeamNumbers
         redScore = match.redAlliance?.score?.stringValue
-        redRP = "••"
 
         blueAlliance = match.blueAllianceTeamNumbers
         blueScore = match.blueAlliance?.score?.stringValue
-        blueRP = "••"
 
         timeString = match.timeString ?? "No Time Yet"
 
@@ -48,6 +47,19 @@ struct MatchViewModel {
             }
             return true
         }()
+        
+        // Set RP things, specifically for 2018
+        // Other years can use a similar pattern
+        redRPString = {
+            var tempString: String = ""
+            if match.year == 2018 {
+                tempString += "•"
+            }
+            return tempString
+        }()
+
+//        redRPString = "••"
+        blueRPString = "••"
 
         redAllianceWon = hasWinnersAndLosers && match.winningAlliance == "red"
         blueAllianceWon = hasWinnersAndLosers && match.winningAlliance == "blue"

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -8,11 +8,11 @@ struct MatchViewModel {
 
     let redAlliance: [String]
     let redScore: String?
-    let redRP: String
+    let redRP: String?
 
     let blueAlliance: [String]
     let blueScore: String?
-    let blueRP: String
+    let blueRP: String?
 
     let timeString: String
 

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -50,17 +50,26 @@ struct MatchViewModel {
         
         // Set RP things, specifically for 2018
         // Other years can use a similar pattern
-        redRPString = {
-            var tempString: String = ""
-            if match.year == 2018 {
-                tempString += "•"
-                tempString += "•"
-            }
-            return tempString
-        }()
+        if match.year == 2018 {
+            redRPString = {
+                guard var redBreakdown = match.breakdown?["red"] as? [String: Any] else { return "" }
+                var rpString: String = ""
+                rpString += (redBreakdown["autoQuestRankingPoint"] as! Bool ? "•" : "")
+                rpString += (redBreakdown["faceTheBossRankingPoint"] as! Bool ? "•" : "")
+                return rpString
+            }()
 
-//        redRPString = "••"
-        blueRPString = "••"
+            blueRPString = {
+                guard var blueBreakdown = match.breakdown?["blue"] as? [String: Any] else { return "" }
+                var rpString: String = ""
+                rpString += (blueBreakdown["autoQuestRankingPoint"] as! Bool ? "•" : "")
+                rpString += (blueBreakdown["faceTheBossRankingPoint"] as! Bool ? "•" : "")
+                return rpString
+            }()
+        } else {
+            redRPString = ""
+            blueRPString = ""
+        }
 
         redAllianceWon = hasWinnersAndLosers && match.winningAlliance == "red"
         blueAllianceWon = hasWinnersAndLosers && match.winningAlliance == "blue"
@@ -71,5 +80,4 @@ struct MatchViewModel {
     var hasScores: Bool {
         return blueScore != nil && redScore != nil
     }
-
 }

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -8,9 +8,11 @@ struct MatchViewModel {
 
     let redAlliance: [String]
     let redScore: String?
+    let redRP: String
 
     let blueAlliance: [String]
     let blueScore: String?
+    let blueRP: String
 
     let timeString: String
 
@@ -28,9 +30,11 @@ struct MatchViewModel {
 
         redAlliance = match.redAllianceTeamNumbers
         redScore = match.redAlliance?.score?.stringValue
+        redRP = "•"
 
         blueAlliance = match.blueAllianceTeamNumbers
         blueScore = match.blueAlliance?.score?.stringValue
+        blueRP = "•"
 
         timeString = match.timeString ?? "No Time Yet"
 

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -54,6 +54,7 @@ struct MatchViewModel {
             var tempString: String = ""
             if match.year == 2018 {
                 tempString += "•"
+                tempString += "•"
             }
             return tempString
         }()

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -30,11 +30,11 @@ struct MatchViewModel {
 
         redAlliance = match.redAllianceTeamNumbers
         redScore = match.redAlliance?.score?.stringValue
-        redRP = "•"
+        redRP = "••"
 
         blueAlliance = match.blueAllianceTeamNumbers
         blueScore = match.blueAlliance?.score?.stringValue
-        blueRP = "•"
+        blueRP = "••"
 
         timeString = match.timeString ?? "No Time Yet"
 


### PR DESCRIPTION
This PR adds in RP dots to the score listings.

There was some concern in the original issue ( #126 ) about parsing the JSON on-the-fly, so that's something we might want to at least look at on an actual device.  Locally, on my emulator, it doesn't appear to have changed the render time, but I feel like that's hard to measure.

This closes #126 