### PR TITLE
Fixes team number bolding in match cells, adds DQ strikethrough to match cells

### DIFF
--- a/tba-unit-tests/Core Data/Match/MatchAllianceTests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchAllianceTests.swift
@@ -3,6 +3,20 @@ import XCTest
 
 class MatchAllianceTestCase: CoreDataTestCase {
 
+    func test_teamKeys() {
+        let model = TBAMatchAlliance(score: 200, teams: ["frc1", "frc2"], surrogateTeams: ["frc3", "frc4"], dqTeams: ["frc5", "frc6"])
+        let alliance = MatchAlliance.insert(model, allianceKey: "red", matchKey: "2018miket_f1m1", in: persistentContainer.viewContext)
+        XCTAssertEqual(alliance.teamKeys, ["frc1", "frc2"])
+    }
+
+    func test_dqTeamKeys() {
+        let alliance = MatchAlliance.init(entity: MatchAlliance.entity(), insertInto: persistentContainer.viewContext)
+        alliance.dqTeams = NSOrderedSet(array: ["frc3", "frc2"].map({ (key) -> TeamKey in
+            return TeamKey.insert(withKey: key, in: persistentContainer.viewContext)
+        }))
+        XCTAssertEqual(alliance.dqTeamKeys, ["frc3", "frc2"])
+    }
+
     func test_insert() {
         let matchModel = TBAMatch(key: "2018miket_f1m1", compLevel: "f", setNumber: 1, matchNumber: 1, eventKey: "2018miket")
 

--- a/tba-unit-tests/Core Data/Match/MatchTests.swift
+++ b/tba-unit-tests/Core Data/Match/MatchTests.swift
@@ -8,7 +8,7 @@ class MatchTestCase: CoreDataTestCase {
         XCTAssertEqual(predicate.predicateFormat, "key == \"2018miket_qm1\"")
     }
 
-    func alliance(allianceKey: String) -> MatchAlliance {
+    func alliance(allianceKey: String, dqs: [String]? = nil) -> MatchAlliance {
         let alliance = MatchAlliance(entity: MatchAlliance.entity(), insertInto: persistentContainer.viewContext)
         alliance.allianceKey = allianceKey
         alliance.teams = NSOrderedSet(array: ["frc2337", "frc7332", "frc3333"].map({ (key) -> TeamKey in
@@ -16,6 +16,13 @@ class MatchTestCase: CoreDataTestCase {
             teamKey.key = key
             return teamKey
         }))
+        if let dqs = dqs {
+            alliance.dqTeams = NSOrderedSet(array: dqs.map({ (key) -> TeamKey in
+                let teamKey = TeamKey.init(entity: TeamKey.entity(), insertInto: persistentContainer.viewContext)
+                teamKey.key = key
+                return teamKey
+            }))
+        }
         return alliance
     }
 
@@ -402,6 +409,12 @@ class MatchTestCase: CoreDataTestCase {
         XCTAssertNotNil(match.redAlliance)
     }
 
+    func test_redAllianceTeamKeys() {
+        let match = Match.init(entity: Match.entity(), insertInto: persistentContainer.viewContext)
+        match.alliances = Set([alliance(allianceKey: "red")]) as NSSet
+        XCTAssertEqual(match.redAllianceTeamKeys, ["frc2337", "frc7332", "frc3333"])
+    }
+    
     func test_redAllianceTeamNumbers() {
         let match = Match.init(entity: Match.entity(), insertInto: persistentContainer.viewContext)
         match.alliances = Set([alliance(allianceKey: "red")]) as NSSet
@@ -416,10 +429,22 @@ class MatchTestCase: CoreDataTestCase {
         XCTAssertNotNil(match.blueAlliance)
     }
 
+    func test_blueAllianceTeamKeys() {
+        let match = Match.init(entity: Match.entity(), insertInto: persistentContainer.viewContext)
+        match.alliances = Set([alliance(allianceKey: "blue")]) as NSSet
+        XCTAssertEqual(match.blueAllianceTeamKeys, ["frc2337", "frc7332", "frc3333"])
+    }
+
     func test_blueAllianceTeamNumbers() {
         let match = Match.init(entity: Match.entity(), insertInto: persistentContainer.viewContext)
         match.alliances = Set([alliance(allianceKey: "blue")]) as NSSet
         XCTAssertEqual(match.blueAllianceTeamNumbers, ["2337", "7332", "3333"])
+    }
+
+    func test_dqTeamKeys() {
+        let match = Match.init(entity: Match.entity(), insertInto: persistentContainer.viewContext)
+        match.alliances = Set([alliance(allianceKey: "blue", dqs: ["frc7332"])]) as NSSet
+        XCTAssertEqual(match.dqTeamKeys, ["frc7332"])
     }
 
     func test_friendlyName() {

--- a/the-blue-alliance-ios/Core Data/Match/Match.swift
+++ b/the-blue-alliance-ios/Core Data/Match/Match.swift
@@ -117,10 +117,17 @@ extension Match {
     }
 
     /**
-     Returns the trimmed team keys for the red alliance.
+     Returns the team keys for the red alliance.
+     */
+    var redAllianceTeamKeys: [String] {
+        return redAlliance?.teamKeys ?? []
+    }
+
+    /**
+     Returns the team numbers (trimmed team keys) for the red alliance.
      */
     var redAllianceTeamNumbers: [String] {
-        return (redAlliance?.teams?.array as? [TeamKey])?.map({ Team.trimFRCPrefix($0.key!) }) ?? []
+        return redAllianceTeamKeys.map({ Team.trimFRCPrefix($0) })
     }
 
     /**
@@ -131,10 +138,24 @@ extension Match {
     }
 
     /**
-     Returns the trimmed team keys for the blue alliance.
+     Returns the team keys for the blue alliance.
+     */
+    var blueAllianceTeamKeys: [String] {
+        return blueAlliance?.teamKeys ?? []
+    }
+
+    /**
+     Returns the team numbers (trimmed team keys) for the blue alliance.
      */
     var blueAllianceTeamNumbers: [String] {
-        return (blueAlliance?.teams!.array as? [TeamKey])?.map({ Team.trimFRCPrefix($0.key!) }) ?? []
+        return blueAllianceTeamKeys.map({ Team.trimFRCPrefix($0) })
+    }
+
+    /**
+    Returns the team keys that were DQ'd in this match - not specifically any alliance
+    */
+    var dqTeamKeys: [String] {
+        return (blueAlliance?.dqTeamKeys ?? []) + (redAlliance?.dqTeamKeys ?? [])
     }
 
     private func alliance(with allianceKey: String) -> MatchAlliance? {

--- a/the-blue-alliance-ios/Core Data/Match/MatchAlliance.swift
+++ b/the-blue-alliance-ios/Core Data/Match/MatchAlliance.swift
@@ -4,6 +4,20 @@ import CoreData
 extension MatchAlliance: Managed {
 
     /**
+     Returns team keys for the alliance.
+     */
+    var teamKeys: [String] {
+        return (teams!.array as? [TeamKey])?.map({ $0.key! }) ?? []
+    }
+
+    /**
+     Returns team keys for DQ'd teams for the alliance.
+     */
+    var dqTeamKeys: [String] {
+        return (dqTeams?.array as? [TeamKey])?.map({ $0.key! }) ?? []
+    }
+
+    /**
      Insert a Match Alliance with values from a TBAKit Match Alliance model in to the managed object context.
 
      - Important: This method does not manage setting up a Match Alliance's relationship to a Match.

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
@@ -106,7 +106,7 @@ class MatchSummaryView: UIView {
 
         for (alliance, stackView) in [(viewModel.redAlliance, redStackView!), (viewModel.blueAlliance, blueStackView!)] {
             for teamKey in alliance {
-                let label = teamLabel(for: teamKey, baseTeamKey: viewModel.baseTeamKey)
+                let label = teamLabel(for: teamKey, baseTeamKey: viewModel.baseTeamKey, dq: viewModel.dqs.contains(teamKey))
                 // Insert each new stack view at the index just before the score view
                 stackView.insertArrangedSubview(label, at: stackView.arrangedSubviews.count - 1)
             }
@@ -139,22 +139,31 @@ class MatchSummaryView: UIView {
         }
     }
     
-    private func teamLabel(for teamKey: String, baseTeamKey: String?) -> UILabel {
+    private func teamLabel(for teamKey: String, baseTeamKey: String?, dq: Bool) -> UILabel {
         let text: String = "\(Team.trimFRCPrefix(teamKey))"
         let isBold: Bool = (teamKey == baseTeamKey)
-        
-        return label(text: text, isBold: isBold)
+
+        return label(text: text, isBold: isBold, isStrikethrough: dq)
     }
 
-    private func label(text: String, isBold: Bool) -> UILabel {
-        let label = UILabel()
-        label.text = text
+    private func label(text: String, isBold: Bool, isStrikethrough: Bool = false) -> UILabel {
+        let attributeString =  NSMutableAttributedString(string: text)
+        let attributedStringRange = NSMakeRange(0, attributeString.length)
+
         var font: UIFont = .systemFont(ofSize: 14)
         if isBold {
             font = .boldSystemFont(ofSize: 14)
         }
-        label.font = font
+        attributeString.addAttribute(.font, value: font, range: attributedStringRange)
+
+        if isStrikethrough {
+            attributeString.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: attributedStringRange)
+        }
+
+        let label = UILabel()
         label.textAlignment = .center
+        label.attributedText = attributeString
+
         return label
     }
 

--- a/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchViewModel.swift
@@ -12,6 +12,8 @@ struct MatchViewModel {
     let blueAlliance: [String]
     let blueScore: String?
 
+    let dqs: [String]
+
     let timeString: String
 
     let redAllianceWon: Bool
@@ -29,11 +31,13 @@ struct MatchViewModel {
 
         hasVideos = match.videos?.count == 0
 
-        redAlliance = match.redAllianceTeamNumbers
+        redAlliance = match.redAllianceTeamKeys
         redScore = match.redAlliance?.score?.stringValue
 
-        blueAlliance = match.blueAllianceTeamNumbers
+        blueAlliance = match.blueAllianceTeamKeys
         blueScore = match.blueAlliance?.score?.stringValue
+
+        dqs = match.dqTeamKeys
 
         timeString = match.timeString ?? "No Time Yet"
 


### PR DESCRIPTION
## Description
Fixes team number bolding when viewing a filtered list of matches for a team. Add a striketrhough like the web has for teams that were DQ'd in a match (closes #436)

## Motivation and Context
I attempted to add the DQ feature and realized the bolding was also broken 🤷‍♂️ 

## How Has This Been Tested?
Wrote tests for new Core Data extensions, manually tested cell changes (note: these should get snapshot tests eventually)


## Screenshots

<img width="584" alt="screen shot 2019-02-24 at 12 09 40 pm" src="https://user-images.githubusercontent.com/516458/53302538-121bb400-382d-11e9-9d78-00e9c52fc432.png">