### PR TITLE
Move webcast section above event info. Filter YouTube webcasts to be shown on the proper day

### DIFF
--- a/Frameworks/TBAData/Resources/TBA.xcdatamodeld/TBA.xcdatamodel/contents
+++ b/Frameworks/TBAData/Resources/TBA.xcdatamodeld/TBA.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15702" systemVersion="18G103" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15702" systemVersion="19C57" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Award" representedClassName="Award" syncable="YES">
         <attribute name="awardTypeRaw" attributeType="Integer 64" usesScalarValueType="NO"/>
         <attribute name="nameRaw" attributeType="String"/>
@@ -289,6 +289,7 @@
     </entity>
     <entity name="Webcast" representedClassName="Webcast" syncable="YES">
         <attribute name="channelRaw" attributeType="String"/>
+        <attribute name="dateRaw" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="fileRaw" optional="YES" attributeType="String"/>
         <attribute name="typeRaw" attributeType="String"/>
         <relationship name="eventsRaw" toMany="YES" minCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="webcastsRaw" inverseEntity="Event"/>
@@ -323,6 +324,6 @@
         <element name="Subscription" positionX="54" positionY="144" width="128" height="58"/>
         <element name="Team" positionX="-54" positionY="135" width="128" height="583"/>
         <element name="TeamMedia" positionX="-45" positionY="144" width="128" height="193"/>
-        <element name="Webcast" positionX="-45" positionY="144" width="128" height="103"/>
+        <element name="Webcast" positionX="-45" positionY="144" width="128" height="118"/>
     </elements>
 </model>

--- a/Frameworks/TBAData/Sources/Event/Webcast.swift
+++ b/Frameworks/TBAData/Sources/Event/Webcast.swift
@@ -29,6 +29,10 @@ extension Webcast {
         return channel
     }
 
+    public var date: Date? {
+        return getValue(\Webcast.dateRaw)
+    }
+
     public var file: String? {
         return getValue(\Webcast.fileRaw)
     }
@@ -58,6 +62,7 @@ public class Webcast: NSManagedObject {
     }
 
     @NSManaged var channelRaw: String?
+    @NSManaged var dateRaw: Date?
     @NSManaged var fileRaw: String?
     @NSManaged var typeRaw: String?
     @NSManaged var eventsRaw: NSSet?
@@ -105,6 +110,7 @@ extension Webcast: Managed {
             // Required: type, channel
             webcast.typeRaw = model.type
             webcast.channelRaw = model.channel
+            webcast.dateRaw = model.date
             webcast.fileRaw = model.file
         })
     }

--- a/Frameworks/TBAKit/Sources/TBAEvent.swift
+++ b/Frameworks/TBAKit/Sources/TBAEvent.swift
@@ -495,11 +495,13 @@ public struct TBAWebcast: TBAModel {
     public var type: String
     public var channel: String
     public var file: String?
+    public var date: Date?
 
-    public init(type: String, channel: String, file: String? = nil) {
+    public init(type: String, channel: String, file: String? = nil, date: Date? = nil) {
         self.type = type
         self.channel = channel
         self.file = file
+        self.date = date
     }
 
     init?(json: [String: Any]) {
@@ -513,7 +515,14 @@ public struct TBAWebcast: TBAModel {
             return nil
         }
         self.channel = channel
-        
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        if let dateString = json["date"] as? String, let date = dateFormatter.date(from: dateString) {
+            self.date = date
+        }
+
         self.file = json["file"] as? String
     }
 


### PR DESCRIPTION
Showing both items with one screenshot - the streams link is now higher to promote watching streams from the app, and the webcasts are filtered if they have a date associated to only show webcasts on the same day

![Simulator Screen Shot - iPhone 11 Pro - 2020-03-05 at 01 59 56](https://user-images.githubusercontent.com/516458/75956070-1f7a6e00-5e85-11ea-86e9-50513b6a68f0.png)
