### PR TITLE
Fix TeamSummaryViewController never being deallocated

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -45,8 +45,8 @@ class TeamSummaryViewController: TBATableViewController {
                     self?.tableView.reloadData()
                 }
 
-                contextObserver.observeObject(object: eventStatus, state: .updated) { (_, _) in
-                    DispatchQueue.main.async { [weak self] in
+                contextObserver.observeObject(object: eventStatus, state: .updated) { [weak self] (_, _) in
+                    DispatchQueue.main.async {
                         self?.tableView.reloadData()
                     }
                 }


### PR DESCRIPTION
`TeamSummaryViewController` was never being deallocated because of a retain cycle with it's `contextObserver`. This should fix that.

<img width="2070" alt="Screen Shot 2019-05-08 at 5 13 22 PM" src="https://user-images.githubusercontent.com/516458/57410455-d439f500-71b8-11e9-9b07-f71415602496.png">
