### PR TITLE
Remove team motto from Team view

### DIFF
--- a/the-blue-alliance-ios/View Elements/Info/InfoCellViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Info/InfoCellViewModel.swift
@@ -12,7 +12,7 @@ struct InfoCellViewModel {
 
     init(team: Team) {
         nameString = team.nickname ?? team.fallbackNickname
-        subtitleStrings = [team.locationString, team.motto].compactMap({ $0 })
+        subtitleStrings = [team.locationString].compactMap({ $0 })
     }
 
 }


### PR DESCRIPTION
Remove team motto from the Team view, since we're moving away from supporting Team mottos. Eventually we can drop this from the data model.