### PR TITLE
Only use split view controller on iPad

### DIFF
--- a/tba-unit-tests/Services/HandoffServiceTests.swift
+++ b/tba-unit-tests/Services/HandoffServiceTests.swift
@@ -1,9 +1,53 @@
+import CoreData
 import CoreSpotlight
+import Photos
+import MyTBAKit
 import Search
+import TBAKit
 import UIKit
 import XCTest
 @testable import TBAData
 @testable import The_Blue_Alliance
+
+struct FakeRootController: RootController {
+
+    let fcmTokenProvider: FCMTokenProvider
+    let myTBA: MyTBA
+    let pasteboard: UIPasteboard? = nil
+    let photoLibrary: PHPhotoLibrary? = nil
+    let pushService: PushService
+    let searchService: SearchService
+    let statusService: StatusService
+    let urlOpener: URLOpener
+    let persistentContainer: NSPersistentContainer
+    let tbaKit: TBAKit
+    let userDefaults: UserDefaults
+
+    var continueSearchExpectation: XCTestExpectation?
+    var continueSearchResult: Bool = true
+
+    var showEventExpectation: XCTestExpectation?
+    var showEventResult: Bool = true
+
+    var showTeamExpectation: XCTestExpectation?
+    var showTeamResult: Bool = true
+
+    func continueSearch(_ searchText: String) -> Bool {
+        continueSearchExpectation?.fulfill()
+        return continueSearchResult
+    }
+
+    func show(event: Event) -> Bool {
+        showEventExpectation?.fulfill()
+        return showEventResult
+    }
+
+    func show(team: Team) -> Bool {
+        showTeamExpectation?.fulfill()
+        return showTeamResult
+    }
+
+}
 
 class HandoffServiceTests: TBATestCase {
 
@@ -13,7 +57,8 @@ class HandoffServiceTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        self.handoffService = HandoffService(persistentContainer: persistentContainer, rootViewController: tabBarController)
+        let rootController = FakeRootController(fcmTokenProvider: fcmTokenProvider, myTBA: myTBA, pushService: pushService, searchService: searchService, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        self.handoffService = HandoffService(persistentContainer: persistentContainer, rootController: rootController)
     }
 
     func test_handoff_unsupported() {

--- a/tba-unit-tests/View Controllers/Districts/DistrictsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictsContainerViewControllerTests.swift
@@ -77,11 +77,9 @@ class DistrictsContainerViewControllerTests: TBATestCase {
         let district = insertDistrict()
 
         districtsContainerViewController.districtSelected(district)
+        XCTAssert(navigationController.pushedViewController is DistrictViewController)
 
-        XCTAssert(navigationController.detailViewController is UINavigationController)
-        let nav = navigationController.detailViewController as! UINavigationController
-        XCTAssert(nav.viewControllers.first is DistrictViewController)
-        let districtViewController = nav.viewControllers.first as! DistrictViewController
+        let districtViewController = navigationController.pushedViewController as! DistrictViewController
         XCTAssertEqual(districtViewController.district, district)
     }
 

--- a/tba-unit-tests/View Controllers/Events/EventsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Events/EventsContainerViewControllerTests.swift
@@ -88,11 +88,9 @@ class EventsContainerViewControllerTests: TBATestCase {
         let event = insertEvent()
 
         eventsContainerViewController.eventSelected(event)
+        XCTAssert(navigationController.pushedViewController is EventViewController)
 
-        XCTAssert(navigationController.detailViewController is UINavigationController)
-        let nav = navigationController.detailViewController as! UINavigationController
-        XCTAssert(nav.viewControllers.first is EventViewController)
-        let eventViewController = nav.viewControllers.first as! EventViewController
+        let eventViewController = navigationController.pushedViewController as! EventViewController
         XCTAssertEqual(eventViewController.event, event)
     }
 

--- a/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
@@ -49,11 +49,9 @@ class TeamsContainerViewControllerTests: TBATestCase {
         let team = insertTeam()
 
         teamsContainerViewController.teamSelected(team)
+        XCTAssert(navigationController.pushedViewController is TeamViewController)
 
-        XCTAssert(navigationController.detailViewController is UINavigationController)
-        let nav = navigationController.detailViewController as! UINavigationController
-        XCTAssert(nav.viewControllers.first is TeamViewController)
-        let teamViewController = nav.viewControllers.first as! TeamViewController
+        let teamViewController = navigationController.pushedViewController as! TeamViewController
         XCTAssertEqual(teamViewController.team, team)
     }
 

--- a/tba-unit-tests/View Controllers/myTBA/MyTBAViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/myTBA/MyTBAViewControllerTests.swift
@@ -57,29 +57,32 @@ class MyTBAViewControllerTests: TBATestCase {
 
     func test_eventSelected() {
         let event = insertDistrictEvent()
-        myTBAViewController.eventSelected(event)
 
-        XCTAssert(navigationController.detailViewController is UINavigationController)
-        let nav = navigationController.detailViewController as! UINavigationController
-        XCTAssert(nav.viewControllers.first is EventViewController)
+        myTBAViewController.eventSelected(event)
+        XCTAssert(navigationController.pushedViewController is EventViewController)
+
+        let eventViewController = navigationController.pushedViewController as! EventViewController
+        XCTAssertEqual(eventViewController.event, event)
     }
 
     func test_teamSelected() {
         let team = insertTeam()
-        myTBAViewController.teamSelected(team)
 
-        XCTAssert(navigationController.detailViewController is UINavigationController)
-        let nav = navigationController.detailViewController as! UINavigationController
-        XCTAssert(nav.viewControllers.first is TeamViewController)
+        myTBAViewController.teamSelected(team)
+        XCTAssert(navigationController.pushedViewController is TeamViewController)
+
+        let teamViewController = navigationController.pushedViewController as! TeamViewController
+        XCTAssertEqual(teamViewController.team, team)
     }
 
     func test_myTBAObjectSelected_match() {
         let match = insertMatch()
-        myTBAViewController.matchSelected(match)
 
-        XCTAssert(navigationController.detailViewController is UINavigationController)
-        let nav = navigationController.detailViewController as! UINavigationController
-        XCTAssert(nav.viewControllers.first is MatchViewController)
+        myTBAViewController.matchSelected(match)
+        XCTAssert(navigationController.pushedViewController is MatchViewController)
+
+        let matchViewController = navigationController.pushedViewController as! MatchViewController
+        XCTAssertEqual(matchViewController.match, match)
     }
     
     func test_authenticated() {

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		9274E14521B10DA000F5D5D0 /* NotificationStatusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9274E14421B10DA000F5D5D0 /* NotificationStatusTableViewCell.swift */; };
 		9274E14721B10DB700F5D5D0 /* NotificationStatusCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9274E14621B10DB700F5D5D0 /* NotificationStatusCellViewModel.swift */; };
 		9274E14921B1AAD300F5D5D0 /* NotificationStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9274E14821B1A12500F5D5D0 /* NotificationStatusTableViewCell.xib */; };
+		92755D942478778D0035C78A /* UIDevice+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92755D932478778D0035C78A /* UIDevice+TBA.swift */; };
 		9275956A21B442AA00560D81 /* StatusServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275956921B442AA00560D81 /* StatusServiceTests.swift */; };
 		9275957321B7514700560D81 /* DistrictTeamsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275957221B7514700560D81 /* DistrictTeamsViewController.swift */; };
 		9275957521B7519C00560D81 /* EventTeamsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275957421B7519C00560D81 /* EventTeamsViewController.swift */; };
@@ -304,6 +305,7 @@
 		9274E14421B10DA000F5D5D0 /* NotificationStatusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStatusTableViewCell.swift; sourceTree = "<group>"; };
 		9274E14621B10DB700F5D5D0 /* NotificationStatusCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStatusCellViewModel.swift; sourceTree = "<group>"; };
 		9274E14821B1A12500F5D5D0 /* NotificationStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NotificationStatusTableViewCell.xib; sourceTree = "<group>"; };
+		92755D932478778D0035C78A /* UIDevice+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+TBA.swift"; sourceTree = "<group>"; };
 		9275956921B442AA00560D81 /* StatusServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusServiceTests.swift; sourceTree = "<group>"; };
 		9275957221B7514700560D81 /* DistrictTeamsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistrictTeamsViewController.swift; sourceTree = "<group>"; };
 		9275957421B7519C00560D81 /* EventTeamsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTeamsViewController.swift; sourceTree = "<group>"; };
@@ -941,6 +943,7 @@
 				921D0B5E222B13480056578A /* ContainerViewController+Team.swift */,
 				925D10EA2394C7F300191D92 /* NSDiffableDataSourceSnapshot+TBA.swift */,
 				92FA4D2E228624D500030BA3 /* UIFont+TBA.swift */,
