### PR TITLE
[WIP] Only save Avatar when fetching Team Media for initial Team Info

### DIFF
--- a/Frameworks/TBAData/Sources/Team/Team.swift
+++ b/Frameworks/TBAData/Sources/Team/Team.swift
@@ -482,19 +482,42 @@ extension Team: Managed {
             $0.predicate = TeamMedia.teamYearPrediate(teamKey: key, year: year)
         }
 
-
         // Insert new TeamMedia for this year
         let media = media.map {
             return TeamMedia.insert($0, year: year, in: managedObjectContext)
         }
         addToMediaRaw(NSSet(array: media))
 
-        // Delete orphaned TeamMedia for this Event
+        // Delete orphaned TeamMedia for this Team
         Set(oldMedia).subtracting(Set(media)).forEach({
             managedObjectContext.delete($0)
         })
 
         return media
+    }
+
+    @discardableResult
+    public func insertAvatar(_ media: TBAMedia?, year: Int) {
+        guard let managedObjectContext = managedObjectContext else {
+            return
+        }
+
+        // Fetch previous Avatar for this Team and year
+        let oldAvatar = TeamMedia.fetchSingleObject(in: managedObjectContext) {
+            $0.predicate = TeamMedia.avatarYearPrediate(teamKey: key, year: year)
+        }
+
+        // Insert new Avatar for this year
+        if let media = media {
+            let avatar = TeamMedia.insert(media, year: year, in: managedObjectContext)
+            // TODO: This is problematic, and not working
+            addToMediaRaw(NSSet(object: avatar))
+        }
+
+        // Delete the old Avatar this year
+        if let oldAvatar = oldAvatar {
+            managedObjectContext.delete(oldAvatar)
+        }
     }
 
     /**

--- a/Frameworks/TBAData/Sources/Team/TeamMedia.swift
+++ b/Frameworks/TBAData/Sources/Team/TeamMedia.swift
@@ -197,6 +197,13 @@ extension TeamMedia {
                            #keyPath(TeamMedia.yearRaw), year)
     }
 
+    public static func avatarYearPrediate(teamKey: String, year: Int) -> NSPredicate {
+        return NSPredicate(format: "%K == %@ AND %K == %ld AND %K == %@",
+                           #keyPath(TeamMedia.teamRaw.keyRaw), teamKey,
+                           #keyPath(TeamMedia.yearRaw), year,
+                           #keyPath(TeamMedia.typeStringRaw), MediaType.avatar.rawValue)
+    }
+
     public static func teamYearImagesPrediate(teamKey: String, year: Int) -> NSPredicate {
         return NSPredicate(format: "%K == %@ AND %K == %ld AND %K in %@",
                            #keyPath(TeamMedia.teamRaw.keyRaw), teamKey,


### PR DESCRIPTION
Note to Zach: This might actually be a different problem with how we're cleaning up the media relationship. Doing a fetch in both Info and Media for team media shouldn't be a problem - one should clean up the other, and Media should fetch the missing images. The doubles might just be a problem with not maintaining the relationship properly on inserts somewhere.

Currently, going from Team Info -> Team Media will show doubles of Team Media

![Simulator Screen Shot - iPhone 11 Pro - 2020-03-05 at 02 52 21](https://user-images.githubusercontent.com/516458/75961263-acc2c000-5e8f-11ea-8d61-07df4a1823e0.png)

## To Do
- [ ] Clear existing Avatar when switching between years
- [ ] Fix `team.avatar` not returning a `TeamMedia` after reload/update
- [ ] Confirm this problem is reproducible when I'm less sleepy