### PR TITLE
Fix YouTube webcast watch link

### DIFF
--- a/Frameworks/TBAData/Sources/Event/Webcast.swift
+++ b/Frameworks/TBAData/Sources/Event/Webcast.swift
@@ -17,7 +17,7 @@ extension Webcast {
         if type == "twitch" {
             return "https://twitch.tv/\(channel)"
         } else if type == "youtube" {
-            return "https://youtube.com/\(channel)"
+            return "https://www.youtube.com/watch?v=\(channel)"
         }
         return nil
     }


### PR DESCRIPTION
The old YouTube link is right for channels, but wrong for streams 🤷‍♂ 