### PR TITLE
Fix selection modals not reloading underlying views in iOS 13

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Base/Containers/ContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Containers/ContainerViewController.swift
@@ -160,7 +160,6 @@ class ContainerViewController: UIViewController, Persistable, Alertable {
         rootStackView.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .top)
     }
 
-    // TODO: This isn't being called in iOS 13 when dismissing modal view controllers
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsViewController.swift
@@ -14,7 +14,6 @@ class DistrictsViewController: TBATableViewController {
     weak var delegate: DistrictsViewControllerDelegate?
     var year: Int {
         didSet {
-            cancelRefresh()
             updateDataSource()
         }
     }
@@ -78,6 +77,10 @@ class DistrictsViewController: TBATableViewController {
 
     private func updateDataSource() {
         fetchedResultsController.reconfigureFetchRequest(setupFetchRequest(_:))
+
+        if shouldRefresh() {
+            refresh()
+        }
     }
 
     private func setupFetchRequest(_ request: NSFetchRequest<District>) {

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -110,6 +110,10 @@ class EventTeamStatsTableViewController: TBATableViewController {
 
     private func updateDataSource() {
         fetchedResultsController.reconfigureFetchRequest(setupFetchRequest(_:))
+
+        if shouldRefresh() {
+            refresh()
+        }
     }
 
     private func setupFetchRequest(_ request: NSFetchRequest<EventTeamStat>) {

--- a/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
@@ -106,6 +106,10 @@ class EventsViewController: TBATableViewController, Refreshable, Stateful, Event
 
     func updateDataSource() {
         fetchedResultsController.reconfigureFetchRequest(setupFetchRequest(_:))
+
+        if shouldRefresh() {
+            refresh()
+        }
     }
 
     private func setupFetchRequest(_ request: NSFetchRequest<Event>) {

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -20,7 +20,6 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
 
     var year: Int? {
         didSet {
-            cancelRefresh()
             updateDataSource()
         }
     }
@@ -158,6 +157,10 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
 
     private func updateDataSource() {
         fetchedResultsController.reconfigureFetchRequest(setupFetchRequest(_:))
+
+        if shouldRefresh() {
+            refresh()
+        }
     }
 
     private func setupFetchRequest(_ request: NSFetchRequest<TeamMedia>) {


### PR DESCRIPTION
I'm not in love with this solution but it'll work for now

Closes #705