### PR TITLE
Disable Crashlytics in debug builds

### DIFF
--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -1,5 +1,6 @@
 import CoreData
 import Crashlytics
+import Fabric
 import Firebase
 import FirebaseAuth
 import FirebaseMessaging
@@ -132,6 +133,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Setup our Firebase app - make sure this is called before other Firebase setup
         FirebaseApp.configure()
+
+        // Disable Crashlytics during debug
+        #if DEBUG
+        Fabric.sharedSDK().debug = true
+        #else
+        Fabric.with([Crashlytics.self])
+        #endif
 
         let secrets = Secrets()
         tbaKit = TBAKit(apiKey: secrets.tbaAPIKey, userDefaults: userDefaults)

--- a/the-blue-alliance-ios/Info.plist
+++ b/the-blue-alliance-ios/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>firebase_crashlytics_collection_enabled</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
This appears to be working properly - the right breakpoints appear to be being hit in the `#if DEBUG` bit, and when running in debug I don't get the usual `[Crashlytics] Version 3.12.0` output, where I do get it still during a Release build. Closes #381