### PR TITLE
Show extraStats/sortInfo in raking cells, show qualAverage in 2015 cells

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 osx_image: xcode10.1
 language: swift
 
+# addons:
+#   artifacts
+#     paths:
+#       - logs
+
 branches:
   only:
     - master

--- a/tba-unit-tests/Core Data/Event/EventRankingTests.swift
+++ b/tba-unit-tests/Core Data/Event/EventRankingTests.swift
@@ -12,7 +12,7 @@ class EventRankingTestCase: CoreDataTestCase {
             TBAEventRankingSortOrder(name: "First Ranking", precision: 0),
             TBAEventRankingSortOrder(name: "Second Raking", precision: 0)
         ]
-        let model = TBAEventRanking(teamKey: "frc1", rank: 2, dq: 10, matchesPlayed: 6, qualAverage: 20, record: TBAWLT(wins: 1, losses: 2, ties: 3), extraStats: [25], sortOrders: [2.08, 530.0, 0.0])
+        let model = TBAEventRanking(teamKey: "frc1", rank: 2, dq: 10, matchesPlayed: 6, qualAverage: 20, record: TBAWLT(wins: 1, losses: 2, ties: 3), extraStats: [25.0, 3], sortOrders: [2.08, 530.0, 3])
         let ranking = EventRanking.insert(model, sortOrderInfo: sortOrderInfo, extraStatsInfo: extraStatsInfo, eventKey: event.key!, in: persistentContainer.viewContext)
 
         XCTAssertEqual(ranking.teamKey?.key, "frc1")
