### PR TITLE
Remove Messaging DI, convert completion blocks to Swift shorthand

### DIFF
--- a/Frameworks/MyTBAKit/Sources/Classes/MyTBA.swift
+++ b/Frameworks/MyTBAKit/Sources/Classes/MyTBA.swift
@@ -54,16 +54,23 @@ open class MyTBA {
         return authToken != nil
     }
 
-    public init(uuid: String, deviceName: String, urlSession: URLSession? = nil) {
+    public init(uuid: String, deviceName: String, fcmTokenProvider: FCMTokenProvider, urlSession: URLSession? = nil) {
         self.uuid = uuid
         self.deviceName = deviceName
+        self.fcmTokenProvider = fcmTokenProvider
         self.urlSession = urlSession ?? URLSession(configuration: .default)
     }
+
     public var authenticationProvider = Provider<MyTBAAuthenticationObservable>()
+
+    internal var fcmToken: String? {
+        return fcmTokenProvider.fcmToken
+    }
 
     internal var urlSession: URLSession
     internal var uuid: String
     internal var deviceName: String
+    private var fcmTokenProvider: FCMTokenProvider
 
     static var jsonEncoder: JSONEncoder {
         let jsonEncoder = JSONEncoder()

--- a/Frameworks/MyTBAKit/Sources/Models/MyTBAPing.swift
+++ b/Frameworks/MyTBAKit/Sources/Models/MyTBAPing.swift
@@ -6,11 +6,13 @@ struct MyTBAPingRequest: Codable {
 
 extension MyTBA {
 
-    public func ping(_ token: String, completion: @escaping MyTBABaseCompletionBlock) -> MyTBAOperation? {
+    public func ping(completion: @escaping MyTBABaseCompletionBlock) -> MyTBAOperation? {
+        guard let token = fcmToken else {
+            return nil
+        }
         let ping = MyTBAPingRequest(mobileId: token)
 
         guard let encodedPing = try? MyTBA.jsonEncoder.encode(ping) else {
-            completion(nil, MyTBAError.error(nil, "Unable to ping device - invalid data"))
             return nil
         }
         return callApi(method: "ping", bodyData: encodedPing, completion: completion)

--- a/Frameworks/MyTBAKit/Sources/Models/MyTBAPreferences.swift
+++ b/Frameworks/MyTBAKit/Sources/Models/MyTBAPreferences.swift
@@ -18,15 +18,14 @@ extension MyTBA {
     // TODO: Android has some local rate limiting, which is probably smart
     // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/174
 
-    public func updatePreferences(deviceKey: String?, modelKey: String, modelType: MyTBAModelType, favorite: Bool, notifications: [NotificationType], completion: @escaping (_ favoriteResponse: MyTBABaseResponse?, _ subscriptionResponse: MyTBABaseResponse?, _ error: Error?) -> Void) -> MyTBAOperation? {
-        let preferences = MyTBAPreferences(deviceKey: deviceKey,
+    public func updatePreferences(modelKey: String, modelType: MyTBAModelType, favorite: Bool, notifications: [NotificationType], completion: @escaping (_ favoriteResponse: MyTBABaseResponse?, _ subscriptionResponse: MyTBABaseResponse?, _ error: Error?) -> Void) -> MyTBAOperation? {
+        let preferences = MyTBAPreferences(deviceKey: fcmToken,
                                            favorite: favorite,
                                            modelKey: modelKey,
                                            modelType: modelType,
                                            notifications: notifications)
 
         guard let encodedPreferences = try? MyTBA.jsonEncoder.encode(preferences) else {
-            completion(nil, nil, MyTBAError.error(nil, "Unable to update myTBA preferences - invalid data"))
             return nil
         }
 

--- a/Frameworks/MyTBAKit/Sources/Models/MyTBARegister.swift
+++ b/Frameworks/MyTBAKit/Sources/Models/MyTBARegister.swift
@@ -9,19 +9,21 @@ public struct MyTBARegisterRequest: Codable {
 
 extension MyTBA {
 
-    public func register(_ token: String, completion: @escaping MyTBABaseCompletionBlock) -> MyTBAOperation? {
-        return registerUnregister("register", token: token, completion: completion)
+    public func register(completion: @escaping MyTBABaseCompletionBlock) -> MyTBAOperation? {
+        return registerUnregister("register", completion: completion)
     }
 
-    public func unregister(_ token: String, completion: @escaping MyTBABaseCompletionBlock) -> MyTBAOperation? {
-        return registerUnregister("unregister", token: token, completion: completion)
+    public func unregister(completion: @escaping MyTBABaseCompletionBlock) -> MyTBAOperation? {
+        return registerUnregister("unregister", completion: completion)
     }
 
-    private func registerUnregister(_ method: String, token: String, completion: @escaping MyTBABaseCompletionBlock) -> MyTBAOperation? {
+    private func registerUnregister(_ method: String, completion: @escaping MyTBABaseCompletionBlock) -> MyTBAOperation? {
+        guard let token = fcmToken else {
+            return nil
+        }
         let registration = MyTBARegisterRequest(deviceUuid: uuid, mobileId: token, name: deviceName)
 
         guard let encodedRegistration = try? MyTBA.jsonEncoder.encode(registration) else {
-            completion(nil, MyTBAError.error(nil, "Unable to update myTBA registration - invalid data"))
             return nil
         }
         return callApi(method: method, bodyData: encodedRegistration, completion: completion)

--- a/Frameworks/MyTBAKit/Sources/Protocols/FCMTokenProvider.swift
+++ b/Frameworks/MyTBAKit/Sources/Protocols/FCMTokenProvider.swift
@@ -1,0 +1,3 @@
+public protocol FCMTokenProvider: AnyObject {
+    var fcmToken: String? { get }
+}

--- a/Frameworks/MyTBAKit/Testing/MockMyTBA.swift
+++ b/Frameworks/MyTBAKit/Testing/MockMyTBA.swift
@@ -2,12 +2,20 @@ import TBATestingMocks
 import XCTest
 @testable import MyTBAKit
 
+public class MockFCMTokenProvider: FCMTokenProvider {
+    public var fcmToken: String?
+
+    public init(fcmToken: String?) {
+        self.fcmToken = fcmToken
+    }
+}
+
 public class MockMyTBA: MyTBA {
 
     let session: MockURLSession
     private let bundle: Bundle
 
-    public init() {
+    public init(fcmTokenProvider: FCMTokenProvider) {
         self.session = MockURLSession()
 
         let selfBundle = Bundle(for: type(of: self))
@@ -17,7 +25,10 @@ public class MockMyTBA: MyTBA {
         }
         self.bundle = bundle
 
-        super.init(uuid: "abcd123", deviceName: "MyTBATesting", urlSession: session)
+        super.init(uuid: "abcd123",
+                   deviceName: "MyTBATesting",
+                   fcmTokenProvider: fcmTokenProvider,
+                   urlSession: session)
     }
 
     public func sendStub(for operation: MyTBAOperation, code: Int = 200) {

--- a/Frameworks/MyTBAKit/Tests/Classes/MyTBATests.swift
+++ b/Frameworks/MyTBAKit/Tests/Classes/MyTBATests.swift
@@ -1,3 +1,4 @@
+import MyTBAKitTesting
 import XCTest
 @testable import MyTBAKit
 
@@ -24,10 +25,13 @@ class MyTBATests: MyTBATestCase {
     func test_init() {
         let uuid = "abcd123"
         let deviceName = "My Device"
+        let fcmToken = "abc"
 
-        let zz = MyTBA(uuid: uuid, deviceName: deviceName)
+        var mfcm = MockFCMTokenProvider(fcmToken: fcmToken)
+        let zz = MyTBA(uuid: uuid, deviceName: deviceName, fcmTokenProvider: mfcm)
         XCTAssertEqual(zz.uuid, uuid)
         XCTAssertEqual(zz.deviceName, deviceName)
+        XCTAssertEqual(zz.fcmToken, fcmToken)
     }
 
     func test_authenticationProvider_authenticated() {

--- a/Frameworks/MyTBAKit/Tests/Models/MyTBAPreferencesTests.swift
+++ b/Frameworks/MyTBAKit/Tests/Models/MyTBAPreferencesTests.swift
@@ -6,7 +6,7 @@ class MyTBAPreferencesTests: MyTBATestCase {
 
     func test_preferences() {
         let ex = expectation(description: "model/setPreferences called")
-        let operation = myTBA.updatePreferences(deviceKey: nil, modelKey: "2018ckw0", modelType: .event, favorite: true, notifications: []) { (favoriteResponse, subscriptionResponse, error) in
+        let operation = myTBA.updatePreferences(modelKey: "2018ckw0", modelType: .event, favorite: true, notifications: []) { (favoriteResponse, subscriptionResponse, error) in
             XCTAssertNotNil(favoriteResponse)
             XCTAssertNotNil(subscriptionResponse)
             XCTAssertNil(error)
@@ -18,7 +18,7 @@ class MyTBAPreferencesTests: MyTBATestCase {
 
     func test_preferences_error() {
         let ex = expectation(description: "model/setPreferences called")
-        let operation = myTBA.updatePreferences(deviceKey: "abc", modelKey: "2018ckw0", modelType: .event, favorite: true, notifications: []) { (favoriteResponse, subscriptionResponse, error) in
+        let operation = myTBA.updatePreferences(modelKey: "2018ckw0", modelType: .event, favorite: true, notifications: []) { (favoriteResponse, subscriptionResponse, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(favoriteResponse)
             XCTAssertNil(subscriptionResponse)

--- a/Frameworks/MyTBAKit/Tests/Models/MyTBARegisterTests.swift
+++ b/Frameworks/MyTBAKit/Tests/Models/MyTBARegisterTests.swift
@@ -5,8 +5,10 @@ import XCTest
 class MyTBARegisterTests: MyTBATestCase {
 
     func test_register() {
+        fcmTokenProvider.fcmToken = "abc"
+
         let ex = expectation(description: "Register called")
-        let operation = myTBA.register("abcd123") { (_, error) in
+        let operation = myTBA.register { (_, error) in
             XCTAssertNil(error)
             ex.fulfill()
         }
@@ -15,8 +17,10 @@ class MyTBARegisterTests: MyTBATestCase {
     }
 
     func test_register_error() {
+        fcmTokenProvider.fcmToken = "abc"
+
         let ex = expectation(description: "Register called")
-        let operation = myTBA.register("abcd123") { (_, error) in
+        let operation = myTBA.register { (_, error) in
             XCTAssertNotNil(error)
             ex.fulfill()
         }

--- a/Frameworks/MyTBAKit/Tests/MyTBATestCase.swift
+++ b/Frameworks/MyTBAKit/Tests/MyTBATestCase.swift
@@ -4,15 +4,18 @@ import XCTest
 open class MyTBATestCase: XCTestCase {
 
     public var myTBA: MockMyTBA!
+    public var fcmTokenProvider: MockFCMTokenProvider!
 
     override open func setUp() {
         super.setUp()
 
-        myTBA = MockMyTBA()
+        fcmTokenProvider = MockFCMTokenProvider(fcmToken: nil)
+        myTBA = MockMyTBA(fcmTokenProvider: fcmTokenProvider)
     }
 
     override open func tearDown() {
         myTBA = nil
+        fcmTokenProvider = nil
 
         super.tearDown()
     }

--- a/tba-unit-tests/Protocols/SubscribableTests.swift
+++ b/tba-unit-tests/Protocols/SubscribableTests.swift
@@ -1,5 +1,4 @@
 import CoreData
-import FirebaseMessaging
 import MyTBAKit
 import XCTest
 @testable import The_Blue_Alliance
@@ -9,15 +8,13 @@ class MockSubscribableViewController: UIViewController, Persistable, Subscribabl
     var favoriteBarButtonItem: UIBarButtonItem {
         return UIBarButtonItem(title: "Button", style: .plain, target: nil, action: nil)
     }
-    var messaging: Messaging
     var myTBA: MyTBA
     var subscribableModel: MyTBASubscribable
     var persistentContainer: NSPersistentContainer
 
     var presentCalled: ((UIViewController) -> ())?
 
-    init(messaging: Messaging, myTBA: MyTBA, subscribableModel: MyTBASubscribable, persistentContainer: NSPersistentContainer) {
-        self.messaging = messaging
+    init(myTBA: MyTBA, subscribableModel: MyTBASubscribable, persistentContainer: NSPersistentContainer) {
         self.myTBA = myTBA
         self.subscribableModel = subscribableModel
         self.persistentContainer = persistentContainer
@@ -44,7 +41,7 @@ class SubscribableTests: TBATestCase {
         super.setUp()
 
         subscribableModel = insertDistrictEvent()
-        subscribableViewController = MockSubscribableViewController(messaging: messaging, myTBA: myTBA, subscribableModel: subscribableModel, persistentContainer: persistentContainer)
+        subscribableViewController = MockSubscribableViewController(myTBA: myTBA, subscribableModel: subscribableModel, persistentContainer: persistentContainer)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/TBATestCase.swift
+++ b/tba-unit-tests/TBATestCase.swift
@@ -1,5 +1,4 @@
 import CoreData
-import FirebaseMessaging
 import MyTBAKitTesting
 import TBAData
 import TBADataTesting
@@ -10,10 +9,10 @@ import XCTest
 class TBATestCase: TBADataTestCase {
 
     var testBundle: Bundle!
-    var messaging: Messaging!
+    var fcmTokenProvider: MockFCMTokenProvider!
     var myTBA: MockMyTBA!
-    var tbaKit: MockTBAKit!
     var userDefaults: UserDefaults!
+    var tbaKit: MockTBAKit!
     var urlOpener: MockURLOpener!
     var reactNativeMetadata: ReactNativeMetadata!
     var pushService: PushService!
@@ -23,12 +22,12 @@ class TBATestCase: TBADataTestCase {
         super.setUp()
 
         testBundle = Bundle(for: type(of: self))
+        fcmTokenProvider = MockFCMTokenProvider(fcmToken: nil)
+        myTBA = MockMyTBA(fcmTokenProvider: fcmTokenProvider)
         userDefaults = UserDefaults(suiteName: "TBATests")
-        messaging = Messaging.messaging()
-        myTBA = MockMyTBA()
         tbaKit = MockTBAKit(userDefaults: userDefaults)
         urlOpener = MockURLOpener()
-        pushService = PushService(messaging: Messaging.messaging(), myTBA: myTBA, retryService: RetryService(), userDefaults: userDefaults)
+        pushService = PushService(myTBA: myTBA, retryService: RetryService())
         statusService = StatusService(bundle: StatusBundle.bundle, persistentContainer: persistentContainer, retryService: RetryService(), tbaKit: tbaKit)
     }
 

--- a/tba-unit-tests/View Controllers/Base/Containers/MyTBAContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Base/Containers/MyTBAContainerViewControllerTests.swift
@@ -1,5 +1,4 @@
 import CoreData
-import FirebaseMessaging
 import TBAKit
 import XCTest
 @testable import MyTBAKit
@@ -14,10 +13,10 @@ class MockMyTBAContainerViewController: MyTBAContainerViewController {
 
     var updateFavoriteButtonExpectation: XCTestExpectation?
 
-    init(subscribableModel: MyTBASubscribable, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(subscribableModel: MyTBASubscribable, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         _subscribableModel = subscribableModel
 
-        super.init(viewControllers: [], messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(viewControllers: [], myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -42,7 +41,7 @@ class MyTBAContainerViewControllerTests: TBATestCase {
 
         subscribableModel = insertDistrictEvent()
 
-        tbaContainerViewController = MockMyTBAContainerViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        tbaContainerViewController = MockMyTBAContainerViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
@@ -18,7 +18,6 @@ class DistrictViewControllerTests: TBATestCase {
         let district = insertDistrict()
 
         districtViewController = DistrictViewController(district: district,
-                                                        messaging: messaging,
                                                         myTBA: myTBA,
                                                         statusService: statusService,
                                                         urlOpener: urlOpener,

--- a/tba-unit-tests/View Controllers/Districts/DistrictsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictsContainerViewControllerTests.swift
@@ -9,8 +9,7 @@ class DistrictsContainerViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        districtsContainerViewController = DistrictsContainerViewController(messaging: messaging,
-                                                                            myTBA: myTBA,
+        districtsContainerViewController = DistrictsContainerViewController(myTBA: myTBA,
                                                                             statusService: statusService,
                                                                             urlOpener: urlOpener,
                                                                             persistentContainer: persistentContainer,

--- a/tba-unit-tests/View Controllers/Events/EventViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Events/EventViewControllerTests.swift
@@ -17,7 +17,7 @@ class EventViewControllerTests: TBATestCase {
 
         let event = insertDistrictEvent()
 
-        eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController = MockNavigationController(rootViewController: eventViewController)
     }
 

--- a/tba-unit-tests/View Controllers/Events/EventsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Events/EventsContainerViewControllerTests.swift
@@ -9,8 +9,7 @@ class EventsContainerViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        eventsContainerViewController = EventsContainerViewController(messaging: messaging,
-                                                                      myTBA: myTBA,
+        eventsContainerViewController = EventsContainerViewController(myTBA: myTBA,
                                                                       statusService: statusService,
                                                                       urlOpener: urlOpener,
                                                                       persistentContainer: persistentContainer,

--- a/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
@@ -16,7 +16,7 @@ class MatchViewControllerTests: TBATestCase {
 
         let match = insertMatch()
 
-        matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
     }
 
     override func tearDown() {
@@ -33,7 +33,7 @@ class MatchViewControllerTests: TBATestCase {
     func test_title_event() {
         let event = insertDistrictEvent()
         match.event = event
-        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
 
         XCTAssertEqual(vc.navigationTitle, "Quals 1")
         XCTAssertEqual(vc.navigationSubtitle, "@ 2018 Kettering University #1 District")
@@ -55,7 +55,7 @@ class MatchViewControllerTests: TBATestCase {
 
     func test_doesNotShowBreakdown() {
         let match = insertMatch(eventKey: "2014miket_qm1")
-        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         XCTAssertFalse(vc.children.contains(where: { (viewController) -> Bool in
             return viewController is MatchBreakdownViewController
         }))

--- a/tba-unit-tests/View Controllers/Settings/SettingsViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Settings/SettingsViewControllerTests.swift
@@ -1,4 +1,3 @@
-import FirebaseMessaging
 import XCTest
 @testable import The_Blue_Alliance
 
@@ -9,7 +8,7 @@ class SettingsViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        settingsViewController = SettingsViewController(messaging: Messaging.messaging(),
+        settingsViewController = SettingsViewController(fcmTokenProvider: fcmTokenProvider,
                                                         metadata: ReactNativeMetadata(userDefaults: userDefaults),
                                                         myTBA: myTBA,
                                                         pushService: pushService,

--- a/tba-unit-tests/View Controllers/Teams/TeamViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamViewControllerTests.swift
@@ -16,7 +16,7 @@ class TeamViewControllerTests: TBATestCase {
 
         let team = insertTeam()
 
-        teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
@@ -9,8 +9,7 @@ class TeamsContainerViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        teamsContainerViewController = TeamsContainerViewController(messaging: messaging,
-                                                                    myTBA: myTBA,
+        teamsContainerViewController = TeamsContainerViewController(myTBA: myTBA,
                                                                     statusService: statusService,
                                                                     urlOpener: urlOpener,
                                                                     persistentContainer: persistentContainer,

--- a/tba-unit-tests/View Controllers/myTBA/MyTBAPreferenceViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/myTBA/MyTBAPreferenceViewControllerTests.swift
@@ -18,7 +18,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         subscribableModel = insertDistrictEvent()
 
-        myTBAPreferencesViewController = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        myTBAPreferencesViewController = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         navigationController = MockNavigationController(rootViewController: myTBAPreferencesViewController)
     }
 
@@ -37,7 +37,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         // Insert a Favorite
         Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         XCTAssertNotNil(newPreferences.favorite)
         XCTAssert(newPreferences.isFavorite)
         XCTAssert(newPreferences.isFavoriteInitially)
@@ -50,7 +50,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         // Insert a Subscription
         Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         XCTAssertNotNil(newPreferences.subscription)
         XCTAssertFalse(newPreferences.notifications.isEmpty)
         XCTAssertFalse(newPreferences.notificationsInitial.isEmpty)
@@ -126,7 +126,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let favorite = Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = false
 
         let deletionExpectation = expectation(description: "Favorite deleted")
@@ -151,7 +151,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let favorite = Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = false
 
         let deletionExpectation = expectation(description: "Favorite deleted")
@@ -176,7 +176,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let favorite = Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = false
 
         let deletionExpectation = expectation(description: "Favorite deleted")
@@ -199,7 +199,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_favorite_insert() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = true
 
         // Sanity check
@@ -217,7 +217,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_favorite_insert_304() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = true
 
         // Sanity check
@@ -235,7 +235,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_favorite_insert_500() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = true
 
         // Sanity check
@@ -256,7 +256,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let subscription = Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = []
 
         let deletionExpectation = expectation(description: "Subscription deleted")
@@ -283,7 +283,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let subscription = Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = []
 
         let deletionExpectation = expectation(description: "Subscription deleted")
@@ -310,7 +310,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let subscription = Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = []
 
         let deletionExpectation = expectation(description: "Subscription deleted")
@@ -347,7 +347,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
             updateExpectation.fulfill()
         }
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.upcomingMatch]
 
         newPreferences.save()
@@ -374,7 +374,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
             updateExpectation.fulfill()
         }
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.upcomingMatch]
 
         newPreferences.save()
@@ -401,7 +401,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
             updateExpectation.fulfill()
         }
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.upcomingMatch]
 
         newPreferences.save()
@@ -416,7 +416,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_subscription_insert() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.awards, .upcomingMatch]
 
         // Sanity check
@@ -434,7 +434,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_subscription_insert_304() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.awards, .upcomingMatch]
 
         // Sanity check
@@ -452,7 +452,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_subscription_insert_500() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.awards, .upcomingMatch]
 
         // Sanity check

--- a/tba-unit-tests/View Controllers/myTBA/MyTBAViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/myTBA/MyTBAViewControllerTests.swift
@@ -1,4 +1,3 @@
-import FirebaseMessaging
 import TBAData
 import XCTest
 @testable import MyTBAKit
@@ -12,7 +11,7 @@ class MyTBAViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        myTBAViewController = MyTBAViewController(messaging: Messaging.messaging(), myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        myTBAViewController = MyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController = MockNavigationController(rootViewController: myTBAViewController)
     }
 
@@ -85,7 +84,7 @@ class MyTBAViewControllerTests: TBATestCase {
     
     func test_authenticated() {
         let ex = expectation(description: "Authenticated")
-        let mock = MockMyTBAViewController(messaging: Messaging.messaging(), myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         mock.authenticatedExpectation = ex
         myTBA.authToken = "abcd123"
         wait(for: [ex], timeout: 1.0)
@@ -94,7 +93,7 @@ class MyTBAViewControllerTests: TBATestCase {
     func test_unauthenticated() {
         myTBA.authToken = "abcd123"
         let ex = expectation(description: "Unauthenticated")
-        let mock = MockMyTBAViewController(messaging: Messaging.messaging(), myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         mock.unauthenticatedExpectation = ex
         myTBA.authToken = nil
         wait(for: [ex], timeout: 1.0)

--- a/the-blue-alliance-ios/Extensions/ContainerViewController+Team.swift
+++ b/the-blue-alliance-ios/Extensions/ContainerViewController+Team.swift
@@ -1,5 +1,4 @@
 import Crashlytics
-import FirebaseMessaging
 import MyTBAKit
 import TBAData
 import UIKit
@@ -12,7 +11,6 @@ protocol ContainerTeamPushable {
 
     var teamKey: TeamKey { get }
     var myTBA: MyTBA { get }
-    var messaging: Messaging { get }
     var statusService: StatusService { get }
     var urlOpener: URLOpener { get }
 }
@@ -28,7 +26,7 @@ extension ContainerTeamPushable where Self: ContainerViewController {
                     self.rightBarButtonItems = [UIBarButtonItem.activityIndicatorBarButtonItem()]
                 }
 
-                let operation = tbaKit.fetchTeam(key: teamKey.key!, completion: { (result, notModified) in
+                let operation = tbaKit.fetchTeam(key: teamKey.key!) { (result, notModified) in
                     let context = self.persistentContainer.newBackgroundContext()
                     context.performChangesAndWait({
                         if let team = try? result.get() {
@@ -45,7 +43,7 @@ extension ContainerTeamPushable where Self: ContainerViewController {
                     DispatchQueue.main.async {
                         self.rightBarButtonItems = [self.pushTeamBarButtonItem].compactMap({ $0 })
                     }
-                })
+                }
                 fetchTeamOperationQueue.addOperation(operation)
             }
             return
@@ -55,7 +53,7 @@ extension ContainerTeamPushable where Self: ContainerViewController {
     }
 
     func _pushTeam(team: Team) {
-        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController?.pushViewController(teamViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/Protocols/Subscribable.swift
+++ b/the-blue-alliance-ios/Protocols/Subscribable.swift
@@ -1,5 +1,4 @@
 import Foundation
-import FirebaseMessaging
 import MyTBAKit
 import UIKit
 
@@ -8,7 +7,6 @@ import UIKit
 // Ex: The 'Event' view controller conforms to Subscribable, which shows the subscribe UI
 
 protocol Subscribable {
-    var messaging: Messaging { get }
     var myTBA: MyTBA { get }
     var favoriteBarButtonItem: UIBarButtonItem { get }
     var subscribableModel: MyTBASubscribable { get }
@@ -18,7 +16,6 @@ extension Subscribable where Self: UIViewController, Self: Persistable {
 
     func presentMyTBAPreferences() {
         let myTBAPreferencesViewController = MyTBAPreferenceViewController(subscribableModel: subscribableModel,
-                                                                           messaging: messaging,
                                                                            myTBA: myTBA,
                                                                            persistentContainer: persistentContainer)
         let navigationController = UINavigationController(rootViewController: myTBAPreferencesViewController)

--- a/the-blue-alliance-ios/Services/ReactNativeService.swift
+++ b/the-blue-alliance-ios/Services/ReactNativeService.swift
@@ -156,7 +156,7 @@ class ReactNativeService {
     }
 
     private func downloadReactNativeBundle(remoteBundleReference: StorageReference, completion: @escaping (Error?) -> Void) {
-        remoteBundleReference.write(toFile: compressedBundleURL, completion: { [unowned self] (url, error) in
+        remoteBundleReference.write(toFile: compressedBundleURL) { [unowned self] (url, error) in
             var downloadError: Error?
             if let error = error {
                 downloadError = error
@@ -169,7 +169,7 @@ class ReactNativeService {
                 }
             }
             completion(downloadError)
-        })
+        }
     }
 
     private func updateMetadata(storageMetadata: StorageMetadata) {

--- a/the-blue-alliance-ios/View Controllers/Base/Containers/MyTBAContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Containers/MyTBAContainerViewController.swift
@@ -1,5 +1,4 @@
 import CoreData
-import FirebaseMessaging
 import Foundation
 import MyTBAKit
 import TBAKit
@@ -7,7 +6,6 @@ import UIKit
 
 class MyTBAContainerViewController: ContainerViewController, Subscribable {
 
-    let messaging: Messaging
     let myTBA: MyTBA
 
     lazy var favoriteBarButtonItem: UIBarButtonItem = {
@@ -20,8 +18,7 @@ class MyTBAContainerViewController: ContainerViewController, Subscribable {
 
     // MARK: - Init
 
-    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.messaging = messaging
+    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.myTBA = myTBA
 
         super.init(viewControllers: viewControllers, navigationTitle: navigationTitle, navigationSubtitle: navigationSubtitle, segmentedControlTitles: segmentedControlTitles, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictEventsViewController.swift
@@ -38,7 +38,7 @@ class DistrictEventsViewController: EventsViewController {
 
     @objc override func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchDistrictEvents(key: district.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchDistrictEvents(key: district.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let events = try? result.get() {
@@ -48,7 +48,7 @@ class DistrictEventsViewController: EventsViewController {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictRankingsViewController.swift
@@ -94,7 +94,7 @@ extension DistrictRankingsViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchDistrictRankings(key: district.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchDistrictRankings(key: district.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let rankings = try? result.get() {
@@ -104,7 +104,7 @@ extension DistrictRankingsViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictTeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictTeamsViewController.swift
@@ -40,7 +40,7 @@ class DistrictTeamsViewController: TeamsViewController {
 
     @objc override func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchDistrictTeams(key: district.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchDistrictTeams(key: district.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let teams = try? result.get() {
@@ -50,7 +50,7 @@ class DistrictTeamsViewController: TeamsViewController {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
@@ -8,7 +8,6 @@ import UIKit
 class DistrictViewController: ContainerViewController {
 
     private(set) var district: District
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -19,9 +18,8 @@ class DistrictViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(district: District, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(district: District, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.district = district
-        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -66,7 +64,7 @@ class DistrictViewController: ContainerViewController {
 extension DistrictViewController: EventsViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
-        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventViewController, animated: true)
     }
 
@@ -79,7 +77,7 @@ extension DistrictViewController: EventsViewControllerDelegate {
 extension DistrictViewController: TeamsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
-        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamViewController, animated: true)
     }
 
@@ -88,7 +86,7 @@ extension DistrictViewController: TeamsViewControllerDelegate {
 extension DistrictViewController: DistrictRankingsViewControllerDelegate {
 
     func districtRankingSelected(_ districtRanking: DistrictRanking) {
-        let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: districtRanking, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: districtRanking, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtDistrictViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
@@ -124,7 +124,7 @@ extension DistrictBreakdownViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchDistrictRankings(key: ranking.district!.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchDistrictRankings(key: ranking.district!.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let rankings = try? result.get() {
@@ -134,7 +134,7 @@ extension DistrictBreakdownViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation!)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
@@ -122,7 +122,7 @@ extension DistrictTeamSummaryViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchDistrictRankings(key: ranking.district!.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchDistrictRankings(key: ranking.district!.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let rankings = try? result.get() {
@@ -132,7 +132,7 @@ extension DistrictTeamSummaryViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -15,7 +15,6 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
     var pushTeamBarButtonItem: UIBarButtonItem?
     private(set) var ranking: DistrictRanking
     let statusService: StatusService
-    let messaging: Messaging
     let myTBA: MyTBA
     let urlOpener: URLOpener
 
@@ -27,9 +26,8 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
 
     // MARK: Init
 
-    init(ranking: DistrictRanking, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(ranking: DistrictRanking, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.ranking = ranking
-        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -89,7 +87,7 @@ extension TeamAtDistrictViewController: DistrictTeamSummaryViewControllerDelegat
         }
 
         // TODO: Let's see what we can to do not force-unwrap these from Core Data
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: eventPoints.teamKey!, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: eventPoints.teamKey!, event: event, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
@@ -8,7 +8,6 @@ import UIKit
 
 class DistrictsContainerViewController: ContainerViewController {
 
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -24,8 +23,7 @@ class DistrictsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.messaging = messaging
+    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -105,7 +103,7 @@ extension DistrictsContainerViewController: DistrictsViewControllerDelegate {
 
     func districtSelected(_ district: District) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let districtViewController = DistrictViewController(district: district, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let districtViewController = DistrictViewController(district: district, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let nav = UINavigationController(rootViewController: districtViewController)
         navigationController?.showDetailViewController(nav, sender: nil)
     }

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
@@ -106,7 +106,7 @@ extension DistrictsViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchDistricts(year: year, completion: { (result, notModified) in
+        operation = tbaKit.fetchDistricts(year: year) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let districts = try? result.get() {
@@ -115,7 +115,7 @@ extension DistrictsViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAlliancesViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 class EventAlliancesContainerViewController: ContainerViewController {
 
     private(set) var event: Event
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -19,9 +18,8 @@ class EventAlliancesContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Event, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
-        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -55,7 +53,7 @@ class EventAlliancesContainerViewController: ContainerViewController {
 extension EventAlliancesContainerViewController: EventAlliancesViewControllerDelegate {
 
     func teamKeySelected(_ teamKey: TeamKey) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -159,7 +157,7 @@ extension EventAlliancesViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventAlliances(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventAlliances(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let alliances = try? result.get() {
@@ -169,7 +167,7 @@ extension EventAlliancesViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
@@ -9,17 +9,15 @@ class EventAwardsContainerViewController: ContainerViewController {
 
     private(set) var event: Event
     private(set) var teamKey: TeamKey?
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
 
     // MARK: - Init
 
-    init(event: Event, teamKey: TeamKey? = nil, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, teamKey: TeamKey? = nil, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
         self.teamKey = teamKey
-        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -70,7 +68,7 @@ extension EventAwardsContainerViewController: EventAwardsViewControllerDelegate 
         if teamKey == self.teamKey {
             return
         }
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -172,7 +170,7 @@ extension EventAwardsViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventAwards(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventAwards(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let awards = try? result.get() {
@@ -182,7 +180,7 @@ extension EventAwardsViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
@@ -9,16 +9,14 @@ import UIKit
 class EventDistrictPointsContainerViewController: ContainerViewController {
 
     private(set) var event: Event
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
 
     // MARK: - Init
 
-    init(event: Event, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
-        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -52,7 +50,7 @@ class EventDistrictPointsContainerViewController: ContainerViewController {
 extension EventDistrictPointsContainerViewController: EventDistrictPointsViewControllerDelegate {
 
     func districtEventPointsSelected(_ districtEventPoints: DistrictEventPoints) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: districtEventPoints.teamKey!, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: districtEventPoints.teamKey!, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -152,7 +150,7 @@ extension EventDistrictPointsViewController: Refreshable {
         let eventKey = event.key!
 
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventDistrictPoints(key: eventKey, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventDistrictPoints(key: eventKey) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let (eventPoints, _) = try? result.get() {
@@ -162,7 +160,7 @@ extension EventDistrictPointsViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventInfoViewController.swift
@@ -241,7 +241,7 @@ extension EventInfoViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEvent(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEvent(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 switch result {
@@ -257,7 +257,7 @@ extension EventInfoViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventRankingsViewController.swift
@@ -94,7 +94,7 @@ extension EventRankingsViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventRankings(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventRankings(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let (rankings, sortOrder, extraStats) = try? result.get() {
@@ -104,7 +104,7 @@ extension EventRankingsViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventTeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventTeamsViewController.swift
@@ -38,7 +38,7 @@ class EventTeamsViewController: TeamsViewController {
 
     @objc override func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventTeams(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventTeams(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let teams = try? result.get() {
@@ -48,7 +48,7 @@ class EventTeamsViewController: TeamsViewController {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventViewController.swift
@@ -22,7 +22,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 
     // MARK: - Init
 
-    init(event: Event, statusService: StatusService, urlOpener: URLOpener, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -34,7 +34,6 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 
         super.init(viewControllers: [infoViewController, teamsViewController, rankingsViewController, matchesViewController],
                    segmentedControlTitles: ["Info", "Teams", "Rankings", "Matches"],
-                   messaging: messaging,
                    myTBA: myTBA,
                    persistentContainer: persistentContainer,
                    tbaKit: tbaKit,
@@ -85,22 +84,22 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 extension EventViewController: EventInfoViewControllerDelegate {
 
     func showAlliances() {
-        let eventAlliancesViewController = EventAlliancesContainerViewController(event: event, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventAlliancesViewController = EventAlliancesContainerViewController(event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventAlliancesViewController, animated: true)
     }
 
     func showAwards() {
-        let eventAwardsViewController = EventAwardsContainerViewController(event: event, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventAwardsViewController = EventAwardsContainerViewController(event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventAwardsViewController, animated: true)
     }
 
     func showDistrictPoints() {
-        let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(event: event, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventDistrictPointsViewController, animated: true)
     }
 
     func showStats() {
-        let eventStatsContainerViewController = EventStatsContainerViewController(event: event, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventStatsContainerViewController = EventStatsContainerViewController(event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(eventStatsContainerViewController, animated: true)
     }
 
@@ -109,7 +108,7 @@ extension EventViewController: EventInfoViewControllerDelegate {
 extension EventViewController: TeamsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.teamKey, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -118,7 +117,7 @@ extension EventViewController: TeamsViewControllerDelegate {
 extension EventViewController: EventRankingsViewControllerDelegate {
 
     func rankingSelected(_ ranking: EventRanking) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: ranking.teamKey!, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: ranking.teamKey!, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -127,7 +126,7 @@ extension EventViewController: EventRankingsViewControllerDelegate {
 extension EventViewController: MatchesViewControllerDelegate, MatchesViewControllerQueryable {
 
     func matchSelected(_ match: Match) {
-        let matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsContainerViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 class EventStatsContainerViewController: ContainerViewController {
 
     private(set) var event: Event
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -18,9 +17,8 @@ class EventStatsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Event, messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.event = event
-        self.messaging = messaging
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -101,7 +99,7 @@ extension EventStatsContainerViewController: EventTeamStatsSelectionDelegate {
     }
 
     func eventTeamStatSelected(_ eventTeamStat: EventTeamStat) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: eventTeamStat.teamKey!, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: eventTeamStat.teamKey!, event: event, myTBA: myTBA, showDetailEvent: false, showDetailTeam: true, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventStatsViewController.swift
@@ -80,7 +80,7 @@ extension EventStatsViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventInsights(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventInsights(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let insights = try? result.get() {
@@ -90,7 +90,7 @@ extension EventStatsViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -160,7 +160,7 @@ extension EventTeamStatsTableViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventTeamStats(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventTeamStats(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let stats = try? result.get() {
@@ -170,7 +170,7 @@ extension EventTeamStatsTableViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
@@ -8,7 +8,6 @@ import UIKit
 
 class EventsContainerViewController: ContainerViewController {
 
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -18,8 +17,7 @@ class EventsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.messaging = messaging
+    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -105,7 +103,7 @@ extension EventsContainerViewController: EventsViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let nav = UINavigationController(rootViewController: eventViewController)
         navigationController?.showDetailViewController(nav, sender: nil)
     }

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -67,7 +67,7 @@ class WeekEventsViewController: EventsViewController {
         }
 
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEvents(year: year, completion: { [unowned self] (result, notModified) in
+        operation = tbaKit.fetchEvents(year: year) { [unowned self] (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let events = try? result.get() {
@@ -88,7 +88,7 @@ class WeekEventsViewController: EventsViewController {
                     }
                 }
             }
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -181,7 +181,7 @@ private class WeeksSelectTableViewController: SelectTableViewController<EventWee
 
     @objc override func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEvents(year: year, completion: { (result, notModified) in
+        operation = tbaKit.fetchEvents(year: year) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let events = try? result.get() {
@@ -195,7 +195,7 @@ private class WeeksSelectTableViewController: SelectTableViewController<EventWee
             DispatchQueue.main.async {
                 self.updateWeeks(in: self.persistentContainer.viewContext)
             }
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchViewController.swift
@@ -21,7 +21,7 @@ class MatchViewController: MyTBAContainerViewController {
 
     // MARK: Init
 
-    init(match: Match, teamKey: TeamKey? = nil, statusService: StatusService, urlOpener: URLOpener, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(match: Match, teamKey: TeamKey? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.match = match
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -39,7 +39,6 @@ class MatchViewController: MyTBAContainerViewController {
             navigationTitle: "\(match.friendlyName)",
             navigationSubtitle: "@ \(match.event?.friendlyNameWithYear ?? match.key!)", // TODO: Use EventKey
             segmentedControlTitles: titles,
-            messaging: messaging,
             myTBA: myTBA,
             persistentContainer: persistentContainer,
             tbaKit: tbaKit,
@@ -71,7 +70,7 @@ extension MatchViewController: MatchSummaryViewDelegate {
         // get team key that matches the target teamNumber
         guard let teamKey = match.teamKeys.first(where: { $0.teamNumber == "\(teamNumber)"}) else { return }
         
-        let teamAtEventVC = TeamAtEventViewController(teamKey: teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventVC = TeamAtEventViewController(teamKey: teamKey, event: event, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController?.pushViewController(teamAtEventVC, animated: true)
     }
     

--- a/the-blue-alliance-ios/View Controllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchesViewController.swift
@@ -196,7 +196,7 @@ extension MatchesViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventMatches(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventMatches(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let matches = try? result.get() {
@@ -206,7 +206,7 @@ extension MatchesViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBASignInViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBASignInViewController.swift
@@ -41,7 +41,7 @@ class MyTBASignInViewController: UIViewController {
                 $0.alpha = newImageAlpha
                 $0.isHidden = shouldHideImages
             }
-        }, completion: nil)
+        })
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
@@ -2,7 +2,6 @@ import CoreData
 import Crashlytics
 import FirebaseAnalytics
 import FirebaseAuth
-import FirebaseMessaging
 import GoogleSignIn
 import MyTBAKit
 import PureLayout
@@ -13,7 +12,6 @@ import UserNotifications
 
 class MyTBAViewController: ContainerViewController {
 
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -41,8 +39,7 @@ class MyTBAViewController: ContainerViewController {
         return myTBA.isAuthenticated
     }
 
-    init(messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.messaging = messaging
+    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -118,12 +115,7 @@ class MyTBAViewController: ContainerViewController {
     }
 
     private func logout() {
-        guard let fcmToken = messaging.fcmToken else {
-            // No FCM token to unregister
-            return
-        }
-
-        let signOutOperation = myTBA.unregister(fcmToken) { [weak self] (_, error) in
+        let signOutOperation = myTBA.unregister { [weak self] (_, error) in
             self?.isLoggingOut = false
 
             if let error = error as? MyTBAError, error.code != 404 {
@@ -136,8 +128,10 @@ class MyTBAViewController: ContainerViewController {
                 }
             }
         }
+        guard let op = signOutOperation else { return }
+
         isLoggingOut = true
-        OperationQueue.main.addOperation(signOutOperation!)
+        OperationQueue.main.addOperation(op)
     }
 
     private func logoutSuccessful() {
@@ -177,19 +171,19 @@ class MyTBAViewController: ContainerViewController {
 extension MyTBAViewController: MyTBATableViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
-        let viewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let viewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let navigationController = UINavigationController(rootViewController: viewController)
         self.navigationController?.showDetailViewController(navigationController, sender: nil)
     }
 
     func teamSelected(_ team: Team) {
-        let viewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let viewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let navigationController = UINavigationController(rootViewController: viewController)
         self.navigationController?.showDetailViewController(navigationController, sender: nil)
     }
 
     func matchSelected(_ match: Match) {
-        let viewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let viewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let navigationController = UINavigationController(rootViewController: viewController)
         self.navigationController?.showDetailViewController(navigationController, sender: nil)
     }

--- a/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
@@ -1,5 +1,4 @@
 import CoreData
-import FirebaseMessaging
 import MyTBAKit
 import TBAKit
 import UIKit
@@ -23,7 +22,7 @@ private enum DebugRow: Int, CaseIterable {
 
 class SettingsViewController: TBATableViewController {
 
-    private let messaging: Messaging
+    private let fcmTokenProvider: FCMTokenProvider
     private let metadata: ReactNativeMetadata
     private let myTBA: MyTBA
     private let pushService: PushService
@@ -37,8 +36,8 @@ class SettingsViewController: TBATableViewController {
 
     // MARK: - Init
 
-    init(messaging: Messaging, metadata: ReactNativeMetadata, myTBA: MyTBA, pushService: PushService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.messaging = messaging
+    init(fcmTokenProvider: FCMTokenProvider, metadata: ReactNativeMetadata, myTBA: MyTBA, pushService: PushService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.fcmTokenProvider = fcmTokenProvider
         self.metadata = metadata
         self.myTBA = myTBA
         self.pushService = pushService
@@ -349,7 +348,7 @@ class SettingsViewController: TBATableViewController {
     }
 
     private func pushTroubleshootNotifications() {
-        let notificationsViewController = NotificationsViewController(messaging: messaging, myTBA: myTBA, pushService: pushService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let notificationsViewController = NotificationsViewController(fcmTokenProvider: fcmTokenProvider, myTBA: myTBA, pushService: pushService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let nav = UINavigationController(rootViewController: notificationsViewController)
         navigationController?.showDetailViewController(nav, sender: nil)
     }

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -18,7 +18,6 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
 
     var pushTeamBarButtonItem: UIBarButtonItem?
 
-    let messaging: Messaging
     let myTBA: MyTBA
     let statusService: StatusService
     let urlOpener: URLOpener
@@ -30,13 +29,12 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
 
     // MARK: - Init
 
-    init(teamKey: TeamKey, event: Event, messaging: Messaging, myTBA: MyTBA, showDetailEvent: Bool, showDetailTeam: Bool, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(teamKey: TeamKey, event: Event, myTBA: MyTBA, showDetailEvent: Bool, showDetailTeam: Bool, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.teamKey = teamKey
         self.event = event
         self.showDetailEvent = showDetailEvent
         self.showDetailTeam = showDetailTeam
         self.myTBA = myTBA
-        self.messaging = messaging
         self.statusService = statusService
         self.urlOpener = urlOpener
 
@@ -91,7 +89,7 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
     // MARK: - Private Methods
 
     @objc private func pushEvent() {
-        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         navigationController?.pushViewController(eventViewController, animated: true)
     }
 
@@ -104,12 +102,12 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
 extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewControllerQueryable, TeamSummaryViewControllerDelegate {
 
     func awardsSelected() {
-        let awardsViewController = EventAwardsContainerViewController(event: event, teamKey: teamKey, messaging: messaging, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let awardsViewController = EventAwardsContainerViewController(event: event, teamKey: teamKey, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(awardsViewController, animated: true)
     }
 
     func matchSelected(_ match: Match) {
-        let matchViewController = MatchViewController(match: match, teamKey: teamKey, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let matchViewController = MatchViewController(match: match, teamKey: teamKey, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 
@@ -123,7 +121,7 @@ extension TeamAtEventViewController: EventAwardsViewControllerDelegate {
             return
         }
 
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: showDetailEvent, showDetailTeam: showDetailTeam, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, event: event, myTBA: myTBA, showDetailEvent: showDetailEvent, showDetailTeam: showDetailTeam, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamStatsViewController.swift
@@ -120,7 +120,7 @@ extension TeamStatsViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventTeamStats(key: event.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchEventTeamStats(key: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let stats = try? result.get() {
@@ -130,7 +130,7 @@ extension TeamStatsViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -484,7 +484,7 @@ extension TeamSummaryViewController: Refreshable {
 
         // Refresh Team@Event status
         var teamStatusOperation: TBAKitOperation!
-        teamStatusOperation = tbaKit.fetchTeamStatus(key: teamKey.key!, eventKey: event.key!, completion: { (result, notModified) in
+        teamStatusOperation = tbaKit.fetchTeamStatus(key: teamKey.key!, eventKey: event.key!) { (result, notModified) in
             switch result {
             case .success(let status):
                 if let status = status {
@@ -504,12 +504,12 @@ extension TeamSummaryViewController: Refreshable {
             default:
                 break
             }
-        })
+        }
 
         // Refresh awards
         let teamKeyKey = teamKey.key!
         var awardsOperation: TBAKitOperation!
-        awardsOperation = tbaKit.fetchTeamAwards(key: teamKeyKey, eventKey: event.key!, completion: { (result, notModified) in
+        awardsOperation = tbaKit.fetchTeamAwards(key: teamKeyKey, eventKey: event.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let awards = try? result.get() {
@@ -520,7 +520,7 @@ extension TeamSummaryViewController: Refreshable {
                 self.tbaKit.storeCacheHeaders(awardsOperation)
                 self.executeUpdate(self.updateAwardsItem)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
 
         finalOperation = addRefreshOperations([teamStatusOperation, awardsOperation])
     }

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamEventsViewController.swift
@@ -47,7 +47,7 @@ class TeamEventsViewController: EventsViewController {
 
     @objc override func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchTeamEvents(key: team.key!, completion: { (result, notModified) in
+        operation = tbaKit.fetchTeamEvents(key: team.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let events = try? result.get() {
@@ -57,7 +57,7 @@ class TeamEventsViewController: EventsViewController {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         addRefreshOperations([operation])
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamInfoViewController.swift
@@ -204,7 +204,7 @@ extension TeamInfoViewController: Refreshable {
 
     @objc func refresh() {
         var infoOperation: TBAKitOperation!
-        infoOperation = tbaKit.fetchTeam(key: team.key!, completion: { (result, notModified) in
+        infoOperation = tbaKit.fetchTeam(key: team.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 switch result {
@@ -220,10 +220,10 @@ extension TeamInfoViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: infoOperation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
 
         var yearsOperation: TBAKitOperation!
-        yearsOperation = tbaKit.fetchTeamYearsParticipated(key: team.key!, completion: { (result, notModified) in
+        yearsOperation = tbaKit.fetchTeamYearsParticipated(key: team.key!) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let years = try? result.get() {
@@ -233,7 +233,7 @@ extension TeamInfoViewController: Refreshable {
             }, saved: {
                 self.tbaKit.storeCacheHeaders(yearsOperation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
 
         // TODO: Think about how we go about refreshing the years, and maybe also move it to the year selector as well?
         addRefreshOperations([infoOperation, yearsOperation])

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -224,7 +224,7 @@ extension TeamMediaCollectionViewController: Refreshable {
         var finalOperation: Operation!
 
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchTeamMedia(key: team.key!, year: year, completion: { (result, notModified) in
+        operation = tbaKit.fetchTeamMedia(key: team.key!, year: year) { (result, notModified) in
             let context = self.persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 if !notModified, let media = try? result.get() {
@@ -234,7 +234,7 @@ extension TeamMediaCollectionViewController: Refreshable {
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
             }, errorRecorder: Crashlytics.sharedInstance())
-        })
+        }
         let fetchMediaOperation = BlockOperation {
             guard let teamMedia = self.team.media?.allObjects as? [TeamMedia] else {
                 return

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamViewController.swift
@@ -45,7 +45,7 @@ class TeamViewController: MyTBAContainerViewController, Observable {
 
     // MARK: Init
 
-    init(team: Team, statusService: StatusService, urlOpener: URLOpener, messaging: Messaging, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(team: Team, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.team = team
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -60,7 +60,6 @@ class TeamViewController: MyTBAContainerViewController, Observable {
             navigationTitle: "Team \(team.teamNumber!.stringValue)",
             navigationSubtitle: ContainerViewController.yearSubtitle(year),
             segmentedControlTitles: ["Info", "Events", "Media"],
-            messaging: messaging,
             myTBA: myTBA,
             persistentContainer: persistentContainer,
             tbaKit: tbaKit,
@@ -202,7 +201,7 @@ extension TeamViewController: SelectTableViewControllerDelegate {
 extension TeamViewController: EventsViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.teamKey, event: event, messaging: messaging, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.teamKey, event: event, myTBA: myTBA, showDetailEvent: true, showDetailTeam: false, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
@@ -7,7 +7,6 @@ import UIKit
 
 class TeamsContainerViewController: ContainerViewController {
 
-    private let messaging: Messaging
     private let myTBA: MyTBA
     private let statusService: StatusService
     private let urlOpener: URLOpener
@@ -16,8 +15,7 @@ class TeamsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(messaging: Messaging, myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.messaging = messaging
+    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
@@ -53,7 +51,7 @@ extension TeamsContainerViewController: TeamsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, messaging: messaging, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let nav = UINavigationController(rootViewController: teamViewController)
         navigationController?.showDetailViewController(nav, sender: nil)
     }

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -113,7 +113,7 @@ class TeamsViewController: TBATableViewController, Refreshable, Stateful, TeamsV
     }
 
     private func fetchAllTeams(operationChanged: @escaping (TBAKitOperation, Int, [TBATeam]) -> Void, page: Int, completion: @escaping (Error?) -> Void) -> TBAKitOperation {
-        return tbaKit.fetchTeams(page: page, completion: { (result, notModified) in
+        return tbaKit.fetchTeams(page: page) { (result, notModified) in
             switch result {
             case .failure(let error):
                 completion(error)
@@ -124,7 +124,7 @@ class TeamsViewController: TBATableViewController, Refreshable, Stateful, TeamsV
                     operationChanged(self.fetchAllTeams(operationChanged: operationChanged, page: page + 1, completion: completion), page, teams)
                 }
             }
-        })
+        }
     }
 
     // MARK: - Stateful


### PR DESCRIPTION
I got a little carried away -

Removed all the `Messaging` DI necessities by adding a `fcmTokenProvider` to the `MyTBA` initializer and changing the myTBA `register`/`unregister`/`ping` methods to return `nil` if the `fcmTokenProvider` doesn't provide a token (most of the flows that grabbed the `fcmToken` would do this behavior anyways)

Also took a pass at all the `completion: {` blocks and changed them to the Swift block-as-final-argument shorthand