### PR TITLE
fix "View photos on Chief Delphi" for TeamInfo and EventInfo

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventInfoViewController.swift
@@ -208,7 +208,7 @@ class EventInfoViewController: TBATableViewController, Observable {
             case EventLinkRow.youtube.rawValue:
                 urlString = "https://www.youtube.com/results?search_query=\(event.key!)"
             case EventLinkRow.chiefDelphi.rawValue:
-                urlString = "http://www.chiefdelphi.com/media/photos/tags/\(event.key!)"
+                urlString = "https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A\(event.key!)"
             default:
                 break
             }

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamInfoViewController.swift
@@ -162,7 +162,7 @@ class TeamInfoViewController: TBATableViewController {
             case TeamLinkRow.youtube.rawValue:
                 urlString = "https://www.youtube.com/results?search_query=\(team.key!)"
             case TeamLinkRow.chiefDelphi.rawValue:
-                urlString = "http://www.chiefdelphi.com/media/photos/tags/\(team.key!)"
+                urlString = "https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A\(team.key!)"
             default:
                 break
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes to new CD search queries for team / event media

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/419

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used the simulator to go to Team 1's info page, then tapped "View photos on Chief Delphi".
I used the simulator to go to 2012 Einstein Field's info page, then tapped "View photos on Chief Delphi".

## Screenshots

https://imgur.com/a/hV8O3aY