### PR TITLE
Fix team search bar count showing up incorrectly

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -200,10 +200,6 @@ extension TeamsViewController: TableViewDataSourceDelegate {
         cell.viewModel = TeamCellViewModel(team: object)
     }
 
-    func controllerDidChangeContent() {
-        updateInterface()
-    }
-
 }
 
 
@@ -211,6 +207,7 @@ extension TeamsViewController: UISearchResultsUpdating {
 
     public func updateSearchResults(for searchController: UISearchController) {
         updateDataSource()
+        updateInterface()
     }
 
 }


### PR DESCRIPTION
Fixes the count in the search bar placeholder being incorrect in some cases (ex: searching, pushing to a team, going backwards, clearing search text). `controllerDidChangeContent` wasn't being called properly, so our `updateInterface` wasn't being called properly. This adds the `updateInterface` call to the `updateSearchResults` delegate method, which should be cleaner.

Closes #428