### PR TITLE
Use weak self when updating table views and collection views

### DIFF
--- a/tba-unit-tests/Protocols/RefreshableTests.swift
+++ b/tba-unit-tests/Protocols/RefreshableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import TBAOperationTesting
 @testable import The_Blue_Alliance
 
 class MockRefreshable: Refreshable {
@@ -158,8 +159,11 @@ class RefreshableTests: TBATestCase {
     }
 
     func test_isRefreshing() {
-        XCTAssertFalse(refreshable.isRefreshing)
-        refreshable.addRefreshOperations([Operation()])
+        let neverFinishOp = Operation()
+        let op = Operation()
+        op.addDependency(neverFinishOp)
+
+        refreshable.addRefreshOperations([op])
         XCTAssert(refreshable.isRefreshing)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -54,8 +54,6 @@ class TeamsViewController: TBATableViewController, Refreshable, Stateful, TeamsV
 
         // Used to make sure the UISearchBar stays in our root VC (this VC) when presented and doesn't overlay in push
         definesPresentationContext = true
-
-        updateInterface()
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Related to #589 - when we're processing updates for our table views and collection views, let's not capture self