### PR TITLE
Fix crash when event has multiple webcasts

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventInfoViewController.swift
@@ -18,13 +18,13 @@ private enum EventInfoSection: Int {
     case link
 }
 
-private enum EventInfoItem {
+private enum EventInfoItem: Hashable {
     case title
     case alliances
     case districtPoints
     case stats
     case awards
-    case webcast
+    case webcast(Webcast)
     case website
     case twitter
     case youtube
@@ -147,7 +147,7 @@ class EventInfoViewController: TBATableViewController, Observable {
         snapshot.appendItems(detailItems, toSection: .detail)
 
         // Webcasts
-        let webcasts = event.webcasts.compactMap { $0.urlString }.map { _ in EventInfoItem.webcast }
+        let webcasts = event.webcasts.map { EventInfoItem.webcast($0) }
         if !webcasts.isEmpty, event.isHappeningThisWeek {
             snapshot.appendSections([.webcast])
             snapshot.appendItems(webcasts, toSection: .webcast)
@@ -201,8 +201,7 @@ class EventInfoViewController: TBATableViewController, Observable {
             delegate?.showStats()
         case .awards:
             delegate?.showAwards()
-        case .webcast:
-            let webcast = event.webcasts[indexPath.row]
+        case .webcast(let webcast):
             urlString = webcast.urlString
         case .website:
             urlString = event.website


### PR DESCRIPTION
Currently we're inserting two `.webcast` rows, which isn't unique in our diffable data source, and we crash. This adds the `Webcast` as an associated value, which as long as it's a different object, won't crash when an Event has multiple webcasts

![Simulator Screen Shot - iPhone 11 Pro - 2020-02-22 at 10 20 32](https://user-images.githubusercontent.com/516458/75094900-600cea00-555d-11ea-989f-286a8595e3ad.png)
