### PR TITLE
Send proper sending device key when updating myTBA

### DIFF
--- a/Frameworks/MyTBAKit/Sources/Models/MyTBAPreferences.swift
+++ b/Frameworks/MyTBAKit/Sources/Models/MyTBAPreferences.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public struct MyTBAPreferences: Codable {
-    var deviceKey: String
+    var deviceKey: String?
     var favorite: Bool
     var modelKey: String
     var modelType: MyTBAModelType
@@ -19,8 +19,8 @@ extension MyTBA {
     // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/174
 
     @discardableResult
-    public func updatePreferences(modelKey: String, modelType: MyTBAModelType, favorite: Bool, notifications: [NotificationType], completion: @escaping (_ favoriteResponse: MyTBABaseResponse?, _ subscriptionResponse: MyTBABaseResponse?, _ error: Error?) -> Void) -> MyTBAOperation? {
-        let preferences = MyTBAPreferences(deviceKey: uuid,
+    public func updatePreferences(deviceKey: String?, modelKey: String, modelType: MyTBAModelType, favorite: Bool, notifications: [NotificationType], completion: @escaping (_ favoriteResponse: MyTBABaseResponse?, _ subscriptionResponse: MyTBABaseResponse?, _ error: Error?) -> Void) -> MyTBAOperation? {
+        let preferences = MyTBAPreferences(deviceKey: deviceKey,
                                            favorite: favorite,
                                            modelKey: modelKey,
                                            modelType: modelType,

--- a/Frameworks/MyTBAKit/Tests/Models/MyTBAPreferencesTests.swift
+++ b/Frameworks/MyTBAKit/Tests/Models/MyTBAPreferencesTests.swift
@@ -6,7 +6,7 @@ class MyTBAPreferencesTests: MyTBATestCase {
 
     func test_preferences() {
         let ex = expectation(description: "model/setPreferences called")
-        let operation = myTBA.updatePreferences(modelKey: "2018ckw0", modelType: .event, favorite: true, notifications: []) { (favoriteResponse, subscriptionResponse, error) in
+        let operation = myTBA.updatePreferences(deviceKey: nil, modelKey: "2018ckw0", modelType: .event, favorite: true, notifications: []) { (favoriteResponse, subscriptionResponse, error) in
             XCTAssertNotNil(favoriteResponse)
             XCTAssertNotNil(subscriptionResponse)
             XCTAssertNil(error)
@@ -18,7 +18,7 @@ class MyTBAPreferencesTests: MyTBATestCase {
 
     func test_preferences_error() {
         let ex = expectation(description: "model/setPreferences called")
-        let operation = myTBA.updatePreferences(modelKey: "2018ckw0", modelType: .event, favorite: true, notifications: []) { (favoriteResponse, subscriptionResponse, error) in
+        let operation = myTBA.updatePreferences(deviceKey: "abc", modelKey: "2018ckw0", modelType: .event, favorite: true, notifications: []) { (favoriteResponse, subscriptionResponse, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(favoriteResponse)
             XCTAssertNil(subscriptionResponse)

--- a/tba-unit-tests/Protocols/SubscribableTests.swift
+++ b/tba-unit-tests/Protocols/SubscribableTests.swift
@@ -1,4 +1,5 @@
 import CoreData
+import FirebaseMessaging
 import MyTBAKit
 import XCTest
 @testable import The_Blue_Alliance
@@ -8,13 +9,15 @@ class MockSubscribableViewController: UIViewController, Persistable, Subscribabl
     var favoriteBarButtonItem: UIBarButtonItem {
         return UIBarButtonItem(title: "Button", style: .plain, target: nil, action: nil)
     }
+    var messaging: Messaging
     var myTBA: MyTBA
     var subscribableModel: MyTBASubscribable
     var persistentContainer: NSPersistentContainer
 
     var presentCalled: ((UIViewController) -> ())?
 
-    init(myTBA: MyTBA, subscribableModel: MyTBASubscribable, persistentContainer: NSPersistentContainer) {
+    init(messaging: Messaging, myTBA: MyTBA, subscribableModel: MyTBASubscribable, persistentContainer: NSPersistentContainer) {
+        self.messaging = messaging
         self.myTBA = myTBA
         self.subscribableModel = subscribableModel
         self.persistentContainer = persistentContainer
@@ -41,7 +44,7 @@ class SubscribableTests: TBATestCase {
         super.setUp()
 
         subscribableModel = insertDistrictEvent()
-        subscribableViewController = MockSubscribableViewController(myTBA: myTBA, subscribableModel: subscribableModel, persistentContainer: persistentContainer)
+        subscribableViewController = MockSubscribableViewController(messaging: messaging, myTBA: myTBA, subscribableModel: subscribableModel, persistentContainer: persistentContainer)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/TBATestCase.swift
+++ b/tba-unit-tests/TBATestCase.swift
@@ -8,6 +8,7 @@ import XCTest
 class TBATestCase: CoreDataTestCase {
 
     var testBundle: Bundle!
+    var messaging: Messaging!
     var myTBA: MockMyTBA!
     var tbaKit: MockTBAKit!
     var userDefaults: UserDefaults!
@@ -21,6 +22,7 @@ class TBATestCase: CoreDataTestCase {
 
         testBundle = Bundle(for: type(of: self))
         userDefaults = UserDefaults(suiteName: "TBATests")
+        messaging = Messaging.messaging()
         myTBA = MockMyTBA()
         tbaKit = MockTBAKit(userDefaults: userDefaults)
         urlOpener = MockURLOpener()

--- a/tba-unit-tests/View Controllers/Base/Containers/MyTBAContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Base/Containers/MyTBAContainerViewControllerTests.swift
@@ -1,4 +1,5 @@
 import CoreData
+import FirebaseMessaging
 import TBAKit
 import XCTest
 @testable import MyTBAKit
@@ -13,10 +14,10 @@ class MockMyTBAContainerViewController: MyTBAContainerViewController {
 
     var updateFavoriteButtonExpectation: XCTestExpectation?
 
-    init(subscribableModel: MyTBASubscribable, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(subscribableModel: MyTBASubscribable, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         _subscribableModel = subscribableModel
 
-        super.init(viewControllers: [], myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(viewControllers: [], messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -44,7 +45,7 @@ class MyTBAContainerViewControllerTests: TBATestCase {
 
         subscribableModel = insertDistrictEvent()
 
-        tbaContainerViewController = MockMyTBAContainerViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        tbaContainerViewController = MockMyTBAContainerViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController = MockNavigationController(rootViewController: tbaContainerViewController)
 
         viewControllerTester = TBAViewControllerTester(withViewController: navigationController)

--- a/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
@@ -19,6 +19,7 @@ class DistrictViewControllerTests: TBATestCase {
         let district = insertDistrict()
 
         districtViewController = DistrictViewController(district: district,
+                                                        messaging: messaging,
                                                         myTBA: myTBA,
                                                         statusService: statusService,
                                                         urlOpener: urlOpener,

--- a/tba-unit-tests/View Controllers/Districts/DistrictsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictsContainerViewControllerTests.swift
@@ -11,7 +11,8 @@ class DistrictsContainerViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        districtsContainerViewController = DistrictsContainerViewController(myTBA: myTBA,
+        districtsContainerViewController = DistrictsContainerViewController(messaging: messaging,
+                                                                            myTBA: myTBA,
                                                                             statusService: statusService,
                                                                             urlOpener: urlOpener,
                                                                             persistentContainer: persistentContainer,

--- a/tba-unit-tests/View Controllers/Events/EventViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Events/EventViewControllerTests.swift
@@ -18,7 +18,7 @@ class EventViewControllerTests: TBATestCase {
 
         let event = insertDistrictEvent()
 
-        eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController = MockNavigationController(rootViewController: eventViewController)
 
         viewControllerTester = TBAViewControllerTester(withViewController: navigationController)

--- a/tba-unit-tests/View Controllers/Events/EventsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Events/EventsContainerViewControllerTests.swift
@@ -11,7 +11,8 @@ class EventsContainerViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        eventsContainerViewController = EventsContainerViewController(myTBA: myTBA,
+        eventsContainerViewController = EventsContainerViewController(messaging: messaging,
+                                                                      myTBA: myTBA,
                                                                       statusService: statusService,
                                                                       urlOpener: urlOpener,
                                                                       persistentContainer: persistentContainer,

--- a/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
@@ -18,7 +18,7 @@ class MatchViewControllerTests: TBATestCase {
 
         let match = insertMatch()
 
-        matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController = MockNavigationController(rootViewController: matchViewController)
 
         viewControllerTester = TBAViewControllerTester(withViewController: navigationController)
@@ -48,7 +48,7 @@ class MatchViewControllerTests: TBATestCase {
     func test_title_event() {
         let event = insertDistrictEvent()
         match.event = event
-        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
 
         XCTAssertEqual(vc.navigationTitle, "Quals 1")
         XCTAssertEqual(vc.navigationSubtitle, "@ 2018 Kettering University #1 District")
@@ -68,7 +68,7 @@ class MatchViewControllerTests: TBATestCase {
 
     func test_doesNotShowBreakdown() {
         let match = insertMatch(eventKey: "2014miket_qm1")
-        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         XCTAssertFalse(vc.children.contains(where: { (viewController) -> Bool in
             return viewController is MatchBreakdownViewController
         }))

--- a/tba-unit-tests/View Controllers/Teams/TeamViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamViewControllerTests.swift
@@ -18,7 +18,7 @@ class TeamViewControllerTests: TBATestCase {
 
         let team = insertTeam()
 
-        teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController = MockNavigationController(rootViewController: teamViewController)
 
         viewControllerTester = TBAViewControllerTester(withViewController: navigationController)

--- a/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
@@ -11,7 +11,8 @@ class TeamsContainerViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        teamsContainerViewController = TeamsContainerViewController(myTBA: myTBA,
+        teamsContainerViewController = TeamsContainerViewController(messaging: messaging,
+                                                                    myTBA: myTBA,
                                                                     statusService: statusService,
                                                                     urlOpener: urlOpener,
                                                                     persistentContainer: persistentContainer,

--- a/tba-unit-tests/View Controllers/myTBA/MyTBAPreferenceViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/myTBA/MyTBAPreferenceViewControllerTests.swift
@@ -19,7 +19,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         subscribableModel = insertDistrictEvent()
 
-        myTBAPreferencesViewController = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        myTBAPreferencesViewController = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
         navigationController = MockNavigationController(rootViewController: myTBAPreferencesViewController)
 
         viewControllerTester = TBAViewControllerTester(withViewController: navigationController)
@@ -61,7 +61,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         // Insert a Favorite
         Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
         XCTAssertNotNil(newPreferences.favorite)
         XCTAssert(newPreferences.isFavorite)
         XCTAssert(newPreferences.isFavoriteInitially)
@@ -74,7 +74,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         // Insert a Subscription
         Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
         XCTAssertNotNil(newPreferences.subscription)
         XCTAssertFalse(newPreferences.notifications.isEmpty)
         XCTAssertFalse(newPreferences.notificationsInitial.isEmpty)
@@ -148,7 +148,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let favorite = Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = false
 
         let deletionExpectation = expectation(description: "Favorite deleted")
@@ -165,7 +165,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_favorite_insert() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = true
 
         // Sanity check
@@ -185,7 +185,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let subscription = Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = []
 
         let deletionExpectation = expectation(description: "Subscription deleted")
@@ -208,7 +208,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         // Sanity check
         XCTAssertEqual(subscription.notifications, [.awards, .upcomingMatch])
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.upcomingMatch]
 
         newPreferences.save()
@@ -222,7 +222,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_subscription_insert() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.awards, .upcomingMatch]
 
         // Sanity check

--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -23,19 +23,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy private var rootSplitViewController: UISplitViewController = { [unowned self] in
         let splitViewController = UISplitViewController()
 
-        let eventsViewController = EventsContainerViewController(myTBA: myTBA,
+        let eventsViewController = EventsContainerViewController(messaging: messaging,
+                                                                 myTBA: myTBA,
                                                                  statusService: statusService,
                                                                  urlOpener: urlOpener,
                                                                  persistentContainer: persistentContainer,
                                                                  tbaKit: tbaKit,
                                                                  userDefaults: userDefaults)
-        let teamsViewController = TeamsContainerViewController(myTBA: myTBA,
+        let teamsViewController = TeamsContainerViewController(messaging: messaging,
+                                                               myTBA: myTBA,
                                                                statusService: statusService,
                                                                urlOpener: urlOpener,
                                                                persistentContainer: persistentContainer,
                                                                tbaKit: tbaKit,
                                                                userDefaults: userDefaults)
-        let districtsViewController = DistrictsContainerViewController(myTBA: myTBA,
+        let districtsViewController = DistrictsContainerViewController(messaging: messaging,
+                                                                       myTBA: myTBA,
                                                                        statusService: statusService,
                                                                        urlOpener: urlOpener,
                                                                        persistentContainer: persistentContainer,
@@ -287,7 +290,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private func setupPushServiceDelegates() {
         messaging.delegate = pushService
-        // TODO: remoteMessageDelegate
         UNUserNotificationCenter.current().delegate = pushService
         myTBA.authenticationProvider.add(observer: pushService)
     }

--- a/the-blue-alliance-ios/Extensions/ContainerViewController+Team.swift
+++ b/the-blue-alliance-ios/Extensions/ContainerViewController+Team.swift
@@ -1,3 +1,4 @@
+import FirebaseMessaging
 import MyTBAKit
 import UIKit
 
@@ -5,9 +6,10 @@ import UIKit
 // Used for Team@Event and Team@District to push to a Team, when contextually available.
 protocol ContainerTeamPushable {
     var teamKey: TeamKey { get }
+    var myTBA: MyTBA { get }
+    var messaging: Messaging { get }
     var statusService: StatusService { get }
     var urlOpener: URLOpener { get }
-    var myTBA: MyTBA { get }
 }
 
 extension ContainerTeamPushable where Self: ContainerViewController {
@@ -48,7 +50,7 @@ extension ContainerTeamPushable where Self: ContainerViewController {
     }
 
     func _pushTeam(team: Team) {
-        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController?.pushViewController(teamViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/Protocols/Subscribable.swift
+++ b/the-blue-alliance-ios/Protocols/Subscribable.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FirebaseMessaging
 import MyTBAKit
 import UIKit
 
@@ -7,6 +8,7 @@ import UIKit
 // Ex: The 'Event' view controller conforms to Subscribable, which shows the subscribe UI
 
 protocol Subscribable {
+    var messaging: Messaging { get }
     var myTBA: MyTBA { get }
     var favoriteBarButtonItem: UIBarButtonItem { get }
     var subscribableModel: MyTBASubscribable { get }
@@ -16,6 +18,7 @@ extension Subscribable where Self: UIViewController, Self: Persistable {
 
     func presentMyTBAPreferences() {
         let myTBAPreferencesViewController = MyTBAPreferenceViewController(subscribableModel: subscribableModel,
+                                                                           messaging: messaging,
                                                                            myTBA: myTBA,
                                                                            persistentContainer: persistentContainer)
         let navController = UINavigationController(rootViewController: myTBAPreferencesViewController)

--- a/the-blue-alliance-ios/View Controllers/Base/Containers/MyTBAContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Containers/MyTBAContainerViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import FirebaseMessaging
 import Foundation
 import MyTBAKit
 import TBAKit
@@ -6,6 +7,7 @@ import UIKit
 
 class MyTBAContainerViewController: ContainerViewController, Subscribable {
 
+    let messaging: Messaging
     let myTBA: MyTBA
 
     lazy var favoriteBarButtonItem: UIBarButtonItem = {
@@ -18,7 +20,8 @@ class MyTBAContainerViewController: ContainerViewController, Subscribable {
 
     // MARK: - Init
 
-    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.messaging = messaging
         self.myTBA = myTBA
 
         super.init(viewControllers: viewControllers, navigationTitle: navigationTitle, navigationSubtitle: navigationSubtitle, segmentedControlTitles: segmentedControlTitles, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 class DistrictViewController: ContainerViewController {
 
     private(set) var district: District
+    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -17,8 +18,9 @@ class DistrictViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(district: District, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(district: District, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.district = district
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -63,7 +65,7 @@ class DistrictViewController: ContainerViewController {
 extension DistrictViewController: EventsViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
-        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventViewController, animated: true)
     }
 
@@ -76,7 +78,7 @@ extension DistrictViewController: EventsViewControllerDelegate {
 extension DistrictViewController: TeamsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
-        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamViewController, animated: true)
     }
 
@@ -85,7 +87,7 @@ extension DistrictViewController: TeamsViewControllerDelegate {
 extension DistrictViewController: DistrictRankingsViewControllerDelegate {
 
     func districtRankingSelected(_ districtRanking: DistrictRanking) {
-        let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: districtRanking, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: districtRanking, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtDistrictViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -12,16 +12,18 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
     }
 
     private(set) var ranking: DistrictRanking
-    internal let statusService: StatusService
-    internal let myTBA: MyTBA
-    internal let urlOpener: URLOpener
+    let statusService: StatusService
+    let messaging: Messaging
+    let myTBA: MyTBA
+    let urlOpener: URLOpener
 
     private var summaryViewController: DistrictTeamSummaryViewController!
 
     // MARK: Init
 
-    init(ranking: DistrictRanking, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(ranking: DistrictRanking, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.ranking = ranking
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -73,7 +75,7 @@ extension TeamAtDistrictViewController: DistrictTeamSummaryViewControllerDelegat
         }
 
         // TODO: Let's see what we can to do not force-unwrap these from Core Data
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: eventPoints.teamKey!, event: event, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: eventPoints.teamKey!, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 
 class DistrictsContainerViewController: ContainerViewController {
 
+    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -22,7 +23,8 @@ class DistrictsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -102,7 +104,7 @@ extension DistrictsContainerViewController: DistrictsViewControllerDelegate {
 
     func districtSelected(_ district: District) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let districtViewController = DistrictViewController(district: district, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let districtViewController = DistrictViewController(district: district, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let nav = UINavigationController(rootViewController: districtViewController)
         navigationController?.showDetailViewController(nav, sender: nil)
     }

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAlliancesViewController.swift
@@ -8,6 +8,7 @@ import UIKit
 class EventAlliancesContainerViewController: ContainerViewController {
 
     private(set) var event: Event
+    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -16,8 +17,9 @@ class EventAlliancesContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Event, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -51,7 +53,7 @@ class EventAlliancesContainerViewController: ContainerViewController {
 extension EventAlliancesContainerViewController: EventAlliancesViewControllerDelegate {
 
     func teamKeySelected(_ teamKey: TeamKey) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
@@ -8,15 +8,17 @@ class EventAwardsContainerViewController: ContainerViewController {
 
     private(set) var event: Event
     private(set) var teamKey: TeamKey?
+    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
 
     // MARK: - Init
 
-    init(event: Event, teamKey: TeamKey? = nil, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, teamKey: TeamKey? = nil, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
         self.teamKey = teamKey
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -67,7 +69,7 @@ extension EventAwardsContainerViewController: EventAwardsViewControllerDelegate 
         if teamKey == self.teamKey {
             return
         }
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
@@ -8,14 +8,16 @@ import UIKit
 class EventDistrictPointsContainerViewController: ContainerViewController {
 
     private(set) var event: Event
+    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
 
     // MARK: - Init
 
-    init(event: Event, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -49,7 +51,7 @@ class EventDistrictPointsContainerViewController: ContainerViewController {
 extension EventDistrictPointsContainerViewController: EventDistrictPointsViewControllerDelegate {
 
     func districtEventPointsSelected(_ districtEventPoints: DistrictEventPoints) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: districtEventPoints.teamKey!, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: districtEventPoints.teamKey!, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventViewController.swift
@@ -21,7 +21,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 
     // MARK: - Init
 
-    init(event: Event, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, statusService: StatusService, urlOpener: URLOpener, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -33,6 +33,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 
         super.init(viewControllers: [infoViewController, teamsViewController, rankingsViewController, matchesViewController],
                    segmentedControlTitles: ["Info", "Teams", "Rankings", "Matches"],
+                   messaging: messaging,
                    myTBA: myTBA,
                    persistentContainer: persistentContainer,
                    tbaKit: tbaKit,
@@ -83,22 +84,22 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 extension EventViewController: EventInfoViewControllerDelegate {
 
     func showAlliances() {
-        let eventAlliancesViewController = EventAlliancesContainerViewController(event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventAlliancesViewController = EventAlliancesContainerViewController(event: event, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventAlliancesViewController, animated: true)
     }
 
     func showAwards() {
-        let eventAwardsViewController = EventAwardsContainerViewController(event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventAwardsViewController = EventAwardsContainerViewController(event: event, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventAwardsViewController, animated: true)
     }
 
     func showDistrictPoints() {
-        let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(event: event, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventDistrictPointsViewController, animated: true)
     }
 
     func showStats() {
-        let eventStatsContainerViewController = EventStatsContainerViewController(event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventStatsContainerViewController = EventStatsContainerViewController(event: event, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventStatsContainerViewController, animated: true)
     }
 
@@ -107,7 +108,7 @@ extension EventViewController: EventInfoViewControllerDelegate {
 extension EventViewController: TeamsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.teamKey, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -116,7 +117,7 @@ extension EventViewController: TeamsViewControllerDelegate {
 extension EventViewController: EventRankingsViewControllerDelegate {
 
     func rankingSelected(_ ranking: EventRanking) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: ranking.teamKey!, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: ranking.teamKey!, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -125,7 +126,7 @@ extension EventViewController: EventRankingsViewControllerDelegate {
 extension EventViewController: MatchesViewControllerDelegate {
 
     func matchSelected(_ match: Match) {
-        let matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsContainerViewController.swift
@@ -8,6 +8,7 @@ import UIKit
 class EventStatsContainerViewController: ContainerViewController {
 
     private(set) var event: Event
+    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -23,8 +24,9 @@ class EventStatsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Event, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -111,7 +113,7 @@ extension EventStatsContainerViewController: SelectTableViewControllerDelegate {
 extension EventStatsContainerViewController: EventTeamStatsSelectionDelegate {
 
     func eventTeamStatSelected(_ eventTeamStat: EventTeamStat) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: eventTeamStat.teamKey!, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: eventTeamStat.teamKey!, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 
 class EventsContainerViewController: ContainerViewController {
 
+    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -16,7 +17,8 @@ class EventsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -102,7 +104,7 @@ extension EventsContainerViewController: EventsViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let nav = UINavigationController(rootViewController: eventViewController)
         navigationController?.showDetailViewController(nav, sender: nil)
     }

--- a/the-blue-alliance-ios/View Controllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchViewController.swift
@@ -20,7 +20,7 @@ class MatchViewController: MyTBAContainerViewController {
 
     // MARK: Init
 
-    init(match: Match, teamKey: TeamKey? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(match: Match, teamKey: TeamKey? = nil, statusService: StatusService, urlOpener: URLOpener, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.match = match
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -38,6 +38,7 @@ class MatchViewController: MyTBAContainerViewController {
             navigationTitle: "\(match.friendlyName)",
             navigationSubtitle: "@ \(match.event?.friendlyNameWithYear ?? match.key!)", // TODO: Use EventKey
             segmentedControlTitles: titles,
+            messaging: messaging,
             myTBA: myTBA,
             persistentContainer: persistentContainer,
             tbaKit: tbaKit,
@@ -69,7 +70,7 @@ extension MatchViewController: MatchSummaryViewDelegate {
         // get team key that matches the target teamNumber
         guard let teamKey = match.teamKeys.first(where: { $0.teamNumber == "\(teamNumber)"}) else { return }
         
-        let teamAtEventVC = TeamAtEventViewController(teamKey: teamKey, event: event, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventVC = TeamAtEventViewController(teamKey: teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController?.pushViewController(teamAtEventVC, animated: true)
     }
     

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAPreferenceViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAPreferenceViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import FirebaseMessaging
 import MyTBAKit
 import UIKit
 
@@ -22,6 +23,7 @@ class MyTBAPreferenceViewController: UITableViewController {
     let notificationsInitial: [NotificationType]
     var notifications: [NotificationType] = []
 
+    let messaging: Messaging
     let myTBA: MyTBA
     let persistentContainer: NSPersistentContainer
 
@@ -43,8 +45,9 @@ class MyTBAPreferenceViewController: UITableViewController {
                                                                            action: #selector(save))
     internal var saveActivityIndicatorBarButtonItem = UIBarButtonItem.activityIndicatorBarButtonItem()
 
-    init(subscribableModel: MyTBASubscribable, myTBA: MyTBA, persistentContainer: NSPersistentContainer) {
+    init(subscribableModel: MyTBASubscribable, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer) {
         self.subscribableModel = subscribableModel
+        self.messaging = messaging
         self.myTBA = myTBA
         self.persistentContainer = persistentContainer
 
@@ -134,7 +137,8 @@ class MyTBAPreferenceViewController: UITableViewController {
 
         isSaving = true
 
-        preferencesOperation = myTBA.updatePreferences(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, favorite: isFavorite, notifications: notifications, completion: { [unowned self] (favoriteResponse, subscriptionResponse, error) in
+        let fcmToken = messaging.fcmToken
+        preferencesOperation = myTBA.updatePreferences(deviceKey: fcmToken, modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, favorite: isFavorite, notifications: notifications, completion: { [unowned self] (favoriteResponse, subscriptionResponse, error) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if let favoriteResponse = favoriteResponse, favoriteResponse.code < 400 {

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
@@ -173,19 +173,19 @@ extension MyTBAViewController: MyTBATableViewControllerDelegate {
         switch myTBAObject.modelType {
         case .event:
             if let event = myTBAObject.tbaObject as? Event {
-                viewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+                viewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
             } else {
                 // TODO: Push using just key
             }
         case .team:
             if let team = myTBAObject.tbaObject as? Team {
-                viewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+                viewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
             } else {
                 // TODO: Push using just key
             }
         case .match:
             if let match = myTBAObject.tbaObject as? Match {
-                viewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+                viewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
             } else {
                 // TODO: Push using just key
             }

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 
 class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable {
 
-    internal let teamKey: TeamKey
+    let teamKey: TeamKey
     private let event: Event
 
     // Where should we push to, when clicking the navigation bar from the top. Should be the opposite of what view sent us here
@@ -15,20 +15,22 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
     private let showDetailEvent: Bool
     private let showDetailTeam: Bool
 
-    internal let statusService: StatusService
-    internal let urlOpener: URLOpener
-    internal let myTBA: MyTBA
-    
+    let messaging: Messaging
+    let myTBA: MyTBA
+    let statusService: StatusService
+    let urlOpener: URLOpener
+
     // MARK: - Init
 
-    init(teamKey: TeamKey, event: Event, myTBA: MyTBA, showDetailEvent: Bool, showDetailTeam: Bool, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(teamKey: TeamKey, event: Event, messaging: Messaging, myTBA: MyTBA, showDetailEvent: Bool, showDetailTeam: Bool, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.teamKey = teamKey
         self.event = event
         self.showDetailEvent = showDetailEvent
         self.showDetailTeam = showDetailTeam
+        self.myTBA = myTBA
+        self.messaging = messaging
         self.statusService = statusService
         self.urlOpener = urlOpener
-        self.myTBA = myTBA
 
         let summaryViewController: TeamSummaryViewController = TeamSummaryViewController(teamKey: teamKey, event: event, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let matchesViewController: MatchesViewController = MatchesViewController(event: event, teamKey: teamKey, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
@@ -69,7 +71,7 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
     // MARK: - Private Methods
 
     @objc private func pushEvent() {
-        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController?.pushViewController(eventViewController, animated: true)
     }
 
@@ -82,12 +84,12 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
 extension TeamAtEventViewController: MatchesViewControllerDelegate, TeamSummaryViewControllerDelegate {
 
     func awardsSelected() {
-        let awardsViewController = EventAwardsContainerViewController(event: event, teamKey: teamKey, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let awardsViewController = EventAwardsContainerViewController(event: event, teamKey: teamKey, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(awardsViewController, animated: true)
     }
 
     func matchSelected(_ match: Match) {
-        let matchViewController = MatchViewController(match: match, teamKey: teamKey, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let matchViewController = MatchViewController(match: match, teamKey: teamKey, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 
@@ -101,7 +103,7 @@ extension TeamAtEventViewController: EventAwardsViewControllerDelegate {
             return
         }
 
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, myTBA: myTBA, showDetailEvent: showDetailEvent, showDetailTeam: showDetailTeam, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: showDetailEvent, showDetailTeam: showDetailTeam, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamViewController.swift
@@ -44,7 +44,7 @@ class TeamViewController: MyTBAContainerViewController, Observable {
 
     // MARK: Init
 
-    init(team: Team, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(team: Team, statusService: StatusService, urlOpener: URLOpener, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.team = team
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -59,6 +59,7 @@ class TeamViewController: MyTBAContainerViewController, Observable {
             navigationTitle: "Team \(team.teamNumber!.stringValue)",
             navigationSubtitle: ContainerViewController.yearSubtitle(year),
             segmentedControlTitles: ["Info", "Events", "Media"],
+            messaging: messaging,
             myTBA: myTBA,
             persistentContainer: persistentContainer,
             tbaKit: tbaKit,
@@ -200,7 +201,7 @@ extension TeamViewController: SelectTableViewControllerDelegate {
 extension TeamViewController: EventsViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.teamKey, event: event, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 
 class TeamsContainerViewController: ContainerViewController {
 
+    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -14,7 +15,8 @@ class TeamsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -50,7 +52,7 @@ extension TeamsContainerViewController: TeamsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let nav = UINavigationController(rootViewController: teamViewController)
         navigationController?.showDetailViewController(nav, sender: nil)
     }


### PR DESCRIPTION
Right now we're sending the device UUID, not the device FCM token, when updating myTBA models. This sends the proper string.