### PR TITLE
Fix Match Summary background view inconsistent with cell highlight background color

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchInfoViewController.swift
@@ -143,7 +143,7 @@ class MatchInfoViewController: TBAViewController, Observable {
                 scoreTitleLabel.autoMatch(.width, to: .width, of: matchSummaryView.redScoreLabel)
             } else {
                 // Match the 'Time' label to the size of the time
-                scoreTitleLabel.autoMatch(.width, to: .width, of: matchSummaryView.timeView)
+                scoreTitleLabel.autoMatch(.width, to: .width, of: matchSummaryView.timeLabel)
             }
         }
     }

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.swift
@@ -50,7 +50,6 @@ class MatchSummaryView: UIView {
     @IBOutlet weak var blueScoreLabel: UILabel!
     @IBOutlet private weak var blueRPStackView: UIStackView!
 
-    @IBOutlet weak var timeView: UIView!
     @IBOutlet weak var timeLabel: UILabel!
     
 
@@ -153,14 +152,17 @@ class MatchSummaryView: UIView {
         } else {
             redScoreLabel.text = nil
         }
+        redScoreView.isHidden = viewModel.redScore == nil
+
         if let blueScore = viewModel.blueScore {
             blueScoreLabel.text = "\(blueScore)"
         } else {
             blueScoreLabel.text = nil
         }
+        blueScoreView.isHidden = viewModel.blueScore == nil
 
         timeLabel.text = viewModel.timeString
-        timeView.isHidden = viewModel.hasScores
+        timeLabel.isHidden = viewModel.hasScores
 
         if viewModel.redAllianceWon {
             redContainerView.layer.borderWidth = 2.0

--- a/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
+++ b/the-blue-alliance-ios/View Elements/Match/MatchSummaryView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,25 +24,24 @@
                 <outlet property="redStackView" destination="Ifh-sb-xaX" id="wM1-3g-BXu"/>
                 <outlet property="summaryView" destination="iN0-l3-epB" id="uEA-0I-L6n"/>
                 <outlet property="timeLabel" destination="D1e-rS-9fu" id="GLs-Sc-vvY"/>
-                <outlet property="timeView" destination="1sY-pY-r3s" id="3c3-KT-IkL"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="553" height="138"/>
+            <rect key="frame" x="0.0" y="0.0" width="658" height="158"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="N94-SY-H14">
-                    <rect key="frame" x="0.0" y="0.0" width="553" height="138"/>
+                    <rect key="frame" x="0.0" y="0.0" width="658" height="158"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Jmu-Uu-boJ">
-                            <rect key="frame" x="0.0" y="0.0" width="60" height="138"/>
+                            <rect key="frame" x="0.0" y="0.0" width="60" height="158"/>
                             <subviews>
                                 <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IRh-sF-Phh">
-                                    <rect key="frame" x="0.0" y="0.0" width="60" height="42.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="60" height="52.5"/>
                                 </view>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="tkL-p5-dZ1">
-                                    <rect key="frame" x="0.0" y="42.5" width="60" height="53.5"/>
+                                    <rect key="frame" x="0.0" y="52.5" width="60" height="53.5"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Quarters 1-1" textAlignment="center" lineBreakMode="clip" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="yPd-Gy-NoB">
                                             <rect key="frame" x="0.0" y="0.0" width="60" height="33.5"/>
@@ -57,7 +56,7 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="F1U-is-RmS">
-                                    <rect key="frame" x="0.0" y="96" width="60" height="42"/>
+                                    <rect key="frame" x="0.0" y="106" width="60" height="52"/>
                                 </view>
                             </subviews>
                             <constraints>
@@ -66,22 +65,22 @@
                             </constraints>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="eE4-4s-f1F">
-                            <rect key="frame" x="68" y="0.0" width="485" height="138"/>
+                            <rect key="frame" x="68" y="0.0" width="442.5" height="158"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="UCu-Ml-6fc">
-                                    <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mpK-JO-dy3">
-                                            <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="Ifh-sb-xaX">
-                                                    <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DTT-M1-On3">
-                                                            <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="114" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r4c-pQ-IQY">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                                                     <color key="backgroundColor" red="1" green="0.86666666670000003" blue="0.86666666670000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="150" id="rJJ-xb-K6o"/>
@@ -131,19 +130,19 @@
                                     </variation>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="8Xt-Td-koe">
-                                    <rect key="frame" x="0.0" y="69" width="485" height="69"/>
+                                    <rect key="frame" x="0.0" y="79" width="442.5" height="79"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ujk-xM-7ok">
-                                            <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="C6h-fR-VJi">
-                                                    <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HMh-7L-pf5">
-                                                            <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5774" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BIa-h9-yIu">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="485" height="69"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="442.5" height="79"/>
                                                                     <color key="backgroundColor" red="0.86666666670000003" green="0.86274509799999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="150" id="tIL-6y-jGh"/>
@@ -204,49 +203,30 @@
                                 </mask>
                             </variation>
                         </stackView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="Sat 12:27 PM" textAlignment="center" lineBreakMode="clip" numberOfLines="3" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="D1e-rS-9fu">
+                            <rect key="frame" x="518.5" y="0.0" width="139.5" height="158"/>
+                            <viewLayoutGuide key="safeArea" id="KX7-UR-bWs"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                     </subviews>
-                </stackView>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zcJ-DS-Tv6">
-                    <rect key="frame" x="434" y="0.0" width="119" height="138"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1sY-pY-r3s">
-                            <rect key="frame" x="0.0" y="0.0" width="119" height="138"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="Sat 12:27 PM" textAlignment="center" lineBreakMode="clip" numberOfLines="3" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="D1e-rS-9fu">
-                                    <rect key="frame" x="2" y="0.0" width="115" height="138"/>
-                                    <viewLayoutGuide key="safeArea" id="KX7-UR-bWs"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                            <constraints>
-                                <constraint firstAttribute="bottom" secondItem="D1e-rS-9fu" secondAttribute="bottom" id="NTT-iy-8ZI"/>
-                                <constraint firstItem="D1e-rS-9fu" firstAttribute="leading" secondItem="1sY-pY-r3s" secondAttribute="leading" constant="2" id="OXo-U5-QCk"/>
-                                <constraint firstAttribute="trailing" secondItem="D1e-rS-9fu" secondAttribute="trailing" constant="2" id="wBq-ef-YHL"/>
-                                <constraint firstItem="D1e-rS-9fu" firstAttribute="top" secondItem="1sY-pY-r3s" secondAttribute="top" id="wuJ-Lr-zw6"/>
-                            </constraints>
-                        </view>
-                    </subviews>
+                    <constraints>
+                        <constraint firstItem="D1e-rS-9fu" firstAttribute="width" secondItem="eE4-4s-f1F" secondAttribute="width" multiplier="1/3" constant="-8" id="zIt-3f-bOZ"/>
+                    </constraints>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
                 <constraint firstItem="N94-SY-H14" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9Mn-zS-QSy"/>
-                <constraint firstItem="eE4-4s-f1F" firstAttribute="width" secondItem="zcJ-DS-Tv6" secondAttribute="width" multiplier="4" constant="8" id="B38-8I-139"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="N94-SY-H14" secondAttribute="bottom" id="U1g-rV-upl"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="N94-SY-H14" secondAttribute="trailing" id="VKx-dT-xzk"/>
-                <constraint firstItem="zcJ-DS-Tv6" firstAttribute="top" secondItem="eE4-4s-f1F" secondAttribute="top" id="Y1m-la-PDH"/>
-                <constraint firstItem="zcJ-DS-Tv6" firstAttribute="bottom" secondItem="eE4-4s-f1F" secondAttribute="bottom" id="bH2-c2-7vk"/>
                 <constraint firstItem="N94-SY-H14" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="cCj-PU-3HE"/>
-                <constraint firstItem="zcJ-DS-Tv6" firstAttribute="trailing" secondItem="eE4-4s-f1F" secondAttribute="trailing" id="t6g-8l-cuY"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <point key="canvasLocation" x="-92" y="-78.260869565217391"/>
+            <point key="canvasLocation" x="-8" y="-69.265367316341838"/>
         </view>
     </objects>
     <resources>

--- a/the-blue-alliance-ios/View Elements/Match/MatchTableViewCell.swift
+++ b/the-blue-alliance-ios/View Elements/Match/MatchTableViewCell.swift
@@ -19,54 +19,12 @@ class MatchTableViewCell: UITableViewCell, Reusable {
 
     @IBOutlet private var matchSummaryView: MatchSummaryView!
 
-    private var coloredViews: [UIView] {
-        return [matchSummaryView.redContainerView, matchSummaryView.redScoreLabel, matchSummaryView.blueContainerView, matchSummaryView.blueScoreLabel, matchSummaryView.timeView]
-    }
-
     // MARK: - View Methods
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        let colors = storeBaseColors(for: coloredViews)
-        super.setSelected(selected, animated: animated)
-
-        if selected {
-            restoreBaseColors(colors, for: coloredViews)
-        }
-    }
-
-    override func setHighlighted(_ highlighted: Bool, animated: Bool) {
-        let colors = storeBaseColors(for: coloredViews)
-        super.setHighlighted(highlighted, animated: animated)
-
-        if highlighted {
-            restoreBaseColors(colors, for: coloredViews)
-        }
-    }
 
     override func prepareForReuse() {
         super.prepareForReuse()
 
         matchSummaryView?.resetView()
-    }
-
-    // MARK: - Private Methods
-
-    private func storeBaseColors(for views: [UIView]) -> [UIColor] {
-        var colors: [UIColor] = []
-        for view in views {
-            colors.append(view.backgroundColor!)
-        }
-        return colors
-    }
-
-    private func restoreBaseColors(_ colors: [UIColor], for views: [UIView]) {
-        if colors.count != views.count {
-            return
-        }
-
-        for (index, view) in views.enumerated() {
-            view.backgroundColor = colors[index]
-        }
     }
 
 }


### PR DESCRIPTION
I think this will work for now - closes #654

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-19 at 12 06 52](https://user-images.githubusercontent.com/516458/72685075-60c0e500-3ab4-11ea-8bf0-0e146af2bf38.png)
