### PR TITLE
Allow Stateless view controllers to use TableViewDataSource

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
@@ -10,7 +10,9 @@ protocol TableViewDataSourceDelegate: AnyObject {
 class TableViewDataSource<Section: Hashable, Item: Hashable>: NSObject, UITableViewDataSource {
 
     private weak var dataSource: UITableViewDiffableDataSource<Section, Item>?
-    weak var delegate: (TableViewDataSourceDelegate & Stateful & Refreshable)?
+
+    weak var delegate: TableViewDataSourceDelegate?
+    weak var statefulDelegate: (Stateful & Refreshable)?
 
     init(dataSource: UITableViewDiffableDataSource<Section, Item>) {
         self.dataSource = dataSource
@@ -23,7 +25,7 @@ class TableViewDataSource<Section: Hashable, Item: Hashable>: NSObject, UITableV
     func numberOfSections(in tableView: UITableView) -> Int {
         let sections = dataSource?.numberOfSections(in: tableView) ?? 0
         if sections == 0 {
-            delegate?.showNoDataView()
+            statefulDelegate?.showNoDataView()
         }
         return sections
     }
@@ -31,9 +33,9 @@ class TableViewDataSource<Section: Hashable, Item: Hashable>: NSObject, UITableV
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let rows = dataSource?.tableView(tableView, numberOfRowsInSection: section) ?? 0
         if rows == 0 {
-            delegate?.showNoDataView()
+            statefulDelegate?.showNoDataView()
         } else {
-            delegate?.removeNoDataView()
+            statefulDelegate?.removeNoDataView()
         }
         return rows
     }

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictRankingsViewController.swift
@@ -60,6 +60,7 @@ class DistrictRankingsViewController: TBATableViewController {
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<DistrictRanking> = DistrictRanking.fetchRequest()
         fetchRequest.sortDescriptors = [

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
@@ -64,6 +64,7 @@ class DistrictsViewController: TBATableViewController {
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<District> = District.fetchRequest()
         fetchRequest.sortDescriptors = [

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventAwardsViewController.swift
@@ -130,6 +130,7 @@ class EventAwardsViewController: TBATableViewController {
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<Award> = Award.fetchRequest()
         fetchRequest.sortDescriptors = [

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventDistrictPointsViewController.swift
@@ -111,6 +111,7 @@ private class EventDistrictPointsViewController: TBATableViewController {
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<DistrictEventPoints> = DistrictEventPoints.fetchRequest()
         fetchRequest.sortDescriptors = [DistrictEventPoints.totalSortDescriptor()]

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventRankingsViewController.swift
@@ -60,6 +60,7 @@ class EventRankingsViewController: TBATableViewController {
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<EventRanking> = EventRanking.fetchRequest()
         fetchRequest.sortDescriptors = [

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -99,6 +99,7 @@ class EventTeamStatsTableViewController: TBATableViewController {
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<EventTeamStat> = EventTeamStat.fetchRequest()
         setupFetchRequest(fetchRequest)

--- a/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
@@ -93,6 +93,7 @@ class EventsViewController: TBATableViewController, Refreshable, Stateful, Event
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<Event> = Event.fetchRequest()
         let sortDescriptors = [firstSortDescriptor] + Event.sortDescriptors()

--- a/the-blue-alliance-ios/View Controllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchesViewController.swift
@@ -85,6 +85,7 @@ class MatchesViewController: TBATableViewController {
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<Match> = Match.fetchRequest()
         setupFetchRequest(fetchRequest)

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
@@ -100,6 +100,7 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
         })
         _dataSource = TableViewDataSource(dataSource: dataSource)
         _dataSource.delegate = self
+        _dataSource.statefulDelegate = self
     }
 
     // MARK: NSFetchedResultsController

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -175,6 +175,7 @@ class TeamSummaryViewController: TBATableViewController {
         })
         _dataSource = TableViewDataSource(dataSource: dataSource)
         _dataSource.delegate = self
+        _dataSource.statefulDelegate = self
     }
 
     private func updateTeamInfo() {

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -145,6 +145,7 @@ class TeamsViewController: TBATableViewController, Refreshable, Stateful, TeamsV
         }
         self.dataSource = TableViewDataSource(dataSource: dataSource)
         self.dataSource.delegate = self
+        self.dataSource.statefulDelegate = self
 
         let fetchRequest: NSFetchRequest<Team> = Team.fetchRequest()
         fetchRequest.sortDescriptors = [


### PR DESCRIPTION
This should allow our simpler table views to use `TableViewDataSource`