### PR TITLE
Support showing team name/location in Team@Event view

### DIFF
--- a/Frameworks/TBAData/Sources/Event/Event.swift
+++ b/Frameworks/TBAData/Sources/Event/Event.swift
@@ -239,13 +239,6 @@ extension Event {
         return webcasts
     }
 
-    public func awards(for teamKey: String) -> [Award] {
-        let teamPredicate = Award.teamPredicate(teamKey: teamKey)
-        return awards.filter {
-            return teamPredicate.evaluate(with: $0)
-        }
-    }
-
     public func dateString() -> String? {
         guard let startDate = startDate, let endDate = endDate else {
             return nil

--- a/Frameworks/TBAData/Tests/Event/EventTests.swift
+++ b/Frameworks/TBAData/Tests/Event/EventTests.swift
@@ -1313,30 +1313,6 @@ class EventTestCase: TBADataTestCase {
         XCTAssertEqual(event.weekString, "Week 2")
     }
 
-    func test_awards_forTeamKey() {
-        let event = insertDistrictEvent()
-
-        // Insert one award, with one award recipient
-        let frc1Model = TBAAwardRecipient(teamKey: "frc1")
-        let modelAwardOne = TBAAward(name: "The Fake Award",
-                                     awardType: 2,
-                                     eventKey: event.key,
-                                     recipients: [frc1Model],
-                                     year: 2018)
-        event.insert([modelAwardOne])
-
-        // Sanity check
-        XCTAssertEqual(event.awards.count, 1)
-
-        let frc1TeamKey = Team.insert("frc1", in: persistentContainer.viewContext)
-        let frc2TeamKey = Team.insert("frc2", in: persistentContainer.viewContext)
-
-        // Should be one award for frc1
-        XCTAssertEqual(event.awards(for: frc1TeamKey.key).count, 1)
-        // Should be no awards for frc2
-        XCTAssertEqual(event.awards(for: frc2TeamKey.key).count, 0)
-    }
-
     func test_safeShortName() {
         let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
         event.keyRaw = "2019miket"

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -43,8 +43,7 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
                    userDefaults: userDefaults)
 
         rightBarButtonItems = [
-            UIBarButtonItem(image: UIImage.eventIcon, style: .plain, target: self, action: #selector(pushEvent)),
-            UIBarButtonItem(image: UIImage.teamIcon, style: .plain, target: self, action: #selector(pushTeam))
+            UIBarButtonItem(image: UIImage.eventIcon, style: .plain, target: self, action: #selector(pushEvent))
         ]
 
         summaryViewController.delegate = self
@@ -76,17 +75,12 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
         navigationController?.pushViewController(eventViewController, animated: true)
     }
 
-    @objc private func pushTeam() {
-        pushTeam(team: team)
-    }
-
 }
 
 extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewControllerQueryable, TeamSummaryViewControllerDelegate {
 
-    func awardsSelected() {
-        let awardsViewController = EventAwardsContainerViewController(event: event, team: team, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        self.navigationController?.pushViewController(awardsViewController, animated: true)
+    func teamInfoSelected(_ team: Team) {
+        pushTeam(team: team)
     }
 
     func matchSelected(_ match: Match) {
@@ -103,7 +97,6 @@ extension TeamAtEventViewController: EventAwardsViewControllerDelegate {
         if self.team == team {
             return
         }
-
         let teamAtEventViewController = TeamAtEventViewController(team: team, event: event, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }


### PR DESCRIPTION
Add `InfoTableViewCell` to the Team@Event view, which should allow showing team name and location in the Team@Event view, and eventually avatar.

Also, removed the awards cell from the Team@Event view - there's already a tab, so we don't really need to duplicate that information

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-08 at 21 14 28](https://user-images.githubusercontent.com/516458/72031896-dda1c280-325b-11ea-98ca-3ba9b3a0bf11.png)

Closes https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/539