+				92755D932478778D0035C78A /* UIDevice+TBA.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1716,6 +1719,7 @@
 				92F79A7623D6536A0026E9E8 /* SearchContainer.swift in Sources */,
 				92B5562A215FCB1300C1D9A3 /* Reusable.swift in Sources */,
 				9274E14121B1026900F5D5D0 /* NotificationsViewController.swift in Sources */,
+				92755D942478778D0035C78A /* UIDevice+TBA.swift in Sources */,
 				921D0B57222AFB0B0056578A /* UIBarButtonItem+TBA.swift in Sources */,
 				92F8E356209AAE890094213F /* PushService.swift in Sources */,
 				92BB8B64214F17440035AF28 /* URLOpener.swift in Sources */,

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		921D0B57222AFB0B0056578A /* UIBarButtonItem+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921D0B54222AF94C0056578A /* UIBarButtonItem+TBA.swift */; };
 		921D0B5B222AFFE40056578A /* UIBarButtonItem+TBATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921D0B5A222AFFE40056578A /* UIBarButtonItem+TBATests.swift */; };
 		921D0B5F222B13480056578A /* ContainerViewController+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921D0B5E222B13480056578A /* ContainerViewController+Team.swift */; };
+		921DD67D241D3D6C00403192 /* RootController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921DD67C241D3D6C00403192 /* RootController.swift */; };
 		921F609923CD4DFD00FE633B /* MatchBreakdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921F609823CD4DFD00FE633B /* MatchBreakdownView.swift */; };
 		9223AC831EE7003C00F54F93 /* CollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */; };
 		9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */; };
@@ -160,6 +161,8 @@
 		92C8CE5921AEF4C600683558 /* MatchViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C8CE5821AEF4C600683558 /* MatchViewControllerTests.swift */; };
 		92C9BD352096907E007FB9C8 /* Stateful.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BD342096907E007FB9C8 /* Stateful.swift */; };
 		92C9BD3B2096BBA5007FB9C8 /* MyTBATableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BD3A2096BBA5007FB9C8 /* MyTBATableViewController.swift */; };
+		92CAF54E240774B90078CA0A /* PadRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CAF54D240774B90078CA0A /* PadRootViewController.swift */; };
+		92CAF550240775180078CA0A /* PhoneRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CAF54F240775180078CA0A /* PhoneRootViewController.swift */; };
 		92CC6D36234588810085867D /* Test.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 92CC6D34234588810085867D /* Test.xcdatamodeld */; };
 		92CFF55D1EB548E3008D2348 /* TableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CFF55C1EB548E3008D2348 /* TableViewDataSource.swift */; };
 		92D855D21EC68F3800572F27 /* TeamsContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D855D11EC68F3800572F27 /* TeamsContainerViewController.swift */; };
@@ -269,6 +272,7 @@
 		921D0B54222AF94C0056578A /* UIBarButtonItem+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+TBA.swift"; sourceTree = "<group>"; };
 		921D0B5A222AFFE40056578A /* UIBarButtonItem+TBATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+TBATests.swift"; sourceTree = "<group>"; };
 		921D0B5E222B13480056578A /* ContainerViewController+Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerViewController+Team.swift"; sourceTree = "<group>"; };
+		921DD67C241D3D6C00403192 /* RootController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootController.swift; sourceTree = "<group>"; };
 		921F609823CD4DFD00FE633B /* MatchBreakdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownView.swift; sourceTree = "<group>"; };
 		9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSource.swift; sourceTree = "<group>"; };
 		9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -404,6 +408,8 @@
 		92C8CE5821AEF4C600683558 /* MatchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchViewControllerTests.swift; sourceTree = "<group>"; };
 		92C9BD342096907E007FB9C8 /* Stateful.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stateful.swift; sourceTree = "<group>"; };
 		92C9BD3A2096BBA5007FB9C8 /* MyTBATableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBATableViewController.swift; sourceTree = "<group>"; };
+		92CAF54D240774B90078CA0A /* PadRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PadRootViewController.swift; sourceTree = "<group>"; };
+		92CAF54F240775180078CA0A /* PhoneRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneRootViewController.swift; sourceTree = "<group>"; };
 		92CC6D35234588810085867D /* Test.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Test.xcdatamodel; sourceTree = "<group>"; };
 		92CFF55C1EB548E3008D2348 /* TableViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewDataSource.swift; sourceTree = "<group>"; };
 		92D6483A20BE4CB8008F0DB3 /* tba-unit-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "tba-unit-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -770,6 +776,7 @@
 		92942DAD1E215722008E79CA /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				92CAF54C240774A80078CA0A /* Root */,
 				92AF73D621EB9E10006A338D /* Search */,
 				92942E311E230340008E79CA /* Base */,
 				92942DB21E215B08008E79CA /* Events */,
@@ -1078,6 +1085,16 @@
 				92C8CE5821AEF4C600683558 /* MatchViewControllerTests.swift */,
 			);
 			path = Match;
