### PR TITLE
Remove validation to allow empty AwardRecipient objects

### DIFF
--- a/tba-unit-tests/Core Data/Award/AwardRecipientTests.swift
+++ b/tba-unit-tests/Core Data/Award/AwardRecipientTests.swift
@@ -79,6 +79,16 @@ class AwardRecipientTestCase: AwardTestCase {
         XCTAssertThrowsError(try persistentContainer.viewContext.save())
     }
 
+    func test_insert_none() {
+        let modelRecipient = TBAAwardRecipient(teamKey: nil, awardee: nil)
+        let recipient = AwardRecipient.insert(modelRecipient, in: persistentContainer.viewContext)
+
+        XCTAssertNil(recipient.teamKey)
+        XCTAssertNil(recipient.awardee)
+
+        XCTAssertThrowsError(try persistentContainer.viewContext.save())
+    }
+
     func test_update_awardee() {
         let modelRecipient = TBAAwardRecipient(awardee: "Zachary Orr")
         let recipientOne = AwardRecipient.insert(modelRecipient, in: persistentContainer.viewContext)
@@ -181,6 +191,12 @@ class AwardRecipientTestCase: AwardTestCase {
         team.nickname = "The Rawrbotz"
 
         XCTAssertEqual(recipient.awardText, ["Team 7332", "The Rawrbotz"])
+    }
+
+    func test_awardText_none() {
+        let modelRecipient = TBAAwardRecipient(teamKey: nil, awardee: nil)
+        let recipient = AwardRecipient.insert(modelRecipient, in: persistentContainer.viewContext)
+        XCTAssertEqual(recipient.awardText, ["--"])
     }
 
 }

--- a/the-blue-alliance-ios/Core Data/Award/AwardRecipient.swift
+++ b/the-blue-alliance-ios/Core Data/Award/AwardRecipient.swift
@@ -23,6 +23,8 @@ extension AwardRecipient {
             }
         } else if let awardee = awardee {
             awardText.append(awardee)
+        } else {
+            awardText.append("--")
         }
         return awardText
     }
@@ -58,7 +60,9 @@ extension AwardRecipient: Managed {
                 return NSPredicate(format: "%K == %@",
                                    #keyPath(AwardRecipient.awardee), awardee)
             } else {
-                fatalError("Award has no info")
+                return NSPredicate(format: "%K == nil AND %K == nil",
+                                   #keyPath(AwardRecipient.awardee),
+                                   #keyPath(AwardRecipient.teamKey.key))
             }
         }
 


### PR DESCRIPTION
iOS-side fix for https://github.com/the-blue-alliance/the-blue-alliance/issues/2399 - we're seeing a lot of crashes where `Award_Recipient` objects coming back from the API have no `team_key` or `awardee`. This allows the creation of an empty `AwardRecipient` object, with neither of those fields populated.

Note: This will be weird because we'll have a bunch of Awards attached to this one null `AwardRecipient`. But maybe it's not weird at all. Maybe it's just quirky, in a kinda cute rom-com leading lady sort of way.