### PR TITLE
Process collection view section updates, only update views when visible, modify team media refresh

### DIFF
--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -45,6 +45,8 @@ protocol Refreshable: AnyObject {
     func refresh()
 
     func updateRefresh()
+
+    func hideNoData()
     func noDataReload()
 }
 
@@ -135,9 +137,8 @@ extension Refreshable {
     @discardableResult
     func addRefreshOperations(_ operations: [Operation]) -> Operation? {
         // Create an operation to update our refresh indicator - should happen last.
-        let updateRefreshOperation = BlockOperation { [weak self] in
-            self?.updateRefresh()
-            self?.noDataReload()
+        let updateRefreshOperation = BlockOperation {
+            self.updateRefresh()
         }
         for op in operations {
             updateRefreshOperation.addDependency(op)
@@ -158,7 +159,6 @@ extension Refreshable {
 
         refreshOperationQueue.cancelAllOperations()
         updateRefresh()
-        noDataReload()
     }
 
     /**
@@ -167,11 +167,15 @@ extension Refreshable {
     func updateRefresh() {
         DispatchQueue.main.async {
             if self.isRefreshing {
+                self.hideNoData()
+
                 let refreshControlHeight = self.refreshControl?.frame.size.height ?? 0
                 self.refreshView.setContentOffset(CGPoint(x: 0, y: -refreshControlHeight), animated: true)
                 self.refreshControl?.beginRefreshing()
             } else {
                 self.refreshControl?.endRefreshing()
+
+                self.noDataReload()
             }
         }
     }

--- a/the-blue-alliance-ios/Protocols/Stateful.swift
+++ b/the-blue-alliance-ios/Protocols/Stateful.swift
@@ -20,6 +20,17 @@ protocol Stateful: AnyObject {
     func removeNoDataView(_ noDataView: UIView)
 }
 
+extension Stateful {
+
+    /**
+     Remove the no data view from the view hiearchy.
+     */
+    func removeNoDataView() {
+        removeNoDataView(noDataViewController.view)
+    }
+
+}
+
 extension Stateful where Self: Refreshable {
 
     /**
@@ -45,13 +56,6 @@ extension Stateful where Self: Refreshable {
         UIView.animate(withDuration: 0.25, animations: {
             noDataView.alpha = 1.0
         })
-    }
-
-    /**
-     Remove the no data view from the view hiearchy.
-     */
-    func removeNoDataView() {
-        removeNoDataView(noDataViewController.view)
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Base/Containers/ContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Containers/ContainerViewController.swift
@@ -243,6 +243,12 @@ class ContainerViewController: UIViewController, Persistable, Alertable {
             let shouldHide = !(containedView == showView)
             if !shouldHide {
                 let refreshViewController = viewControllers[index]
+
+                // Reload our view on subsequent appears, since we don't process table view updates in the background.
+                // This can mean our view state falls out of sync with our data state while backgrounded.
+                // Kickoff a reload to make sure our states match up.
+                reloadViewController(refreshViewController)
+
                 if refreshViewController.shouldRefresh() {
                     refreshViewController.refresh()
                 }
@@ -251,6 +257,16 @@ class ContainerViewController: UIViewController, Persistable, Alertable {
             containedView.isHidden = shouldHide
         }
         switchedToIndex(switchedIndex)
+    }
+
+    private func reloadViewController(_ viewController: UIViewController) {
+        if let viewController = viewController as? TBAViewController {
+            viewController.reloadData()
+        } else if let viewController = viewController as? UITableViewController {
+            viewController.tableView.reloadData()
+        } else if let viewController = viewController as? UICollectionViewController {
+            viewController.collectionView.reloadData()
+        }
     }
 
     private func cancelRefreshes() {

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
@@ -10,6 +10,8 @@ protocol TableViewDataSourceDelegate: class {
 
     var tableView: UITableView! { get }
 
+    var shouldProcessUpdates: Bool { get }
+
     func configure(_ cell: Cell, for object: Object, at indexPath: IndexPath)
     func title(for section: Int) -> String?
     func controllerDidChangeContent()
@@ -72,6 +74,9 @@ class TableViewDataSource<Result: NSFetchRequestResult, Delegate: TableViewDataS
     fileprivate func processUpdates(sections sectionUpdates: [SectionUpdate]?, rows rowUpdates: [RowUpdate<Object>]?) {
         guard let sectionUpdates = sectionUpdates else { return delegate.tableView.reloadData() }
         guard let rowUpdates = rowUpdates else { return delegate.tableView.reloadData() }
+        if sectionUpdates.isEmpty, rowUpdates.isEmpty {
+            return
+        }
         delegate.tableView.performBatchUpdates({
             for update in sectionUpdates {
                 switch update {
@@ -175,8 +180,10 @@ class TableViewDataSource<Result: NSFetchRequestResult, Delegate: TableViewDataS
     }
 
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        processUpdates(sections: sectionUpdates, rows: rowUpdates)
-        delegate.controllerDidChangeContent()
+        if delegate.shouldProcessUpdates {
+            processUpdates(sections: sectionUpdates, rows: rowUpdates)
+            delegate.controllerDidChangeContent()
+        }
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBACollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBACollectionViewController.swift
@@ -41,6 +41,33 @@ class TBACollectionViewController: UICollectionViewController, DataController {
         collectionView.registerReusableCell(BasicCollectionViewCell.self)
     }
 
+    // MARK: - TableViewDataSourceDelegate
+
+    var shouldProcessUpdates: Bool {
+        // Don't update our interface if we're in the background
+
+        // Only respond to updates if we're the selected element in the tab bar
+        guard let selectedViewController = tabBarController?.selectedViewController else {
+            return false
+        }
+        guard let navigationController = navigationController else {
+            return false
+        }
+        guard selectedViewController == navigationController else {
+            return false
+        }
+
+        // Only respond to updates if we're the top item in the navigation stack
+        if let topViewController = navigationController.topViewController {
+            if let parent = parent, topViewController == parent {
+                return true
+            } else if topViewController == self {
+                return true
+            }
+        }
+        return false
+    }
+
 }
 
 extension Refreshable where Self: TBACollectionViewController {
@@ -58,10 +85,12 @@ extension Refreshable where Self: TBACollectionViewController {
         return collectionView
     }
 
+    func hideNoData() {
+        // Does not conform to Stateful - probably no no data view
+    }
+
     func noDataReload() {
-        DispatchQueue.main.async {
-            self.collectionView.reloadData()
-        }
+        // Does not conform to Stateful - probably no no data view
     }
 
 }
@@ -77,6 +106,22 @@ extension Stateful where Self: TBACollectionViewController {
     func removeNoDataView(_ view: UIView) {
         DispatchQueue.main.async {
             self.collectionView.backgroundView = nil
+        }
+    }
+
+}
+
+extension Refreshable where Self: TBACollectionViewController & Stateful {
+
+    func hideNoData() {
+        removeNoDataView()
+    }
+
+    func noDataReload() {
+        if isDataSourceEmpty {
+            showNoDataView()
+        } else {
+            removeNoDataView()
         }
     }
 

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBATableViewController.swift
@@ -54,6 +54,33 @@ class TBATableViewController: UITableViewController, DataController {
         }
     }
 
+    // MARK: - TableViewDataSourceDelegate
+
+    var shouldProcessUpdates: Bool {
+        // Don't update our interface if we're in the background
+
+        // Only respond to updates if we're the selected element in the tab bar
+        guard let selectedViewController = tabBarController?.selectedViewController else {
+            return false
+        }
+        guard let navigationController = navigationController else {
+            return false
+        }
+        guard selectedViewController == navigationController else {
+            return false
+        }
+
+        // Only respond to updates if we're the top item in the navigation stack
+        if let topViewController = navigationController.topViewController {
+            if let parent = parent, topViewController == parent {
+                return true
+            } else if topViewController == self {
+                return true
+            }
+        }
+        return false
+    }
+
 }
 
 extension Refreshable where Self: TBATableViewController {
@@ -71,10 +98,12 @@ extension Refreshable where Self: TBATableViewController {
         return tableView
     }
 
+    func hideNoData() {
+        // Does not conform to Stateful - probably no no data view
+    }
+
     func noDataReload() {
-        DispatchQueue.main.async {
-            self.tableView.reloadData()
-        }
+        // Does not conform to Stateful - probably no no data view
     }
 
 }
@@ -90,6 +119,22 @@ extension Stateful where Self: TBATableViewController {
     func removeNoDataView(_ noDataView: UIView) {
         DispatchQueue.main.async {
             self.tableView.backgroundView = nil
+        }
+    }
+
+}
+
+extension Refreshable where Self: TBATableViewController & Stateful {
+
+    func hideNoData() {
+        removeNoDataView()
+    }
+
+    func noDataReload() {
+        if isDataSourceEmpty {
+            showNoDataView()
+        } else {
+            removeNoDataView()
         }
     }
 

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAViewController.swift
@@ -72,11 +72,12 @@ extension Refreshable where Self: TBAViewController {
         return scrollView
     }
 
+    func hideNoData() {
+        // Does not conform to Stateful - probably no no data view
+    }
+
     func noDataReload() {
-        // TODO: https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/133
-        DispatchQueue.main.async {
-            self.reloadData()
-        }
+        // Does not conform to Stateful - probably no no data view
     }
 
 }
@@ -93,6 +94,22 @@ extension Stateful where Self: TBAViewController {
     func removeNoDataView(_ noDataView: UIView) {
         DispatchQueue.main.async {
             noDataView.removeFromSuperview()
+        }
+    }
+
+}
+
+extension Refreshable where Self: TBAViewController & Stateful {
+
+    func hideNoData() {
+        removeNoDataView()
+    }
+
+    func noDataReload() {
+        if isDataSourceEmpty {
+            showNoDataView()
+        } else {
+            removeNoDataView()
         }
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictEventsViewController.swift
@@ -35,8 +35,6 @@ class DistrictEventsViewController: EventsViewController {
     }
 
     @objc override func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchDistrictEvents(key: district.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictRankingsViewController.swift
@@ -86,8 +86,6 @@ extension DistrictRankingsViewController: Refreshable {
 
     // TODO: Think about building a way to "chain" requests together for a refresh...
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchDistrictRankings(key: district.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictTeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictTeamsViewController.swift
@@ -37,8 +37,6 @@ class DistrictTeamsViewController: TeamsViewController {
     }
 
     @objc override func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchDistrictTeams(key: district.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
@@ -121,8 +121,6 @@ extension DistrictBreakdownViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchDistrictRankings(key: ranking.district!.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
@@ -96,8 +96,6 @@ extension DistrictsViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchDistricts(year: year, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAlliancesViewController.swift
@@ -148,8 +148,6 @@ extension EventAlliancesViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEventAlliances(key: event.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
@@ -164,8 +164,6 @@ extension EventAwardsViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEventAwards(key: event.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
@@ -137,8 +137,6 @@ extension EventDistrictPointsViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         let eventKey = event.key!
 
         var operation: TBAKitOperation!

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventRankingsViewController.swift
@@ -85,8 +85,6 @@ extension EventRankingsViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEventRankings(key: event.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventTeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventTeamsViewController.swift
@@ -35,8 +35,6 @@ class EventTeamsViewController: TeamsViewController {
     }
 
     @objc override func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEventTeams(key: event.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsViewController.swift
@@ -69,8 +69,6 @@ extension EventStatsViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEventInsights(key: event.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -129,8 +129,6 @@ extension EventTeamStatsTableViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEventTeamStats(key: event.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -57,8 +57,6 @@ class WeekEventsViewController: EventsViewController {
     }
 
     @objc override func refresh() {
-        removeNoDataView()
-
         // Default to refreshing the currently selected year
         // Fall back to the init'd year (used during initial refresh)
         var year = self.year

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -178,8 +178,6 @@ private class WeeksSelectTableViewController: SelectTableViewController<EventWee
     }
 
     @objc override func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEvents(year: year, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchBreakdownViewController.swift
@@ -102,8 +102,6 @@ extension MatchBreakdownViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchMatch(key: match.key!, { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchesViewController.swift
@@ -107,8 +107,6 @@ extension MatchesViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEventMatches(key: event.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
@@ -50,18 +50,6 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
         }
     }
 
-    // MARK: - Public methods
-
-    public func clearFRC() {
-        fetchedResultsController = nil
-
-        DispatchQueue.main.async {
-            try! self.fetchedResultsController!.performFetch()
-            self.tableView.reloadData()
-        }
-    }
-
-
     // MARK: FRC
 
     fileprivate var fetchedResultsController: NSFetchedResultsController<T>?
@@ -217,8 +205,6 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
         if T.self == Subscription.self {
             return
         }
-
-        removeNoDataView()
 
         var finalOperation: Operation!
 

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamStatsViewController.swift
@@ -114,8 +114,6 @@ extension TeamStatsViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchEventTeamStats(key: event.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -267,8 +267,6 @@ extension TeamSummaryViewController: Refreshable {
     }
 
     @objc func refresh() {
-        removeNoDataView()
-
         var finalOperation: Operation!
 
         // Refresh team status

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamEventsViewController.swift
@@ -44,8 +44,6 @@ class TeamEventsViewController: EventsViewController {
     }
 
     @objc override func refresh() {
-        removeNoDataView()
-
         var operation: TBAKitOperation!
         operation = tbaKit.fetchTeamEvents(key: team.key!, completion: { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -194,13 +194,7 @@ class TeamsViewController: TBATableViewController, Refreshable, Stateful, TeamsV
     // MARK: TableViewDataSourceDelegate
 
     func controllerDidChangeContent() {
-        // Don't update our interface if we're in the background - since updating the search bar count is expensive
-        guard let nav = navigationController, nav.visibleViewController == parent else {
-            return
-        }
-        DispatchQueue.main.async { [weak self] in
-            self?.updateInterface()
-        }
+        updateInterface()
     }
 
     // MARK: - EventsViewControllerDataSourceConfiguration


### PR DESCRIPTION
- Handle removing no data views during refresh automatically
- Remove non-granular reloads in `noDataReload` - don't reload data, show/hide no data view if appropriate
- Fix refreshing non-stateful views (calling `noDataReload` actions) after refreshes
- Only process view changes on foreground view controllers
- Update background'd view controllers to sync view changes on `viewWillAppear`
    - Launch a fresh install
    - Navigate to an Event
    - Load Event Rankings, notice team names are missing
    - View Event Teams
    - Navigate back to Event Rankings, notice team names are now populated, since we refreshed the table view in `viewWillAppear`
- Change Team Media refreshing to gracefully load in images