+			sourceTree = "<group>";
+		};
+		92CAF54C240774A80078CA0A /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				921DD67C241D3D6C00403192 /* RootController.swift */,
+				92CAF54D240774B90078CA0A /* PadRootViewController.swift */,
+				92CAF54F240775180078CA0A /* PhoneRootViewController.swift */,
+			);
+			path = Root;
 			sourceTree = "<group>";
 		};
 		92CC6D33234588810085867D /* Resources */ = {
@@ -1692,6 +1709,7 @@
 				92C079C723F99CA400AE2AFA /* EventStatsConfigurator2020.swift in Sources */,
 				1479694C215EC1670075AF4E /* EventTeamStatCellViewModel.swift in Sources */,
 				9274E14521B10DA000F5D5D0 /* NotificationStatusTableViewCell.swift in Sources */,
+				92CAF54E240774B90078CA0A /* PadRootViewController.swift in Sources */,
 				92B55633215FDB5300C1D9A3 /* BasicCollectionViewCell.swift in Sources */,
 				92FF10F021A61A1B003BC5C4 /* TeamMediaCollectionViewController.swift in Sources */,
 				92942D961E2154DA008E79CA /* AppDelegate.swift in Sources */,
@@ -1796,6 +1814,7 @@
 				14796944215EAF7A0075AF4E /* TeamCellViewModel.swift in Sources */,
 				92B07371235CB47800967FC3 /* TableViewDataSourceFetchedResultsController.swift in Sources */,
 				92FA4D2D228606BB00030BA3 /* TeamHeaderView.swift in Sources */,
+				92CAF550240775180078CA0A /* PhoneRootViewController.swift in Sources */,
 				92FF111C21A61B37003BC5C4 /* DistrictEventsViewController.swift in Sources */,
 				92FF110A21A61AF6003BC5C4 /* EventInfoViewController.swift in Sources */,
 				92FF110C21A61AF6003BC5C4 /* EventInsightsContainerViewController.swift in Sources */,
@@ -1817,6 +1836,7 @@
 				1479694A215EBE460075AF4E /* EventAllianceCellViewModel.swift in Sources */,
 				9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */,
 				92B076F320FF948D00F9B2D7 /* TestAppDelegate.swift in Sources */,
+				921DD67D241D3D6C00403192 /* RootController.swift in Sources */,
 				9255EB6D209AC9760006A745 /* RetryService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -26,14 +26,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Root VC on iPhone is a tab bar controller
     lazy private var rootViewController: UIViewController & RootController = {
-        switch UIDevice.current.userInterfaceIdiom {
-        case .phone:
+        if UIDevice.isPhone {
             return rootViewControllerPhone
-        case .pad:
+        } else if UIDevice.isPad {
             return rootViewControllerPad
-        default:
-            fatalError("userInterfaceIdiom \(UIDevice.current.userInterfaceIdiom) unsupported")
         }
+        fatalError("userInterfaceIdiom \(UIDevice.current.userInterfaceIdiom) unsupported")
     }()
     lazy private var rootViewControllerPhone: PhoneRootViewController = {
         return PhoneRootViewController(fcmTokenProvider: messaging,

--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: - View Hierarchy
 
-    // Root VC on iPhone is a tab bar controller
+    // Root VC on iPhone: a tab bar controller, iPad: a split view controller
     lazy private var rootViewController: UIViewController & RootController = {
         if UIDevice.isPhone {
             return rootViewControllerPhone

--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -5,7 +5,6 @@ import Fabric
 import Firebase
 import FirebaseAuth
 import FirebaseMessaging
-import FirebaseRemoteConfig
 import GoogleSignIn
 import MyTBAKit
 import Photos

--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -5,6 +5,7 @@ import Fabric
 import Firebase
 import FirebaseAuth
 import FirebaseMessaging
+import FirebaseRemoteConfig
 import GoogleSignIn
 import MyTBAKit
 import Photos
@@ -23,72 +24,42 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: - View Hierarchy
 
-    // Root VC is a split view controller, with the left side being a tab bar,
-    // and the right side being a navigation controller
-    lazy private var rootSplitViewController: UISplitViewController = { [unowned self] in
-        let splitViewController = UISplitViewController()
-
-        let eventsViewController = EventsContainerViewController(myTBA: myTBA,
-                                                                 pasteboard: pasteboard,
-                                                                 photoLibrary: photoLibrary,
-                                                                 searchService: searchService,
-                                                                 statusService: statusService,
-                                                                 urlOpener: urlOpener,
-                                                                 persistentContainer: persistentContainer,
-                                                                 tbaKit: tbaKit,
-                                                                 userDefaults: userDefaults)
-        let teamsViewController = TeamsContainerViewController(myTBA: myTBA,
-                                                               pasteboard: pasteboard,
-                                                               photoLibrary: photoLibrary,
-                                                               searchService: searchService,
-                                                               statusService: statusService,
-                                                               urlOpener: urlOpener,
-                                                               persistentContainer: persistentContainer,
-                                                               tbaKit: tbaKit,
-                                                               userDefaults: userDefaults)
-        let districtsViewController = DistrictsContainerViewController(myTBA: myTBA,
-                                                                       statusService: statusService,
-                                                                       urlOpener: urlOpener,
-                                                                       persistentContainer: persistentContainer,
-                                                                       tbaKit: tbaKit,
-                                                                       userDefaults: userDefaults)
-        let settingsViewController = SettingsViewController(fcmTokenProvider: messaging,
-                                                            myTBA: myTBA,
-                                                            pushService: pushService,
-                                                            searchService: searchService,
-                                                            urlOpener: urlOpener,
-                                                            persistentContainer: persistentContainer,
-                                                            tbaKit: tbaKit,
-                                                            userDefaults: userDefaults)
-        let myTBAViewController = MyTBAViewController(myTBA: myTBA,
-                                                      statusService: statusService,
-                                                      urlOpener: urlOpener,
-                                                      persistentContainer: persistentContainer,
-                                                      tbaKit: tbaKit,
-                                                      userDefaults: userDefaults)
-        let rootViewControllers: [UIViewController] = [eventsViewController, teamsViewController, districtsViewController, myTBAViewController, settingsViewController]
-        tabBarController.viewControllers = rootViewControllers.compactMap({ (viewController) -> UIViewController? in
-            let navigationController = UINavigationController(rootViewController: viewController)
-            return navigationController
-        })
-
-        splitViewController.viewControllers = [tabBarController, emptyNavigationController]
-
-        splitViewController.preferredDisplayMode = .allVisible
-        splitViewController.delegate = self
-
-        return splitViewController
-    }()
-    private let tabBarController = UITabBarController()
-    lazy var emptyNavigationController: UINavigationController = {
-        guard let emptyViewController = Bundle.main.loadNibNamed("EmptyViewController", owner: nil, options: nil)?.first as? UIViewController else {
-            fatalError("Unable to load empty view controller")
+    // Root VC on iPhone is a tab bar controller
+    lazy private var rootViewController: UIViewController & RootController = {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .phone:
+            return rootViewControllerPhone
+        case .pad:
+            return rootViewControllerPad
+        default:
+            fatalError("userInterfaceIdiom \(UIDevice.current.userInterfaceIdiom) unsupported")
         }
-
-        let navigationController = UINavigationController(rootViewController: emptyViewController)
-        navigationController.restorationIdentifier = kNoSelectionNavigationController
-
-        return navigationController
+    }()
+    lazy private var rootViewControllerPhone: PhoneRootViewController = {
+        return PhoneRootViewController(fcmTokenProvider: messaging,
+                                       myTBA: myTBA,
+                                       pasteboard: pasteboard,
+                                       photoLibrary: photoLibrary,
+                                       pushService: pushService,
+                                       searchService: searchService,
+                                       statusService: statusService,
+                                       urlOpener: urlOpener,
+                                       persistentContainer: persistentContainer,
+                                       tbaKit: tbaKit,
+                                       userDefaults: userDefaults)
+    }()
+    lazy private var rootViewControllerPad: PadRootViewController = {
+        return PadRootViewController(fcmTokenProvider: messaging,
+                                       myTBA: myTBA,
+                                       pasteboard: pasteboard,
+                                       photoLibrary: photoLibrary,
+                                       pushService: pushService,
+                                       searchService: searchService,
+                                       statusService: statusService,
+                                       urlOpener: urlOpener,
+                                       persistentContainer: persistentContainer,
+                                       tbaKit: tbaKit,
+                                       userDefaults: userDefaults)
     }()
 
     // MARK: - Services
@@ -115,7 +86,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     lazy var handoffService: HandoffService = {
         return HandoffService(persistentContainer: persistentContainer,
-                              rootViewController: tabBarController)
+                              rootViewController: rootViewController)
     }()
     lazy var pushService: PushService = {
         return PushService(myTBA: myTBA,
@@ -222,8 +193,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     guard let snapshot = window.snapshotView(afterScreenUpdates: true) else {
                         fatalError("Unable to snapshot root view controller")
                     }
-                    self.rootSplitViewController.view.addSubview(snapshot)
-                    window.rootViewController = self.rootSplitViewController
+                    self.rootViewController.view.addSubview(snapshot)
+                    window.rootViewController = self.rootViewController
 
                     // 0.35 is an iOS animation magic number... for now
                     UIView.transition(with: snapshot, duration: 0.35, options: .transitionCrossDissolve, animations: {
@@ -434,70 +405,6 @@ extension AppDelegate: FMSStatusSubscribable {
                                                 message: "We rely on FIRST to provide scores, ranking, and more. Unfortunately, FIRST's servers are broken right now, so we can't get the latest updates. The information you see here may be out of date.",
                                                 preferredStyle: .alert)
         window?.rootViewController?.present(alertController, animated: true, completion: nil)
-    }
-
-}
-
-extension AppDelegate: UISplitViewControllerDelegate {
-
-    func splitViewController(_ splitViewController: UISplitViewController, showDetail vc: UIViewController, sender: Any?) -> Bool {
-        // If our split view controller is collapsed and we're trying to show a detail view,
-        // push it on the master navigation stack
-        if splitViewController.isCollapsed,
-            // Need to get the VC for the currently selected tab...
-            let masterNavigationController = tabBarController.selectedViewController as? UINavigationController {
-            // We want to push the view controller, but make sure we're not pushing something in a nav controller
-            guard let detailNavigationController = vc as? UINavigationController else {
-                return false
-            }
-
-            guard let detailViewController = detailNavigationController.viewControllers.first else {
-                return false
-            }
-
-            masterNavigationController.show(detailViewController, sender: nil)
-
-            return true
-        }
-
-        return false
-    }
-
-    func primaryViewController(forCollapsing splitViewController: UISplitViewController) -> UIViewController? {
-        // If collapsing and detail view controller is not a no selection navigation view controller,
-        // push the first view controller on to primary navigation view controller and return
-        // the primary tab bar controller
-        if let detailNavigationController = splitViewController.viewControllers.last as? UINavigationController,
-            detailNavigationController.restorationIdentifier != kNoSelectionNavigationController {
-            // This is a view controller we want to push
-            if let masterNavigationController = tabBarController.selectedViewController as? UINavigationController {
-                // Add the detail navigation controller stack to our root navigation controller
-                masterNavigationController.viewControllers += detailNavigationController.viewControllers
-                return tabBarController
-            }
-        }
-
-        return splitViewController.viewControllers.first
-    }
-
-    func splitViewController(_ splitViewController: UISplitViewController, separateSecondaryFrom primaryViewController: UIViewController) -> UIViewController? {
-        // If our primary view controller is not a no selection view controller, pop the old one, return the tab bar,
-        // and setup the detail view controller to be the primary view controller
-        //
-        // Otherwise, return our detail
-        if let masterNavigationController = tabBarController.selectedViewController as? UINavigationController,
-            masterNavigationController.topViewController?.restorationIdentifier != kNoSelectionNavigationController {
-            // We want to seperate this event view controller in to the detail view controller
-            if let detailViewControllers = masterNavigationController.popToRootViewController(animated: true) {
-                let detailNavigationController = UINavigationController()
-                detailNavigationController.viewControllers = detailViewControllers
-                splitViewController.viewControllers = [tabBarController, detailNavigationController]
-
-                return detailNavigationController
-            }
-        }
-
-        return emptyNavigationController
     }
 
 }

--- a/the-blue-alliance-ios/App Delegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/App Delegate/AppDelegate.swift
@@ -83,7 +83,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     lazy var handoffService: HandoffService = {
         return HandoffService(persistentContainer: persistentContainer,
-                              rootViewController: rootViewController)
+                              rootController: rootViewController)
     }()
     lazy var pushService: PushService = {
         return PushService(myTBA: myTBA,

--- a/the-blue-alliance-ios/Extensions/UIDevice+TBA.swift
+++ b/the-blue-alliance-ios/Extensions/UIDevice+TBA.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIDevice {
+
+    public static var isPhone: Bool {
+        return UIDevice.current.userInterfaceIdiom == .phone
+    }
+
+    public static var isPad: Bool {
+        return UIDevice.current.userInterfaceIdiom == .pad
+    }
+
+}

--- a/the-blue-alliance-ios/Protocols/SearchContainer.swift
+++ b/the-blue-alliance-ios/Protocols/SearchContainer.swift
@@ -57,15 +57,23 @@ extension SearchContainerDelegate where Self: ContainerViewController {
     func eventSelected(_ event: Event) {
         // Show detail wrapped in a UINavigationController for our split view controller
         let eventViewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let nav = UINavigationController(rootViewController: eventViewController)
-        navigationController?.showDetailViewController(nav, sender: nil)
+        if let splitViewController = splitViewController {
+            let navigationController = UINavigationController(rootViewController: eventViewController)
+            splitViewController.showDetailViewController(navigationController, sender: nil)
+        } else if let navigationController = navigationController {
+            navigationController.pushViewController(eventViewController, animated: true)
+        }
     }
 
     func teamSelected(_ team: Team) {
         // Show detail wrapped in a UINavigationController for our split view controller
         let teamViewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let nav = UINavigationController(rootViewController: teamViewController)
-        navigationController?.showDetailViewController(nav, sender: nil)
+        if let splitViewController = splitViewController {
+            let navigationController = UINavigationController(rootViewController: teamViewController)
+            splitViewController.showDetailViewController(navigationController, sender: nil)
+        } else if let navigationController = navigationController {
+            navigationController.pushViewController(teamViewController, animated: true)
+        }
     }
 
 }

--- a/the-blue-alliance-ios/Services/HandoffService.swift
+++ b/the-blue-alliance-ios/Services/HandoffService.swift
@@ -10,7 +10,7 @@ import UIKit
 class HandoffService {
 
     private let persistentContainer: NSPersistentContainer
-    private let rootViewController: UITabBarController
+    private let rootViewController: RootController & UIViewController
 
     var appSetup: Bool = false {
         didSet {
@@ -24,7 +24,7 @@ class HandoffService {
     private(set) var continueSearchText: String?
     private(set) var continueURI: URL?
 
-    init(persistentContainer: NSPersistentContainer, rootViewController: UITabBarController) {
+    init(persistentContainer: NSPersistentContainer, rootViewController: RootController & UIViewController) {
         self.persistentContainer = persistentContainer
         self.rootViewController = rootViewController
     }
@@ -100,26 +100,7 @@ class HandoffService {
             continueSearchText = searchText
             return true
         }
-
-        // Pop to root of Events tab, show search
-        // Dismiss existing modal view controller
-        if let presentedViewController = rootViewController.presentedViewController {
-            presentedViewController.dismiss(animated: false)
-        }
-
-        rootViewController.selectedIndex = 0
-        guard let navigationController = rootViewController.selectedViewController as? UINavigationController else {
-            return false
-        }
-        navigationController.popToRootViewController(animated: false)
-
-        guard let searchContainerViewController = navigationController.viewControllers.first as? SearchContainer else {
-            return false
-        }
-        searchContainerViewController.searchController.searchBar.text = searchText
-        searchContainerViewController.searchController.isActive = true
-
-        return true
+        return rootViewController.continueSearch(searchText)
     }
 
     @discardableResult
@@ -133,28 +114,11 @@ class HandoffService {
             return false
         }
 
-        // Dismiss existing modal view controller
-        if let presentedViewController = rootViewController.presentedViewController {
-            presentedViewController.dismiss(animated: false)
-        }
-
-        rootViewController.selectedIndex = 0
-        guard let navigationController = rootViewController.selectedViewController as? UINavigationController else {
-            return false
-        }
-        navigationController.popToRootViewController(animated: false)
-
-        guard let searchContainerViewController = navigationController.viewControllers.first as? SearchViewControllerDelegate else {
-            return false
-        }
-
         let object = persistentContainer.viewContext.object(with: objectID)
         if let event = object as? Event {
-            searchContainerViewController.eventSelected(event)
-            return true
+            return rootViewController.show(event: event)
         } else if let team = object as? Team {
-            searchContainerViewController.teamSelected(team)
-            return true
+            return rootViewController.show(team: team)
         }
         return false
     }

--- a/the-blue-alliance-ios/Services/HandoffService.swift
+++ b/the-blue-alliance-ios/Services/HandoffService.swift
@@ -10,7 +10,7 @@ import UIKit
 class HandoffService {
 
     private let persistentContainer: NSPersistentContainer
-    private let rootViewController: RootController & UIViewController
+    private let rootController: RootController
 
     var appSetup: Bool = false {
         didSet {
@@ -24,9 +24,9 @@ class HandoffService {
     private(set) var continueSearchText: String?
     private(set) var continueURI: URL?
 
-    init(persistentContainer: NSPersistentContainer, rootViewController: RootController & UIViewController) {
+    init(persistentContainer: NSPersistentContainer, rootController: RootController) {
         self.persistentContainer = persistentContainer
-        self.rootViewController = rootViewController
+        self.rootController = rootController
     }
 
     func application(continue userActivity: NSUserActivity) -> Bool {
@@ -100,7 +100,7 @@ class HandoffService {
             continueSearchText = searchText
             return true
         }
-        return rootViewController.continueSearch(searchText)
+        return rootController.continueSearch(searchText)
     }
 
     @discardableResult
@@ -116,9 +116,9 @@ class HandoffService {
 
         let object = persistentContainer.viewContext.object(with: objectID)
         if let event = object as? Event {
-            return rootViewController.show(event: event)
+            return rootController.show(event: event)
         } else if let team = object as? Team {
-            return rootViewController.show(team: team)
+            return rootController.show(team: team)
         }
         return false
     }

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
@@ -38,8 +38,8 @@ class DistrictsContainerViewController: ContainerViewController {
                    tbaKit: tbaKit,
                    userDefaults: userDefaults)
 
-        title = "Districts"
-        tabBarItem.image = UIImage.districtIcon
+        title = RootType.districts.title
+        tabBarItem.image = RootType.districts.icon
 
         navigationTitleDelegate = self
         districtsViewController.delegate = self

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
@@ -98,8 +98,12 @@ extension DistrictsContainerViewController: DistrictsViewControllerDelegate {
     func districtSelected(_ district: District) {
         // Show detail wrapped in a UINavigationController for our split view controller
         let districtViewController = DistrictViewController(district: district, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let nav = UINavigationController(rootViewController: districtViewController)
-        navigationController?.showDetailViewController(nav, sender: nil)
+        if let splitViewController = splitViewController {
+            let navigationController = UINavigationController(rootViewController: districtViewController)
+            splitViewController.showDetailViewController(navigationController, sender: nil)
+        } else if let navigationController = navigationController {
+            navigationController.pushViewController(districtViewController, animated: true)
+        }
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
@@ -41,8 +41,9 @@ class EventsContainerViewController: ContainerViewController {
                    tbaKit: tbaKit,
                    userDefaults: userDefaults)
 
-        title = "Events"
-        tabBarItem.image = UIImage.eventIcon
+        // TODO: We should be able to move this somewhere else and DRY this code
+        title = RootType.events.title
+        tabBarItem.image = RootType.events.icon
 
         navigationTitleDelegate = self
         eventsViewController.delegate = self

--- a/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
@@ -59,7 +59,10 @@ class EventsContainerViewController: ContainerViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupSearchController()
+        // Only show Search in container view on iPhone
+        if UIDevice.isPhone {
+            setupSearchController()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
@@ -58,8 +58,8 @@ class MyTBAViewController: ContainerViewController {
                    tbaKit: tbaKit,
                    userDefaults: userDefaults)
 
-        title = "myTBA"
-        tabBarItem.image = UIImage.starIcon
+        title = RootType.myTBA.title
+        tabBarItem.image = RootType.myTBA.icon
 
         favoritesViewController.delegate = self
         subscriptionsViewController.delegate = self

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
@@ -172,20 +172,32 @@ extension MyTBAViewController: MyTBATableViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
         let viewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        self.navigationController?.showDetailViewController(navigationController, sender: nil)
+        if let splitViewController = splitViewController {
+            let navigationController = UINavigationController(rootViewController: viewController)
+            splitViewController.showDetailViewController(navigationController, sender: nil)
+        } else if let navigationController = navigationController {
+            navigationController.pushViewController(viewController, animated: true)
+        }
     }
 
     func teamSelected(_ team: Team) {
         let viewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        self.navigationController?.showDetailViewController(navigationController, sender: nil)
+        if let splitViewController = splitViewController {
+            let navigationController = UINavigationController(rootViewController: viewController)
+            splitViewController.showDetailViewController(navigationController, sender: nil)
+        } else if let navigationController = navigationController {
+            navigationController.pushViewController(viewController, animated: true)
+        }
     }
 
     func matchSelected(_ match: Match) {
         let viewController = MatchViewController(match: match, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        self.navigationController?.showDetailViewController(navigationController, sender: nil)
+        if let splitViewController = splitViewController {
+            let navigationController = UINavigationController(rootViewController: viewController)
+            splitViewController.showDetailViewController(navigationController, sender: nil)
+        } else if let navigationController = navigationController {
+            navigationController.pushViewController(viewController, animated: true)
+        }
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
@@ -1,0 +1,203 @@
+import CoreData
+import Foundation
+import MyTBAKit
+import Photos
+import TBAData
+import TBAKit
+import UIKit
+
+class PadRootViewController: UISplitViewController, RootController {
+
+    let fcmTokenProvider: FCMTokenProvider
+    let myTBA: MyTBA
+    let pasteboard: UIPasteboard?
+    let photoLibrary: PHPhotoLibrary?
+    let pushService: PushService
+    let searchService: SearchService
+    let urlOpener: URLOpener
+    let statusService: StatusService
+    let persistentContainer: NSPersistentContainer
+    let tbaKit: TBAKit
+    let userDefaults: UserDefaults
+
+    lazy var emptyNavigationController: UINavigationController = {
+       guard let emptyViewController = Bundle.main.loadNibNamed("EmptyViewController", owner: nil, options: nil)?.first as? UIViewController else {
+           fatalError("Unable to load empty view controller")
+        }
+
+        let navigationController = UINavigationController(rootViewController: emptyViewController)
+        navigationController.restorationIdentifier = kNoSelectionNavigationController
+
+        return navigationController
+    }()
+
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.fcmTokenProvider = fcmTokenProvider
+        self.myTBA = myTBA
+        self.pasteboard = pasteboard
+        self.photoLibrary = photoLibrary
+        self.pushService = pushService
+        self.searchService = searchService
+        self.statusService = statusService
+        self.urlOpener = urlOpener
+        self.persistentContainer = persistentContainer
+        self.tbaKit = tbaKit
+        self.userDefaults = userDefaults
+
+        super.init(nibName: nil, bundle: nil)
+
+        let masterViewController = PadMasterViewController(searchService: searchService, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let masterNavigationController = UINavigationController(rootViewController: masterViewController)
+        viewControllers = [masterNavigationController, emptyNavigationController]
+
+        // splitViewController.preferredDisplayMode = .allVisible
+        // splitViewController.delegate = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - RootController
+
+    func continueSearch(_ searchText: String) -> Bool {
+        // Pass
+        return true
+    }
+
+    func show(event: Event) -> Bool {
+        // Pass
+        return true
+    }
+
+    func show(team: Team) -> Bool {
+        // Pass
+        return true
+    }
+
+}
+
+private class PadMasterViewController: ContainerViewController, SearchContainer, SearchContainerDelegate {
+
+    let myTBA: MyTBA
+    let pasteboard: UIPasteboard?
+    let photoLibrary: PHPhotoLibrary?
+    let searchService: SearchService
+    let statusService: StatusService
+    let urlOpener: URLOpener
+
+    var searchController: UISearchController!
+
+    init(myTBA: MyTBAsearchService: SearchService, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.searchService = searchService
+
+        super.init(viewControllers: [], persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupSearchController()
+    }
+
+}
+
+private class PadRootTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.isScrollEnabled = false
+        tableView.registerReusableCell(BasicTableViewCell.self)
+        tableView.tableFooterView = nil
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 5
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(indexPath: indexPath) as BasicTableViewCell
+
+        cell.textLabel?.text = "Events"
+
+        return cell
+    }
+
+}
+
+/*
+extension PadRootViewController: UISplitViewControllerDelegate {
+
+    func splitViewController(_ splitViewController: UISplitViewController, showDetail vc: UIViewController, sender: Any?) -> Bool {
+        // If our split view controller is collapsed and we're trying to show a detail view,
+        // push it on the master navigation stack
+        if splitViewController.isCollapsed,
+            // Need to get the VC for the currently selected tab...
+            let masterNavigationController = tabBarController.selectedViewController as? UINavigationController {
+            // We want to push the view controller, but make sure we're not pushing something in a nav controller
+            guard let detailNavigationController = vc as? UINavigationController else {
+                return false
+            }
+
+            guard let detailViewController = detailNavigationController.viewControllers.first else {
+                return false
+            }
+
+            masterNavigationController.show(detailViewController, sender: nil)
+
+            return true
+        }
+
+        return false
+    }
+
+    func primaryViewController(forCollapsing splitViewController: UISplitViewController) -> UIViewController? {
+        // If collapsing and detail view controller is not a no selection navigation view controller,
+        // push the first view controller on to primary navigation view controller and return
+        // the primary tab bar controller
+        if let detailNavigationController = splitViewController.viewControllers.last as? UINavigationController,
+            detailNavigationController.restorationIdentifier != kNoSelectionNavigationController {
+            // This is a view controller we want to push
+            if let masterNavigationController = tabBarController.selectedViewController as? UINavigationController {
+                // Add the detail navigation controller stack to our root navigation controller
+                masterNavigationController.viewControllers += detailNavigationController.viewControllers
+                return tabBarController
+            }
+        }
+
+        return splitViewController.viewControllers.first
+    }
+
+    func splitViewController(_ splitViewController: UISplitViewController, separateSecondaryFrom primaryViewController: UIViewController) -> UIViewController? {
+        // If our primary view controller is not a no selection view controller, pop the old one, return the tab bar,
+        // and setup the detail view controller to be the primary view controller
+        //
+        // Otherwise, return our detail
+        if let masterNavigationController = tabBarController.selectedViewController as? UINavigationController,
+            masterNavigationController.topViewController?.restorationIdentifier != kNoSelectionNavigationController {
+            // We want to seperate this event view controller in to the detail view controller
+            if let detailViewControllers = masterNavigationController.popToRootViewController(animated: true) {
+                let detailNavigationController = UINavigationController()
+                detailNavigationController.viewControllers = detailViewControllers
+                splitViewController.viewControllers = [tabBarController, detailNavigationController]
+
+                return detailNavigationController
+            }
+        }
+
+        return emptyNavigationController
+    }
+
+}
+*/

--- a/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
@@ -63,15 +63,13 @@ class PadRootViewController: UISplitViewController, RootController {
         let masterNavigationController = UINavigationController(rootViewController: masterViewController)
         viewControllers = [masterNavigationController, emptyNavigationController]
 
-        // splitViewController.preferredDisplayMode = .allVisible
-        // splitViewController.delegate = self
+        preferredDisplayMode = .allVisible
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // TODO: Remove these
     // MARK: - RootController
 
     func continueSearch(_ searchText: String) -> Bool {
@@ -154,17 +152,25 @@ extension PadMasterViewController: SearchContainer, SearchContainerDelegate, Sea
 extension PadMasterViewController: PadRootTableViewControllerDelegate {
 
     func rootTypeSelected(_ rootType: RootType) {
-        switch rootType {
-        case .events:
-            navigationController?.pushViewController(eventsViewController, animated: true)
-        case .teams:
-            navigationController?.pushViewController(teamsViewController, animated: true)
-        case .districts:
-            navigationController?.pushViewController(districtsViewController, animated: true)
-        case .myTBA:
-            navigationController?.pushViewController(myTBAViewController, animated: true)
-        case .settings:
-            let navigationController = UINavigationController(rootViewController: settingsViewController)
+        let viewController: UIViewController = {
+            switch rootType {
+            case .events:
+                return eventsViewController
+            case .teams:
+                return teamsViewController
+            case .districts:
+                return districtsViewController
+            case .myTBA:
+                return myTBAViewController
+            case .settings:
+                return settingsViewController
+            }
+        }()
+
+        if rootType.supportsPush {
+            navigationController?.pushViewController(viewController, animated: true)
+        } else {
+            let navigationController = UINavigationController(rootViewController: viewController)
             showDetailViewController(navigationController, sender: nil)
         }
     }
@@ -244,69 +250,3 @@ private class PadRootTableViewController: TBATableViewController, Refreshable, S
     }
 
 }
-
-/*
-extension PadRootViewController: UISplitViewControllerDelegate {
-
-    func splitViewController(_ splitViewController: UISplitViewController, showDetail vc: UIViewController, sender: Any?) -> Bool {
-        // If our split view controller is collapsed and we're trying to show a detail view,
-        // push it on the master navigation stack
-        if splitViewController.isCollapsed,
-            // Need to get the VC for the currently selected tab...
-            let masterNavigationController = tabBarController.selectedViewController as? UINavigationController {
-            // We want to push the view controller, but make sure we're not pushing something in a nav controller
-            guard let detailNavigationController = vc as? UINavigationController else {
-                return false
-            }
-
-            guard let detailViewController = detailNavigationController.viewControllers.first else {
-                return false
-            }
-
-            masterNavigationController.show(detailViewController, sender: nil)
-
-            return true
-        }
-
-        return false
-    }
-
-    func primaryViewController(forCollapsing splitViewController: UISplitViewController) -> UIViewController? {
-        // If collapsing and detail view controller is not a no selection navigation view controller,
-        // push the first view controller on to primary navigation view controller and return
-        // the primary tab bar controller
-        if let detailNavigationController = splitViewController.viewControllers.last as? UINavigationController,
-            detailNavigationController.restorationIdentifier != kNoSelectionNavigationController {
-            // This is a view controller we want to push
-            if let masterNavigationController = tabBarController.selectedViewController as? UINavigationController {
-                // Add the detail navigation controller stack to our root navigation controller
-                masterNavigationController.viewControllers += detailNavigationController.viewControllers
-                return tabBarController
-            }
-        }
-
-        return splitViewController.viewControllers.first
-    }
-
-    func splitViewController(_ splitViewController: UISplitViewController, separateSecondaryFrom primaryViewController: UIViewController) -> UIViewController? {
-        // If our primary view controller is not a no selection view controller, pop the old one, return the tab bar,
-        // and setup the detail view controller to be the primary view controller
-        //
-        // Otherwise, return our detail
-        if let masterNavigationController = tabBarController.selectedViewController as? UINavigationController,
-            masterNavigationController.topViewController?.restorationIdentifier != kNoSelectionNavigationController {
-            // We want to seperate this event view controller in to the detail view controller
-            if let detailViewControllers = masterNavigationController.popToRootViewController(animated: true) {
-                let detailNavigationController = UINavigationController()
-                detailNavigationController.viewControllers = detailViewControllers
-                splitViewController.viewControllers = [tabBarController, detailNavigationController]
-
-                return detailNavigationController
-            }
-        }
-
-        return emptyNavigationController
-    }
-
-}
-*/

--- a/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
@@ -131,20 +131,63 @@ private class PadMasterViewController: ContainerViewController, RootController {
     // MARK: - RootController
 
     func continueSearch(_ searchText: String) -> Bool {
-        // Pass
+        // Pop to root tab, show search
+        // Dismiss existing modal view controller
+        if let presentedViewController = presentedViewController {
+            presentedViewController.dismiss(animated: false)
+        }
+
+        guard let navigationController = navigationController else {
+            return false
+        }
+
+        // Fix `popToRootViewController` clobbering our `isActive` animation
+        // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/878
+        CATransaction.setCompletionBlock { [weak self] in
+            self?.searchController.isActive = true
+        }
+        CATransaction.begin()
+        navigationController.popToRootViewController(animated: false)
+        CATransaction.commit()
+
+        searchController.searchBar.text = searchText
+
         return true
     }
 
     func show(event: Event) -> Bool {
-        // Pass
+        let eventViewController = EventViewController(event: event,
+                                                      pasteboard: pasteboard,
+                                                      photoLibrary: photoLibrary,
+                                                      statusService: statusService,
+                                                      urlOpener: urlOpener,
+                                                      myTBA: myTBA,
+                                                      persistentContainer: persistentContainer,
+                                                      tbaKit: tbaKit,
+                                                      userDefaults: userDefaults)
+        _push(eventViewController)
         return true
     }
 
     func show(team: Team) -> Bool {
-        // Pass
+        let teamViewController = TeamViewController(team: team,
+                                                    pasteboard: pasteboard,
+                                                    photoLibrary: photoLibrary,
+                                                    statusService: statusService,
+                                                    urlOpener: urlOpener,
+                                                    myTBA: myTBA,
+                                                    persistentContainer: persistentContainer,
+                                                    tbaKit: tbaKit,
+                                                    userDefaults: userDefaults)
+        _push(teamViewController)
         return true
     }
-    
+
+    func _push(_ viewController: UIViewController) {
+        let navigationController = UINavigationController(rootViewController: viewController)
+        showDetailViewController(navigationController, sender: nil)
+    }
+
 }
 
 extension PadMasterViewController: SearchContainer, SearchContainerDelegate, SearchViewControllerDelegate {}
@@ -170,8 +213,7 @@ extension PadMasterViewController: PadRootTableViewControllerDelegate {
         if rootType.supportsPush {
             navigationController?.pushViewController(viewController, animated: true)
         } else {
-            let navigationController = UINavigationController(rootViewController: viewController)
-            showDetailViewController(navigationController, sender: nil)
+            _push(viewController)
         }
     }
 

--- a/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
@@ -20,6 +20,20 @@ class PadRootViewController: UISplitViewController, RootController {
     let tbaKit: TBAKit
     let userDefaults: UserDefaults
 
+    lazy fileprivate var masterViewController: PadMasterViewController = {
+        return PadMasterViewController(fcmTokenProvider: fcmTokenProvider,
+                                       myTBA: myTBA,
+                                       pasteboard: pasteboard,
+                                       photoLibrary: photoLibrary,
+                                       pushService: pushService,
+                                       searchService: searchService,
+                                       statusService: statusService,
+                                       urlOpener: urlOpener,
+                                       persistentContainer: persistentContainer,
+                                       tbaKit: tbaKit,
+                                       userDefaults: userDefaults)
+    }()
+
     lazy var emptyNavigationController: UINavigationController = {
        guard let emptyViewController = Bundle.main.loadNibNamed("EmptyViewController", owner: nil, options: nil)?.first as? UIViewController else {
            fatalError("Unable to load empty view controller")
@@ -46,7 +60,6 @@ class PadRootViewController: UISplitViewController, RootController {
 
         super.init(nibName: nil, bundle: nil)
 
-        let masterViewController = PadMasterViewController(searchService: searchService, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
         let masterNavigationController = UINavigationController(rootViewController: masterViewController)
         viewControllers = [masterNavigationController, emptyNavigationController]
 
@@ -56,6 +69,65 @@ class PadRootViewController: UISplitViewController, RootController {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // TODO: Remove these
+    // MARK: - RootController
+
+    func continueSearch(_ searchText: String) -> Bool {
+        return masterViewController.continueSearch(searchText)
+    }
+
+    func show(event: Event) -> Bool {
+        return masterViewController.show(event: event)
+    }
+
+    func show(team: Team) -> Bool {
+        return masterViewController.show(team: team)
+    }
+
+}
+
+private class PadMasterViewController: ContainerViewController, RootController {
+
+    let fcmTokenProvider: FCMTokenProvider
+    let myTBA: MyTBA
+    let pasteboard: UIPasteboard?
+    let photoLibrary: PHPhotoLibrary?
+    let pushService: PushService
+    let searchService: SearchService
+    let statusService: StatusService
+    let urlOpener: URLOpener
+
+    var searchController: UISearchController!
+
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard?, photoLibrary: PHPhotoLibrary?, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.fcmTokenProvider = fcmTokenProvider
+        self.myTBA = myTBA
+        self.pasteboard = pasteboard
+        self.photoLibrary = photoLibrary
+        self.pushService = pushService
+        self.searchService = searchService
+        self.statusService = statusService
+        self.urlOpener = urlOpener
+
+        let rootTableViewController = PadRootTableViewController(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+
+        super.init(viewControllers: [rootTableViewController], persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+
+        rootTableViewController.delegate = self
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupSearchController()
     }
 
     // MARK: - RootController
@@ -74,48 +146,45 @@ class PadRootViewController: UISplitViewController, RootController {
         // Pass
         return true
     }
-
+    
 }
 
-private class PadMasterViewController: ContainerViewController, SearchContainer, SearchContainerDelegate {
+extension PadMasterViewController: SearchContainer, SearchContainerDelegate, SearchViewControllerDelegate {}
 
-    let myTBA: MyTBA
-    let pasteboard: UIPasteboard?
-    let photoLibrary: PHPhotoLibrary?
-    let searchService: SearchService
-    let statusService: StatusService
-    let urlOpener: URLOpener
+extension PadMasterViewController: PadRootTableViewControllerDelegate {
 
-    var searchController: UISearchController!
-
-    init(myTBA: MyTBAsearchService: SearchService, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.searchService = searchService
-
-        super.init(viewControllers: [], persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - View Lifecycle
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        setupSearchController()
+    func rootTypeSelected(_ rootType: RootType) {
+        switch rootType {
+        case .events:
+            navigationController?.pushViewController(eventsViewController, animated: true)
+        case .teams:
+            navigationController?.pushViewController(teamsViewController, animated: true)
+        case .districts:
+            navigationController?.pushViewController(districtsViewController, animated: true)
+        case .myTBA:
+            navigationController?.pushViewController(myTBAViewController, animated: true)
+        case .settings:
+            // TODO: Fix
+            break
+        }
     }
 
 }
 
-private class PadRootTableViewController: UITableViewController {
+protocol PadRootTableViewControllerDelegate: AnyObject {
+    func rootTypeSelected(_ rootType: RootType)
+}
+
+private class PadRootTableViewController: TBATableViewController, Refreshable, Stateful {
+
+    weak var delegate: PadRootTableViewControllerDelegate?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        disableRefreshing()
 
         tableView.isScrollEnabled = false
-        tableView.registerReusableCell(BasicTableViewCell.self)
-        tableView.tableFooterView = nil
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -123,15 +192,53 @@ private class PadRootTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 5
+        return RootType.allCases.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(indexPath: indexPath) as BasicTableViewCell
 
-        cell.textLabel?.text = "Events"
+        cell.textLabel?.text = RootType.allCases[indexPath.row].title
+        cell.imageView?.image = RootType.allCases[indexPath.row].icon
+        cell.imageView?.tintColor = UIColor.tabBarTintColor
+        cell.accessoryType = .disclosureIndicator
 
         return cell
+    }
+
+    // MARK: - Table View Delegate
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        delegate?.rootTypeSelected(RootType.allCases[indexPath.row])
+    }
+
+    // MARK: - Refreshable
+
+    var refreshKey: String? {
+        return nil
+    }
+
+    var automaticRefreshInterval: DateComponents? {
+        return nil
+    }
+
+    var automaticRefreshEndDate: Date? {
+        return nil
+    }
+
+    var isDataSourceEmpty: Bool {
+        return false
+    }
+
+    func refresh() {
+        // NOP
+    }
+
+
+    // MARK: - Stateful
+
+    var noDataText: String? {
+        return nil
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
@@ -164,8 +164,8 @@ extension PadMasterViewController: PadRootTableViewControllerDelegate {
         case .myTBA:
             navigationController?.pushViewController(myTBAViewController, animated: true)
         case .settings:
-            // TODO: Fix
-            break
+            let navigationController = UINavigationController(rootViewController: settingsViewController)
+            showDetailViewController(navigationController, sender: nil)
         }
     }
 
@@ -198,10 +198,12 @@ private class PadRootTableViewController: TBATableViewController, Refreshable, S
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(indexPath: indexPath) as BasicTableViewCell
 
-        cell.textLabel?.text = RootType.allCases[indexPath.row].title
-        cell.imageView?.image = RootType.allCases[indexPath.row].icon
+        let type = RootType.allCases[indexPath.row]
+
+        cell.textLabel?.text = type.title
+        cell.imageView?.image = type.icon
         cell.imageView?.tintColor = UIColor.tabBarTintColor
-        cell.accessoryType = .disclosureIndicator
+        cell.accessoryType =  type.supportsPush ? .disclosureIndicator : .none
 
         return cell
     }

--- a/the-blue-alliance-ios/View Controllers/Root/PhoneRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PhoneRootViewController.swift
@@ -57,13 +57,21 @@ class PhoneRootViewController: UITabBarController, RootController {
         guard let navigationController = selectedViewController as? UINavigationController else {
             return false
         }
-        navigationController.popToRootViewController(animated: false)
 
         guard let searchContainerViewController = navigationController.viewControllers.first as? SearchContainer else {
             return false
         }
+
+        // Fix `popToRootViewController` clobbering our `isActive` animation
+        // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/878
+        CATransaction.setCompletionBlock {
+            searchContainerViewController.searchController.isActive = true
+        }
+        CATransaction.begin()
+        navigationController.popToRootViewController(animated: true)
+        CATransaction.commit()
+
         searchContainerViewController.searchController.searchBar.text = searchText
-        searchContainerViewController.searchController.isActive = true
 
         return true
     }

--- a/the-blue-alliance-ios/View Controllers/Root/PhoneRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PhoneRootViewController.swift
@@ -1,0 +1,106 @@
+import CoreData
+import Foundation
+import MyTBAKit
+import Photos
+import TBAData
+import TBAKit
+import UIKit
+
+class PhoneRootViewController: UITabBarController, RootController {
+
+    let fcmTokenProvider: FCMTokenProvider
+    let myTBA: MyTBA
+    let pasteboard: UIPasteboard?
+    let photoLibrary: PHPhotoLibrary?
+    let pushService: PushService
+    let searchService: SearchService
+    let statusService: StatusService
+    let urlOpener: URLOpener
+    let persistentContainer: NSPersistentContainer
+    let tbaKit: TBAKit
+    let userDefaults: UserDefaults
+
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.fcmTokenProvider = fcmTokenProvider
+        self.myTBA = myTBA
+        self.pasteboard = pasteboard
+        self.photoLibrary = photoLibrary
+        self.pushService = pushService
+        self.searchService = searchService
+        self.statusService = statusService
+        self.urlOpener = urlOpener
+        self.persistentContainer = persistentContainer
+        self.tbaKit = tbaKit
+        self.userDefaults = userDefaults
+
+        super.init(nibName: nil, bundle: nil)
+
+        viewControllers = [eventsViewController, teamsViewController, districtsViewController, myTBAViewController, settingsViewController].compactMap({ (viewController) -> UIViewController? in
+            return UINavigationController(rootViewController: viewController)
+        })
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - RootController
+
+    func continueSearch(_ searchText: String) -> Bool {
+        // Pop to root of Events tab, show search
+        // Dismiss existing modal view controller
+        if let presentedViewController = presentedViewController {
+            presentedViewController.dismiss(animated: false)
+        }
+
+        selectedIndex = 0
+        guard let navigationController = selectedViewController as? UINavigationController else {
+            return false
+        }
+        navigationController.popToRootViewController(animated: false)
+
+        guard let searchContainerViewController = navigationController.viewControllers.first as? SearchContainer else {
+            return false
+        }
+        searchContainerViewController.searchController.searchBar.text = searchText
+        searchContainerViewController.searchController.isActive = true
+
+        return true
+    }
+
+    func show(event: Event) -> Bool {
+        guard let searchContainerViewController = show(index: 0) else {
+            return false
+        }
+        searchContainerViewController.eventSelected(event)
+        return true
+    }
+
+    func show(team: Team) -> Bool {
+        guard let searchContainerViewController = show(index: 1) else {
+            return false
+        }
+        searchContainerViewController.teamSelected(team)
+        return true
+    }
+
+    private func show(index: Int) -> SearchViewControllerDelegate? {
+        // Dismiss existing modal view controller
+        if let presentedViewController = presentedViewController {
+            presentedViewController.dismiss(animated: false)
+        }
+
+        selectedIndex = index
+        guard let navigationController = selectedViewController as? UINavigationController else {
+            return nil
+        }
+        navigationController.popToRootViewController(animated: false)
+
+        guard let searchContainerViewController = navigationController.viewControllers.first as? SearchViewControllerDelegate else {
+            return nil
+        }
+
+        return searchContainerViewController
+    }
+
+}

--- a/the-blue-alliance-ios/View Controllers/Root/RootController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/RootController.swift
@@ -1,0 +1,83 @@
+import CoreData
+import Foundation
+import MyTBAKit
+import Photos
+import TBAData
+import TBAKit
+
+protocol RootController {
+    var fcmTokenProvider: FCMTokenProvider { get }
+    var myTBA: MyTBA { get }
+    var pasteboard: UIPasteboard? { get }
+    var photoLibrary: PHPhotoLibrary? { get }
+    var pushService: PushService { get }
+    var searchService: SearchService { get }
+    var urlOpener: URLOpener { get }
+    var statusService: StatusService { get }
+    var persistentContainer: NSPersistentContainer { get }
+    var tbaKit: TBAKit { get }
+    var userDefaults: UserDefaults { get }
+
+    // MARK: - Handoff Methods
+    func continueSearch(_ searchText: String) -> Bool
+
+    func show(event: Event) -> Bool
+    func show(team: Team) -> Bool
+}
+
+extension RootController {
+
+    var eventsViewController: EventsContainerViewController {
+        return EventsContainerViewController(myTBA: myTBA,
+                                             pasteboard: pasteboard,
+                                             photoLibrary: photoLibrary,
+                                             searchService: searchService,
+                                             statusService: statusService,
+                                             urlOpener: urlOpener,
+                                             persistentContainer: persistentContainer,
+                                             tbaKit: tbaKit,
+                                             userDefaults: userDefaults)
+    }
+
+    var teamsViewController: TeamsContainerViewController {
+        return TeamsContainerViewController(myTBA: myTBA,
+                                            pasteboard: pasteboard,
+                                            photoLibrary: photoLibrary,
+                                            searchService: searchService,
+                                            statusService: statusService,
+                                            urlOpener: urlOpener,
+                                            persistentContainer: persistentContainer,
+                                            tbaKit: tbaKit,
+                                            userDefaults: userDefaults)
+    }
+
+    var districtsViewController: DistrictsContainerViewController {
+        return DistrictsContainerViewController(myTBA: myTBA,
+                                                statusService: statusService,
+                                                urlOpener: urlOpener,
+                                                persistentContainer: persistentContainer,
+                                                tbaKit: tbaKit,
+                                                userDefaults: userDefaults)
+    }
+
+    var settingsViewController: SettingsViewController {
+        return SettingsViewController(fcmTokenProvider: fcmTokenProvider,
+                                      myTBA: myTBA,
+                                      pushService: pushService,
+                                      searchService: searchService,
+                                      urlOpener: urlOpener,
+                                      persistentContainer: persistentContainer,
+                                      tbaKit: tbaKit,
+                                      userDefaults: userDefaults)
+    }
+
+    var myTBAViewController: MyTBAViewController {
+        return MyTBAViewController(myTBA: myTBA,
+                                   statusService: statusService,
+                                   urlOpener: urlOpener,
+                                   persistentContainer: persistentContainer,
+                                   tbaKit: tbaKit,
+                                   userDefaults: userDefaults)
+    }
+
+}

--- a/the-blue-alliance-ios/View Controllers/Root/RootController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/RootController.swift
@@ -5,6 +5,49 @@ import Photos
 import TBAData
 import TBAKit
 
+protocol RootChildController {
+    var rootType: RootType { get }
+}
+
+enum RootType: CaseIterable {
+    case events
+    case teams
+    case districts
+    case myTBA
+    case settings
+
+    var title: String {
+        switch self {
+        case .events:
+            return "Events"
+        case .teams:
+            return "Teams"
+        case .districts:
+            return "Districts"
+        case .myTBA:
+            return "myTBA"
+        case .settings:
+            return "Settings"
+        }
+    }
+
+    var icon: UIImage? {
+        switch self {
+        case .events:
+            return UIImage.eventIcon
+        case .teams:
+            return UIImage.teamIcon
+        case .districts:
+            return UIImage.districtIcon
+        case .myTBA:
+            return UIImage.starIcon
+        case .settings:
+            return UIImage.settingsIcon
+        }
+    }
+
+}
+
 protocol RootController {
     var fcmTokenProvider: FCMTokenProvider { get }
     var myTBA: MyTBA { get }

--- a/the-blue-alliance-ios/View Controllers/Root/RootController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/RootController.swift
@@ -46,6 +46,11 @@ enum RootType: CaseIterable {
         }
     }
 
+    var supportsPush: Bool {
+        // Settings is currently the only VC that doesn't support a sub-menu push
+        return self != .settings
+    }
+
 }
 
 protocol RootController {

--- a/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
@@ -349,12 +349,7 @@ class SettingsViewController: TBATableViewController {
 
     private func pushTroubleshootNotifications() {
         let notificationsViewController = NotificationsViewController(fcmTokenProvider: fcmTokenProvider, myTBA: myTBA, pushService: pushService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        if let splitViewController = splitViewController {
-            let navigationController = UINavigationController(rootViewController: notificationsViewController)
-            splitViewController.showDetailViewController(navigationController, sender: nil)
-        } else if let navigationController = navigationController {
-            navigationController.pushViewController(notificationsViewController, animated: true)
-        }
+        navigationController?.pushViewController(notificationsViewController, animated: true)
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
@@ -348,8 +348,12 @@ class SettingsViewController: TBATableViewController {
 
     private func pushTroubleshootNotifications() {
         let notificationsViewController = NotificationsViewController(fcmTokenProvider: fcmTokenProvider, myTBA: myTBA, pushService: pushService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let nav = UINavigationController(rootViewController: notificationsViewController)
-        navigationController?.showDetailViewController(nav, sender: nil)
+        if let splitViewController = splitViewController {
+            let navigationController = UINavigationController(rootViewController: notificationsViewController)
+            splitViewController.showDetailViewController(navigationController, sender: nil)
+        } else if let navigationController = navigationController {
+            navigationController.pushViewController(notificationsViewController, animated: true)
+        }
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
@@ -42,8 +42,9 @@ class SettingsViewController: TBATableViewController {
 
         super.init(style: .grouped, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
 
-        title = "Settings"
-        tabBarItem.image = UIImage.settingsIcon
+        title = RootType.settings.title
+        tabBarItem.image = RootType.settings.icon
+
         hidesBottomBarWhenPushed = false
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
@@ -36,8 +36,8 @@ class TeamsContainerViewController: ContainerViewController {
                    tbaKit: tbaKit,
                    userDefaults: userDefaults)
 
-        title = "Teams"
-        tabBarItem.image = UIImage.teamIcon
+        title = RootType.teams.title
+        tabBarItem.image = RootType.teams.icon
 
         teamsViewController.delegate = self
     }

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
@@ -51,7 +51,10 @@ class TeamsContainerViewController: ContainerViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupSearchController()
+        // Only show Search in container view on iPhone
+        if UIDevice.isPhone {
+            setupSearchController()
+        }
     }
 
 }


### PR DESCRIPTION
## Description
This change removes the use of the `UISplitViewController` on iPhone and introduces a new navigation pattern of a root table view on iPad. This gives both iPhone and iPad two distinct navigation patterns that are proper for their platform, as opposed to shoehorning the iPhone navigation patterns in to iPad by using a hybrid tab view + split view approach.

Fixes #858, fixes #878

## Motivation and Context
Only using the split view controller on iPad is probably the right approach from a hierarchical standpoint. There's some weirdness at the intersection of the split view controller + iPhone (such as #858). This also allows us to create a more iPad specific navigation flow, like removing the tabs on iPad but keeping them on iPhone.

## How Has This Been Tested?
Manually tested

## Screenshots
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-05-22 at 14 33 06](https://user-images.githubusercontent.com/516458/82708794-1cee1000-9c4d-11ea-90bb-a852c077f266.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-05-22 at 14 33 11](https://user-images.githubusercontent.com/516458/82708798-1f506a00-9c4d-11ea-8e71-7fbfaf4fb024.png)
