### PR TITLE
Add log events for container views

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import Firebase
 import Foundation
 import UIKit
 
@@ -48,6 +49,12 @@ class DistrictViewController: ContainerViewController {
         super.viewDidLoad()
 
         navigationController?.setupSplitViewLeftBarButtonItem(viewController: self)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("district", parameters: ["district": district.key!])
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -1,5 +1,6 @@
-import Foundation
 import CoreData
+import Firebase
+import Foundation
 import UIKit
 
 class TeamAtDistrictViewController: ContainerViewController {
@@ -33,6 +34,14 @@ class TeamAtDistrictViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("team_at_district", parameters: ["district": ranking.district!.key!, "team": ranking.teamKey!.key!])
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import Firebase
 import Foundation
 import UIKit
 
@@ -43,6 +44,14 @@ class DistrictsContainerViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("districts", parameters: nil)
     }
 
     // MARK: - Private Methods

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAlliancesViewController.swift
@@ -1,6 +1,7 @@
+import CoreData
+import Firebase
 import Foundation
 import UIKit
-import CoreData
 
 class EventAlliancesContainerViewController: ContainerViewController {
 
@@ -29,6 +30,14 @@ class EventAlliancesContainerViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("event_alliances", parameters: ["event": event.key!])
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import Firebase
 import UIKit
 
 class EventAwardsContainerViewController: ContainerViewController {
@@ -36,6 +37,20 @@ class EventAwardsContainerViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        var parameters = [
+            "event": self.event.key!,
+            ]
+        if let teamKey = teamKey {
+            parameters["team"] = teamKey.key!
+        }
+        Analytics.logEvent("event_awards", parameters: parameters)
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
@@ -1,5 +1,6 @@
-import UIKit
 import CoreData
+import Firebase
+import UIKit
 
 // TODO: Eventually, this will be redundant, and will go away
 class EventDistrictPointsContainerViewController: ContainerViewController {
@@ -27,6 +28,14 @@ class EventDistrictPointsContainerViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("event_district_points", parameters: ["event": event.key!])
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import Firebase
 import UIKit
 
 class EventViewController: MyTBAContainerViewController, EventStatusSubscribable {
@@ -56,6 +57,12 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
             showOfflineEventMessage(shouldShow: true, animated: false)
         }
         registerForEventStatusChanges(eventKey: event.key!)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("event", parameters: ["event": event.key!])
     }
 
     // MARK: - Interface Methods

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsContainerViewController.swift
@@ -1,5 +1,6 @@
-import Foundation
 import CoreData
+import Firebase
+import Foundation
 import UIKit
 
 class EventStatsContainerViewController: ContainerViewController {
@@ -45,6 +46,14 @@ class EventStatsContainerViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("event_stats", parameters: ["event": event.key!])
     }
 
     // MARK: - Interface Actions

--- a/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
@@ -1,6 +1,7 @@
+import CoreData
+import Firebase
 import Foundation
 import UIKit
-import CoreData
 
 class EventsContainerViewController: ContainerViewController {
 
@@ -38,6 +39,14 @@ class EventsContainerViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Methods
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("events", parameters: ["year": NSNumber(value: year)])
     }
 
     // MARK: - Private Methods

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import Firebase
 import Foundation
 import UIKit
 
@@ -9,6 +10,7 @@ protocol YearSelectViewControllerDelegate: AnyObject {
 class YearSelectViewController: ContainerViewController {
 
     private(set) var year: Int
+    private(set) var years: [Int]
     private(set) var week: Event?
 
     private let selectViewController: SelectTableViewController<YearSelectViewController>
@@ -24,6 +26,7 @@ class YearSelectViewController: ContainerViewController {
 
     init(year: Int, years: [Int], week: Event?, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.year = year
+        self.years = years
         self.week = week
 
         selectViewController = SelectTableViewController<YearSelectViewController>(current: year, options: years, willPush: true, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
@@ -52,6 +55,16 @@ class YearSelectViewController: ContainerViewController {
         eventWeekSelectViewController?.delegate = delegate
 
         navigationController?.viewControllers = [self, eventWeekSelectViewController!]
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        var parameters = ["year": NSNumber(value: year), "years": NSArray(array: years)]
+        if let week = week {
+            parameters["week"] = NSString(string: week.key!)
+        }
+        Analytics.logEvent("year_select", parameters: parameters)
     }
 
     // MARK: - Private Methods

--- a/the-blue-alliance-ios/View Controllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import Firebase
 import Foundation
 import UIKit
 
@@ -41,6 +42,14 @@ class MatchViewController: MyTBAContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("match", parameters: ["match": match.key!])
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -1,3 +1,4 @@
+import Firebase
 import Foundation
 import CoreData
 import UIKit
@@ -35,6 +36,14 @@ class TeamAtEventViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("team_at_event", parameters: ["event": event.key!, "team": teamKey.key!])
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamViewController.swift
@@ -1,5 +1,6 @@
 import BFRImageViewer
 import CoreData
+import Firebase
 import Photos
 import UIKit
 
@@ -87,6 +88,12 @@ class TeamViewController: MyTBAContainerViewController, Observable {
         }
 
         refreshYearsParticipated()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("team", parameters: ["team": team.key!])
     }
 
     // MARK: - Private

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import Firebase
 import Foundation
 import UIKit
 
@@ -32,6 +33,14 @@ class TeamsContainerViewController: ContainerViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        Analytics.logEvent("teams", parameters: nil)
     }
 
 }


### PR DESCRIPTION
In an attempt to track down the illusive Team@Event AwardRecipient crash, we're going to add some logging so we can figure out what team/event users are looking at when they're experiencing a crash.