### PR TITLE
Show full name for myTBA Event cells

### DIFF
--- a/Frameworks/TBAData/Sources/Event/Event.swift
+++ b/Frameworks/TBAData/Sources/Event/Event.swift
@@ -294,6 +294,13 @@ extension Event {
         return shortName.isEmpty ? name : shortName
     }
 
+    public var safeNameYear: String {
+        guard let name = name else {
+            return key
+        }
+        return name.isEmpty ? key : "\(year) \(name)"
+    }
+
     public var friendlyNameWithYear: String {
         guard let name = name else {
             return key

--- a/Frameworks/TBAData/Tests/Event/EventTests.swift
+++ b/Frameworks/TBAData/Tests/Event/EventTests.swift
@@ -1313,6 +1313,20 @@ class EventTestCase: TBADataTestCase {
         XCTAssertEqual(event.weekString, "Week 2")
     }
 
+    func test_safeNameYear() {
+        let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
+        event.yearRaw = NSNumber(value: 2019)
+        event.keyRaw = "2019miket"
+        // No name - use key
+        XCTAssertEqual(event.safeNameYear, "2019miket")
+        // Empty name - use key
+        event.nameRaw = ""
+        XCTAssertEqual(event.safeNameYear, "2019miket")
+        // Name - use name
+        event.nameRaw = "FIM District Kettering University Event #1"
+        XCTAssertEqual(event.safeNameYear, "2019 FIM District Kettering University Event #1")
+    }
+
     func test_safeShortName() {
         let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
         event.keyRaw = "2019miket"

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBATableViewController.swift
@@ -165,7 +165,7 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
 
     private static func tableView(_ tableView: UITableView, cellForEvent event: Event, at indexPath: IndexPath) -> EventTableViewCell {
         let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
-        cell.viewModel = EventCellViewModel(event: event)
+        cell.viewModel = EventCellViewModel(name: event.safeNameYear, location: event.locationString, dateString: event.dateString)
         return cell
     }
 

--- a/the-blue-alliance-ios/View Elements/Events/EventCellViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Events/EventCellViewModel.swift
@@ -4,14 +4,20 @@ import TBAProtocols
 
 struct EventCellViewModel {
 
-    let eventShortname: String
-    let eventLocation: String?
-    let eventDate: String?
+    let name: String
+    let location: String?
+    let dateString: String?
 
     init(event: Event) {
-        eventShortname = event.safeShortName
-        eventLocation = event.locationString
-        eventDate = event.dateString
+        name = event.safeShortName
+        location = event.locationString
+        dateString = event.dateString
+    }
+
+    init(name: String, location: String?, dateString: String?) {
+        self.name = name
+        self.location = location
+        self.dateString = dateString
     }
 
 }

--- a/the-blue-alliance-ios/View Elements/Events/EventTableViewCell.swift
+++ b/the-blue-alliance-ios/View Elements/Events/EventTableViewCell.swift
@@ -27,9 +27,9 @@ class EventTableViewCell: UITableViewCell, Reusable {
             return
         }
 
-        nameLabel.text = viewModel.eventShortname
-        locationLabel.text = viewModel.eventLocation
-        dateLabel.text = viewModel.eventDate
+        nameLabel.text = viewModel.name
+        locationLabel.text = viewModel.location
+        dateLabel.text = viewModel.dateString
     }
 
 }

--- a/the-blue-alliance-ios/View Elements/Teams/TeamCellViewModel.swift
+++ b/the-blue-alliance-ios/View Elements/Teams/TeamCellViewModel.swift
@@ -4,13 +4,19 @@ import TBAData
 struct TeamCellViewModel {
 
     let teamNumber: String
-    let teamNickname: String
-    let teamLocation: String?
+    let nickname: String
+    let location: String?
 
     init(team: Team) {
         teamNumber = "\(team.teamNumber)"
-        teamNickname = team.nickname ?? team.teamNumberNickname
-        teamLocation = team.locationString
+        nickname = team.nickname ?? team.teamNumberNickname
+        location = team.locationString
+    }
+
+    init(teamNumber: String, nickname: String, location: String?) {
+        self.teamNumber = teamNumber
+        self.nickname = nickname
+        self.location = location
     }
 
 }

--- a/the-blue-alliance-ios/View Elements/Teams/TeamTableViewCell.swift
+++ b/the-blue-alliance-ios/View Elements/Teams/TeamTableViewCell.swift
@@ -29,7 +29,7 @@ class TeamTableViewCell: UITableViewCell, Reusable {
         }
 
         numberLabel.text = viewModel.teamNumber
-        nameLabel.text = viewModel.teamNickname
-        locationLabel.text = viewModel.teamLocation
+        nameLabel.text = viewModel.nickname
+        locationLabel.text = viewModel.location
     }
 }


### PR DESCRIPTION
This change looks MUCH better when showing events in the myTBA view where we're not filtering on year/week/type. Fixes #455

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-21 at 20 40 45](https://user-images.githubusercontent.com/516458/72858706-adace300-3c8f-11ea-802e-5be2cd019f26.png)