@@ -21,9 +21,9 @@ class EventRankingTestCase: CoreDataTestCase {
         XCTAssertEqual(ranking.matchesPlayed, 6)
         XCTAssertEqual(ranking.qualAverage, 20)
         XCTAssertNotNil(ranking.record)
-        XCTAssertEqual(ranking.tiebreakerValues, [2.08, 530.0, 0.0])
+        XCTAssertEqual(ranking.tiebreakerValues, [2.08, 530.0, 3])
         XCTAssertEqual(ranking.tiebreakerNames, ["Ranking Score", "First Ranking", "Second Raking"])
-        XCTAssertEqual(ranking.extraStatsValues, [25])
+        XCTAssertEqual(ranking.extraStatsValues, [25.0, 3])
         XCTAssertEqual(ranking.extraStatsNames, ["Total Ranking Points"])
 
         // Should throw an error - must be attached to an Event
@@ -66,7 +66,7 @@ class EventRankingTestCase: CoreDataTestCase {
             TBAEventRankingSortOrder(name: "First Ranking", precision: 0),
             TBAEventRankingSortOrder(name: "Second Raking", precision: 0)
         ]
-        let modelOne = TBAEventRanking(teamKey: "frc1", rank: 2, dq: 10, matchesPlayed: 6, qualAverage: 20, record: TBAWLT(wins: 1, losses: 2, ties: 3), extraStats: [25], sortOrders: [2.08, 530.0, 0.0])
+        let modelOne = TBAEventRanking(teamKey: "frc1", rank: 2, dq: 10, matchesPlayed: 6, qualAverage: 20, record: TBAWLT(wins: 1, losses: 2, ties: 3), extraStats: [25, 3.0], sortOrders: [2.08, 530.0, 2])
         let rankingOne = EventRanking.insert(modelOne, sortOrderInfo: sortOrderInfo, extraStatsInfo: extraStatsInfo, eventKey: event.key!, in: persistentContainer.viewContext)
         event.addToRankings(rankingOne)
 
@@ -162,21 +162,45 @@ class EventRankingTestCase: CoreDataTestCase {
 
     func test_tiebreakerInfoString() {
         let ranking = EventRanking.init(entity: EventRanking.entity(), insertInto: persistentContainer.viewContext)
-        XCTAssertNil(ranking.tiebreakerInfoString)
+        XCTAssertNil(ranking.rankingInfoString)
+
+        let extraStatsNames = ["Value 4", "Value 6", "Value 5"]
+        let extraStatsValues: [NSNumber] = [2, 3.0, 49.999]
 
         let tiebreakerNames = ["Value 1", "Value 2", "Value 3"]
-        let tiebreakerValues = [1.00, 2.2, 3.33]
+        let tiebreakerValues: [NSNumber] = [1.00, 2.2, 3.33]
 
         // Needs both keys and values
         ranking.tiebreakerNames = tiebreakerNames
-        XCTAssertNil(ranking.tiebreakerInfoString)
+        XCTAssertNil(ranking.rankingInfoString)
         ranking.tiebreakerNames = nil
 
         ranking.tiebreakerValues = tiebreakerValues
-        XCTAssertNil(ranking.tiebreakerInfoString)
+        XCTAssertNil(ranking.rankingInfoString)
+        ranking.tiebreakerValues = nil
 
+        ranking.extraStatsNames = extraStatsNames
+        XCTAssertNil(ranking.rankingInfoString)
+        ranking.extraStatsNames = nil
+
+        ranking.extraStatsValues = extraStatsValues
+        XCTAssertNil(ranking.rankingInfoString)
+
+        // Only with extra stats
+        ranking.extraStatsNames = extraStatsNames
+        XCTAssertEqual(ranking.rankingInfoString, "Value 4: 2, Value 6: 3, Value 5: 49.999")
+        ranking.extraStatsNames = nil
+        ranking.extraStatsValues = nil
+
+        // Only with tiebreaker info
         ranking.tiebreakerNames = tiebreakerNames
-        XCTAssertEqual(ranking.tiebreakerInfoString, "Value 1: 1.0, Value 2: 2.2, Value 3: 3.33")
+        ranking.tiebreakerValues = tiebreakerValues
+        XCTAssertEqual(ranking.rankingInfoString, "Value 1: 1, Value 2: 2.2, Value 3: 3.33")
+
+        // Show with both
+        ranking.extraStatsNames = extraStatsNames
+        ranking.extraStatsValues = extraStatsValues
+        XCTAssertEqual(ranking.rankingInfoString, "Value 4: 2, Value 6: 3, Value 5: 49.999, Value 1: 1, Value 2: 2.2, Value 3: 3.33")
     }
 
 }

--- a/the-blue-alliance-ios/Core Data/Event/EventRanking.swift
+++ b/the-blue-alliance-ios/Core Data/Event/EventRanking.swift
@@ -3,17 +3,22 @@ import CoreData
 
 extension EventRanking: Managed {
 
-    /// Description for an EventRanking's sortOrders (tiebreaker names/values) as a comma separated string.
-    var tiebreakerInfoString: String? {
+    /// Description for an EventRanking's extraStats/sortOrders (ranking/tiebreaker names/values) as a comma separated string.
+    var rankingInfoString: String? {
         get {
-            if let tiebreakerValues = tiebreakerValues, !tiebreakerValues.isEmpty, let tiebreakerNames = tiebreakerNames, !tiebreakerNames.isEmpty {
-                var infoParts: [String] = []
-                for (sortOrderName, sortOrderValue) in zip(tiebreakerNames, tiebreakerValues) {
-                    infoParts.append("\(sortOrderName): \(sortOrderValue)")
+            let rankingInformation: [([String]?, [NSNumber]?)] = [(extraStatsNames, extraStatsValues), (tiebreakerNames, tiebreakerValues)]
+            var rankingInfoStringParts: [String] = []
+            for (names, values) in rankingInformation {
+                guard let names = names, !names.isEmpty, let values = values, !values.isEmpty else {
+                    continue
                 }
-                return infoParts.joined(separator: ", ")
+                var infoParts: [String] = []
+                for (name, value) in zip(names, values) {
+                    infoParts.append("\(name): \(value)")
+                }
+                rankingInfoStringParts.append(infoParts.joined(separator: ", "))
             }
-            return nil
+            return rankingInfoStringParts.isEmpty ? nil : rankingInfoStringParts.joined(separator: ", ")
         }
     }
 
@@ -44,6 +49,7 @@ extension EventRanking: Managed {
             }
 
             if let sortOrderInfo = sortOrderInfo {
+                // Note: We get rid of precision, because... we probably don't need it
                 let tiebreakerNames = sortOrderInfo.map { $0.name }
                 if !tiebreakerNames.isEmpty {
                     ranking.tiebreakerNames = tiebreakerNames
@@ -60,6 +66,7 @@ extension EventRanking: Managed {
             }
 
             if let extraStatsInfo = extraStatsInfo {
+                // Note: We get rid of precision, because... we probably don't need it
                 let extraStatsNames = extraStatsInfo.map { $0.name }
                 if !extraStatsNames.isEmpty {
                     ranking.extraStatsNames = extraStatsNames

--- a/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
+++ b/the-blue-alliance-ios/Core Data/TBA.xcdatamodeld/TBA.xcdatamodel/contents
@@ -113,13 +113,13 @@
     <entity name="EventRanking" representedClassName="EventRanking" syncable="YES" codeGenerationType="class">
         <attribute name="dq" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="extraStatsNames" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
-        <attribute name="extraStatsValues" optional="YES" attributeType="Transformable" customClassName="[Int]" syncable="YES"/>
+        <attribute name="extraStatsValues" optional="YES" attributeType="Transformable" customClassName="[NSNumber]" syncable="YES"/>
         <attribute name="matchesPlayed" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="qualAverage" optional="YES" attributeType="Double" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="rank" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="record" optional="YES" attributeType="Transformable" customClassName="WLT" syncable="YES"/>
         <attribute name="tiebreakerNames" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
-        <attribute name="tiebreakerValues" optional="YES" attributeType="Transformable" customClassName="[Double]" syncable="YES"/>
+        <attribute name="tiebreakerValues" optional="YES" attributeType="Transformable" customClassName="[NSNumber]" syncable="YES"/>
         <relationship name="event" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="rankings" inverseEntity="Event" syncable="YES"/>
         <relationship name="qualStatus" optional="YES" maxCount="1" deletionRule="Deny" destinationEntity="EventStatusQual" inverseName="ranking" inverseEntity="EventStatusQual" syncable="YES"/>
         <relationship name="teamKey" maxCount="1" deletionRule="Nullify" destinationEntity="TeamKey" inverseName="eventRankings" inverseEntity="TeamKey" syncable="YES"/>

--- a/the-blue-alliance-ios/Frameworks/TBAKit/Sources/TBAEvent.swift
+++ b/the-blue-alliance-ios/Frameworks/TBAKit/Sources/TBAEvent.swift
@@ -370,10 +370,10 @@ public struct TBAEventRanking: TBAModel {
     public var matchesPlayed: Int?
     public var qualAverage: Double?
     public var record: TBAWLT?
-    public var extraStats: [Int]?
-    public var sortOrders: [Double]?
+    public var extraStats: [NSNumber]?
+    public var sortOrders: [NSNumber]?
 
-    public init(teamKey: String, rank: Int, dq: Int? = nil, matchesPlayed: Int? = nil, qualAverage: Double? = nil, record: TBAWLT? = nil, extraStats: [Int]? = nil, sortOrders: [Double]? = nil) {
+    public init(teamKey: String, rank: Int, dq: Int? = nil, matchesPlayed: Int? = nil, qualAverage: Double? = nil, record: TBAWLT? = nil, extraStats: [NSNumber]? = nil, sortOrders: [NSNumber]? = nil) {
         self.teamKey = teamKey
         self.rank = rank
         self.dq = dq
@@ -404,8 +404,8 @@ public struct TBAEventRanking: TBAModel {
             self.record = TBAWLT(json: recordJSON)
         }
 
-        self.extraStats = json["extra_stats"] as? [Int]
-        self.sortOrders = json["sort_orders"] as? [Double]
+        self.extraStats = json["extra_stats"] as? [NSNumber]
+        self.sortOrders = json["sort_orders"] as? [NSNumber]
     }
     
 }

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -14,7 +14,7 @@ private enum TeamSummaryRow {
     case record(wlt: WLT) // don't show record for 2015, because no wins
     case alliance(allianceStatus: String)
     case status(overallStatus: String)
-    case breakdown(tiebreakerInfo: String)
+    case breakdown(rankingInfo: String)
     case nextMatchKey(key: String)
     case nextMatch(match: Match)
     case lastMatchKey(key: String)
@@ -89,8 +89,8 @@ class TeamSummaryViewController: TBATableViewController {
         }
 
         // Breakdown
-        if let tiebreakerInfo = eventStatus?.qual?.ranking?.tiebreakerInfoString {
-            summaryRows.append(TeamSummaryRow.breakdown(tiebreakerInfo: tiebreakerInfo))
+        if let rankingInfo = eventStatus?.qual?.ranking?.rankingInfoString {
+            summaryRows.append(TeamSummaryRow.breakdown(rankingInfo: rankingInfo))
         }
 
         // From here on, we only show this data if the event is currently happening

--- a/the-blue-alliance-ios/View Elements/Events/RankingCellViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Events/RankingCellViewModel.swift
@@ -37,14 +37,20 @@ struct RankingCellViewModel {
         teamName = eventRanking.teamKey!.team?.nickname ?? eventRanking.teamKey!.name
 
         detailText = {
-            if let qualAverage = eventRanking.qualAverage {
-                return "Avg. \(qualAverage.doubleValue) Points"
-            } else if let tiebreakerInfoString = eventRanking.tiebreakerInfoString {
-                return tiebreakerInfoString
+            if let rankingInfoString = eventRanking.rankingInfoString {
+                return rankingInfoString
             }
             return nil
         }()
-        wltText = eventRanking.record?.displayString()
+
+        wltText = {
+            // Show qualAverage - WLT otherwise
+            if let qualAverage = eventRanking.qualAverage {
+                return qualAverage.stringValue
+            } else {
+                return eventRanking.record?.displayString()
+            }
+        }()
     }
 
     init(eventTeamStat: EventTeamStat) {


### PR DESCRIPTION
Show `extraStats`/`sortInfo` in `rankingInfoString` in ranking cell (helpful because we'll show RP). Additionally for the 2015 cells, add the qualAverage where WLT would be so it's scanable(ish)

<img width="632" alt="Screen Shot 2019-03-09 at 9 40 26 PM" src="https://user-images.githubusercontent.com/516458/54079937-2099af00-42b4-11e9-9929-c6b1f05a96c5.png">
<img width="632" alt="Screen Shot 2019-03-09 at 9 40 45 PM" src="https://user-images.githubusercontent.com/516458/54079940-28595380-42b4-11e9-869f-6856ce608d3f.png">
<img width="632" alt="Screen Shot 2019-03-09 at 9 41 10 PM" src="https://user-images.githubusercontent.com/516458/54079941-298a8080-42b4-11e9-842b-e8b43bb6e503.png">
