### PR TITLE
Periodically refresh myTBA auth token

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1479694A215EBE460075AF4E /* EventAllianceCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14796949215EBE460075AF4E /* EventAllianceCellViewModel.swift */; };
 		1479694C215EC1670075AF4E /* EventTeamStatCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1479694B215EC1660075AF4E /* EventTeamStatCellViewModel.swift */; };
 		1479694E215EC4B60075AF4E /* InfoCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1479694D215EC4B60075AF4E /* InfoCellViewModel.swift */; };
+		14B5DF122413295A00BAE07D /* MyTBAService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B5DF112413295A00BAE07D /* MyTBAService.swift */; };
 		14F51704239AA70A00D9240F /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F51703239AA70A00D9240F /* SearchService.swift */; };
 		304ED0411EF1D2D300E31791 /* RankingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 304ED03F1EF1D2D300E31791 /* RankingTableViewCell.xib */; };
 		304ED0421EF1D2D300E31791 /* RankingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304ED0401EF1D2D300E31791 /* RankingTableViewCell.swift */; };
@@ -254,6 +255,7 @@
 		14796949215EBE460075AF4E /* EventAllianceCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAllianceCellViewModel.swift; sourceTree = "<group>"; };
 		1479694B215EC1660075AF4E /* EventTeamStatCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTeamStatCellViewModel.swift; sourceTree = "<group>"; };
 		1479694D215EC4B60075AF4E /* InfoCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoCellViewModel.swift; sourceTree = "<group>"; };
+		14B5DF112413295A00BAE07D /* MyTBAService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBAService.swift; sourceTree = "<group>"; };
 		14F51703239AA70A00D9240F /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		304ED03F1EF1D2D300E31791 /* RankingTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RankingTableViewCell.xib; sourceTree = "<group>"; };
 		304ED0401EF1D2D300E31791 /* RankingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RankingTableViewCell.swift; sourceTree = "<group>"; };
@@ -1143,6 +1145,7 @@
 				92F8E355209AAE890094213F /* PushService.swift */,
 				92DF54E021B1B65A0082C58C /* StatusService.swift */,
 				92564C6A21644AA30047917F /* Secrets.swift */,
+				14B5DF112413295A00BAE07D /* MyTBAService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1802,6 +1805,7 @@
 				92FF111921A61B37003BC5C4 /* TeamAtDistrictViewController.swift in Sources */,
 				925471F7208CC6F100AD3204 /* EventAllianceTableViewCell.swift in Sources */,
 				9279737F23CFF3B100FF9B86 /* EventStatsConfigurator2019.swift in Sources */,
+				14B5DF122413295A00BAE07D /* MyTBAService.swift in Sources */,
 				92FA4D3122865C1A00030BA3 /* TeamHeaderViewModel.swift in Sources */,
 				92F481F11E7DA04B00B4ED7E /* EventsContainerViewController.swift in Sources */,
 				92FF10EC21A61A1B003BC5C4 /* TeamEventsViewController.swift in Sources */,

--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -103,6 +103,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      deviceName: UIDevice.current.name,
                      fcmTokenProvider: messaging)
     }()
+    private var myTBAService: MyTBAService!
     let pasteboard = UIPasteboard.general
     lazy var persistentContainer: TBAPersistenceContainer = {
         return TBAPersistenceContainer()
@@ -160,6 +161,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Setup our Firebase app - make sure this is called before other Firebase setup
         FirebaseApp.configure()
 
+        // Setup myTBA Service after Firebase config
+        self.myTBAService = MyTBAService(myTBA: myTBA,
+                                         retryService: RetryService(),
+                                         errorRecorder: Crashlytics.sharedInstance())
+        self.myTBAService.registerRetryable()
+
         // Disable Crashlytics during debug
         #if DEBUG
         Fabric.sharedSDK().debug = true
@@ -179,16 +186,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupPushServiceDelegates()
         // Register for remote notifications - don't worry if we fail here
         PushService.registerForRemoteNotifications(nil)
-
-        Auth.auth().addIDTokenDidChangeListener { (_, user) in
-            if let user = user {
-                user.getIDToken { (token, _) in
-                    self.myTBA.authToken = token
-                }
-            } else {
-                self.myTBA.authToken = nil
-            }
-        }
 
         // Kickoff background myTBA/Google sign in, along with setting up delegates
         setupGoogleAuthentication()

--- a/the-blue-alliance-ios/Services/MyTBAService.swift
+++ b/the-blue-alliance-ios/Services/MyTBAService.swift
@@ -1,0 +1,51 @@
+import FirebaseAuth
+import Foundation
+import MyTBAKit
+import TBAUtils
+
+// Note: Not *really* a myTBA service. Really just a glorified token refresher, until someone comes up with a better design
+// to refresh tokens at the proper time before making requests to myTBA. Zach can probably figure it out, but he's very tired,
+// and has a lot of other things to get done. So instead he built a glorified token refresher.
+// Once we move to supporting Sign In with Apple we should move this in to the auth delegate thing that got built.
+class MyTBAService {
+
+    private let myTBA: MyTBA
+    internal var retryService: RetryService
+    private let errorRecorder: ErrorRecorder
+
+    private var user: User?
+
+    init(myTBA: MyTBA, retryService: RetryService, errorRecorder: ErrorRecorder) {
+        self.myTBA = myTBA
+        self.retryService = retryService
+        self.errorRecorder = errorRecorder
+
+        Auth.auth().addStateDidChangeListener { [weak self] (auth, user) in
+            self?.user = user
+            self?.retry()
+        }
+    }
+
+}
+
+extension MyTBAService: Retryable {
+
+    var retryInterval: TimeInterval {
+        return 60
+    }
+
+    func retry() {
+        if let user = user {
+            user.getIDToken() { [weak self] (token, error) in
+                if let error = error {
+                    self?.errorRecorder.recordError(error)
+                } else {
+                    self?.myTBA.authToken = token
+                }
+            }
+        } else {
+            myTBA.authToken = nil
+        }
+    }
+
+}


### PR DESCRIPTION
A pretty bad fix for the issue where our myTBA auth token is expiring after an hour and we're never refreshing it. This should periodically refresh our myTBA token every minute to ensure that users only go roughly ~60s with an expired myTBA token.

Absolutely sucks - it'll get a better fix eventually.