### PR TITLE
Fix broken push from Team@Event or Team@District -> Team

### DIFF
--- a/the-blue-alliance-ios/Extensions/ContainerViewController+Team.swift
+++ b/the-blue-alliance-ios/Extensions/ContainerViewController+Team.swift
@@ -8,6 +8,7 @@ import UIKit
 // Used for Team@Event and Team@District to push to a Team, when contextually available.
 protocol ContainerTeamPushable {
     var pushTeamBarButtonItem: UIBarButtonItem? { get }
+    var fetchTeamOperationQueue: OperationQueue { get }
 
     var teamKey: TeamKey { get }
     var myTBA: MyTBA { get }
@@ -27,7 +28,7 @@ extension ContainerTeamPushable where Self: ContainerViewController {
                     self.rightBarButtonItems = [UIBarButtonItem.activityIndicatorBarButtonItem()]
                 }
 
-                tbaKit.fetchTeam(key: teamKey.key!, completion: { (result, notModified) in
+                let operation = tbaKit.fetchTeam(key: teamKey.key!, completion: { (result, notModified) in
                     let context = self.persistentContainer.newBackgroundContext()
                     context.performChangesAndWait({
                         if let team = try? result.get() {
@@ -45,6 +46,7 @@ extension ContainerTeamPushable where Self: ContainerViewController {
                         self.rightBarButtonItems = [self.pushTeamBarButtonItem].compactMap({ $0 })
                     }
                 })
+                fetchTeamOperationQueue.addOperation(operation)
             }
             return
         }

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -21,6 +21,10 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
 
     private var summaryViewController: DistrictTeamSummaryViewController!
 
+    // MARK:  - ContainerTeamPushable
+
+    var fetchTeamOperationQueue: OperationQueue = OperationQueue()
+
     // MARK: Init
 
     init(ranking: DistrictRanking, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
@@ -59,6 +63,13 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
         super.viewWillAppear(animated)
 
         Analytics.logEvent("team_at_district", parameters: ["district": ranking.district!.key!, "team": ranking.teamKey!.key!])
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        // TODO: Move this out in to some shared class with TeamAtEvent
+        fetchTeamOperationQueue.cancelAllOperations()
     }
 
     // MARK: - Private Methods

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -23,6 +23,10 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
     let statusService: StatusService
     let urlOpener: URLOpener
 
+    // MARK:  - ContainerTeamPushable
+
+    var fetchTeamOperationQueue: OperationQueue = OperationQueue()
+
     // MARK: - Init
 
     init(teamKey: TeamKey, event: Event, messaging: Messaging, myTBA: MyTBA, showDetailEvent: Bool, showDetailTeam: Bool, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
@@ -74,6 +78,13 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
         super.viewWillAppear(animated)
 
         Analytics.logEvent("team_at_event", parameters: ["event": event.key!, "team": teamKey.key!])
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        // TODO: Move this out in to some shared class with TeamAtDistrict
+        fetchTeamOperationQueue.cancelAllOperations()
     }
 
     // MARK: - Private Methods


### PR DESCRIPTION
Not sure how long this has been broken for - probably since the TBAKitOperation PR I'd imagine.

- [x] Make sure we cancel the operation in `ContainerTeamPushable` if the view gets deallocated