### PR TITLE
Assume updateRefresh called on main thread

### DIFF
--- a/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
@@ -33,10 +33,12 @@ class MatchViewControllerTests: TBATestCase {
     }
 
     func test_snapshot() {
+        waitOneSecond()
         verifyLayer(viewControllerTester.window.layer)
 
         // myTBA authed
         myTBA.authToken = "abcd123"
+        waitOneSecond()
         verifyLayer(viewControllerTester.window.layer, identifier: "mytba")
     }
 

--- a/tba-unit-tests/View Controllers/Teams/TeamViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamViewControllerTests.swift
@@ -33,10 +33,12 @@ class TeamViewControllerTests: TBATestCase {
     }
 
     func test_snapshot() {
+        waitOneSecond()
         verifyLayer(viewControllerTester.window.layer)
 
         // myTBA authed
         myTBA.authToken = "abcd123"
+        waitOneSecond()
         verifyLayer(viewControllerTester.window.layer, identifier: "mytba")
     }
 

--- a/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
@@ -31,6 +31,7 @@ class TeamsContainerViewControllerTests: TBATestCase {
     }
 
     func test_snapshot() {
+        waitOneSecond()
         verifyLayer(viewControllerTester.window.layer)
     }
 

--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -165,18 +165,18 @@ extension Refreshable {
      WARNING: This method should not be called directly - exposed for testing, used internally
      */
     func updateRefresh() {
-        DispatchQueue.main.async {
-            if self.isRefreshing {
-                self.hideNoData()
+        if self.isRefreshing {
+            self.hideNoData()
 
-                let refreshControlHeight = self.refreshControl?.frame.size.height ?? 0
-                self.refreshView.setContentOffset(CGPoint(x: 0, y: -refreshControlHeight), animated: true)
-                self.refreshControl?.beginRefreshing()
-            } else {
-                self.refreshControl?.endRefreshing()
-
-                self.noDataReload()
+            let refreshControlHeight = self.refreshControl?.frame.size.height ?? 0
+            UIView.animate(withDuration: 0.5) { [weak refreshView] in
+                refreshView?.setContentOffset(CGPoint(x: 0, y: -refreshControlHeight), animated: true)
             }
+            self.refreshControl?.beginRefreshing()
+        } else {
+            self.refreshControl?.endRefreshing()
+
+            self.noDataReload()
         }
     }
 


### PR DESCRIPTION
`updateRefresh` should only be called in Refreshable, and it executes on `OperationQueue.main`, so it should only be called on the main thread.