### PR TITLE
Fix second curtain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ jobs:
 
 after_failure:
   - gem install second_curtain
-  - cat build/reports/tba-unit-tests-tba-unit-tests.log | bundle exec second_curtain > /dev/null
+  - cat build/reports/tba-unit-tests-tba-unit-tests.log | second_curtain > /dev/null


### PR DESCRIPTION
Second curtain isn't uploading snapshot test diffs because we're installing it globally and trying to run it via bundler.