### PR TITLE
[ios14] Create Dependencies for base view dependencies, abstract error reporting and logging

### DIFF
--- a/Frameworks/TBAUtils/Sources/Error/ErrorRecorder.swift
+++ b/Frameworks/TBAUtils/Sources/Error/ErrorRecorder.swift
@@ -1,5 +1,6 @@
 import Foundation
 
 public protocol ErrorRecorder {
+    func log(_ log: String, _ args: [CVarArg])
     func recordError(_ error: Error)
 }

--- a/tba-unit-tests/Operations/App Setup/PersistentContainerOperationTests.swift
+++ b/tba-unit-tests/Operations/App Setup/PersistentContainerOperationTests.swift
@@ -12,7 +12,12 @@ class PersistentContainerOperationTests: XCTestCase {
         super.setUp()
 
         persistentContainer = PrivateMockPersistentContainer(name: "Test")
-        persistentContainerOperation = MockPersistentContainerOperation(indexDelegate: TBACoreDataCoreSpotlightDelegate(), persistentContainer: persistentContainer)
+        let indexDelegate: TBACoreDataCoreSpotlightDelegate = {
+            let description = persistentContainer.persistentStoreDescriptions.first!
+            return TBACoreDataCoreSpotlightDelegate(forStoreWith: description,
+                                                    model: persistentContainer.managedObjectModel)
+        }()
+        persistentContainerOperation = MockPersistentContainerOperation(indexDelegate: indexDelegate, persistentContainer: persistentContainer)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/Protocols/SubscribableTests.swift
+++ b/tba-unit-tests/Protocols/SubscribableTests.swift
@@ -1,5 +1,6 @@
 import CoreData
 import MyTBAKit
+import TBAUtils
 import XCTest
 @testable import The_Blue_Alliance
 
@@ -8,13 +9,15 @@ class MockSubscribableViewController: UIViewController, Persistable, Subscribabl
     var favoriteBarButtonItem: UIBarButtonItem {
         return UIBarButtonItem(title: "Button", style: .plain, target: nil, action: nil)
     }
+    var errorRecorder: ErrorRecorder
     var myTBA: MyTBA
     var subscribableModel: MyTBASubscribable
     var persistentContainer: NSPersistentContainer
 
     var presentCalled: ((UIViewController) -> ())?
 
-    init(myTBA: MyTBA, subscribableModel: MyTBASubscribable, persistentContainer: NSPersistentContainer) {
+    init(errorRecorder: ErrorRecorder, myTBA: MyTBA, subscribableModel: MyTBASubscribable, persistentContainer: NSPersistentContainer) {
+        self.errorRecorder = errorRecorder
         self.myTBA = myTBA
         self.subscribableModel = subscribableModel
         self.persistentContainer = persistentContainer
@@ -41,7 +44,7 @@ class SubscribableTests: TBATestCase {
         super.setUp()
 
         subscribableModel = insertDistrictEvent()
-        subscribableViewController = MockSubscribableViewController(myTBA: myTBA, subscribableModel: subscribableModel, persistentContainer: persistentContainer)
+        subscribableViewController = MockSubscribableViewController(errorRecorder: errorRecorder, myTBA: myTBA, subscribableModel: subscribableModel, persistentContainer: persistentContainer)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/Services/HandoffServiceTests.swift
+++ b/tba-unit-tests/Services/HandoffServiceTests.swift
@@ -19,9 +19,7 @@ struct FakeRootController: RootController {
     let searchService: SearchService
     let statusService: StatusService
     let urlOpener: URLOpener
-    let persistentContainer: NSPersistentContainer
-    let tbaKit: TBAKit
-    let userDefaults: UserDefaults
+    let dependencies: Dependencies
 
     var continueSearchExpectation: XCTestExpectation?
     var continueSearchResult: Bool = true
@@ -57,8 +55,8 @@ class HandoffServiceTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        let rootController = FakeRootController(fcmTokenProvider: fcmTokenProvider, myTBA: myTBA, pushService: pushService, searchService: searchService, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        self.handoffService = HandoffService(persistentContainer: persistentContainer, rootController: rootController)
+        let rootController = FakeRootController(fcmTokenProvider: fcmTokenProvider, myTBA: myTBA, pushService: pushService, searchService: searchService, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        self.handoffService = HandoffService(errorRecorder: errorRecorder, persistentContainer: persistentContainer, rootController: rootController)
     }
 
     func test_handoff_unsupported() {

--- a/tba-unit-tests/View Controllers/Base/Containers/ContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Base/Containers/ContainerViewControllerTests.swift
@@ -12,7 +12,7 @@ class ContainerViewControllerTestCase: TBATestCase {
         super.setUp()
 
         let mockContainableViewController = MockContainableViewController(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        containerViewController = ContainerViewController(viewControllers: [mockContainableViewController], persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        containerViewController = ContainerViewController(viewControllers: [mockContainableViewController], dependencies: dependencies)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/View Controllers/Base/Containers/MyTBAContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Base/Containers/MyTBAContainerViewControllerTests.swift
@@ -13,10 +13,10 @@ class MockMyTBAContainerViewController: MyTBAContainerViewController {
 
     var updateFavoriteButtonExpectation: XCTestExpectation?
 
-    init(subscribableModel: MyTBASubscribable, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(subscribableModel: MyTBASubscribable, myTBA: MyTBA, dependencies: Dependencies) {
         _subscribableModel = subscribableModel
 
-        super.init(viewControllers: [], myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(viewControllers: [], myTBA: myTBA, dependencies: dependencies)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -41,7 +41,7 @@ class MyTBAContainerViewControllerTests: TBATestCase {
 
         subscribableModel = insertDistrictEvent()
 
-        tbaContainerViewController = MockMyTBAContainerViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        tbaContainerViewController = MockMyTBAContainerViewController(subscribableModel: subscribableModel, myTBA: myTBA, dependencies: dependencies)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictViewControllerTests.swift
@@ -21,9 +21,7 @@ class DistrictViewControllerTests: TBATestCase {
                                                         myTBA: myTBA,
                                                         statusService: statusService,
                                                         urlOpener: urlOpener,
-                                                        persistentContainer: persistentContainer,
-                                                        tbaKit: tbaKit,
-                                                        userDefaults: userDefaults)
+                                                        dependencies: dependencies)
         navigationController = MockNavigationController(rootViewController: districtViewController)
     }
 

--- a/tba-unit-tests/View Controllers/Districts/DistrictsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Districts/DistrictsContainerViewControllerTests.swift
@@ -12,9 +12,7 @@ class DistrictsContainerViewControllerTests: TBATestCase {
         districtsContainerViewController = DistrictsContainerViewController(myTBA: myTBA,
                                                                             statusService: statusService,
                                                                             urlOpener: urlOpener,
-                                                                            persistentContainer: persistentContainer,
-                                                                            tbaKit: tbaKit,
-                                                                            userDefaults: userDefaults)
+                                                                            dependencies: dependencies)
         districtsContainerViewController.viewDidLoad()
 
         navigationController = MockNavigationController(rootViewController: districtsContainerViewController)

--- a/tba-unit-tests/View Controllers/Events/EventViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Events/EventViewControllerTests.swift
@@ -17,7 +17,7 @@ class EventViewControllerTests: TBATestCase {
 
         let event = insertDistrictEvent()
 
-        eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        eventViewController = EventViewController(event: event, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         navigationController = MockNavigationController(rootViewController: eventViewController)
     }
 

--- a/tba-unit-tests/View Controllers/Events/EventsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Events/EventsContainerViewControllerTests.swift
@@ -13,9 +13,7 @@ class EventsContainerViewControllerTests: TBATestCase {
                                                                       searchService: searchService,
                                                                       statusService: statusService,
                                                                       urlOpener: urlOpener,
-                                                                      persistentContainer: persistentContainer,
-                                                                      tbaKit: tbaKit,
-                                                                      userDefaults: userDefaults)
+                                                                      dependencies: dependencies)
         eventsContainerViewController.viewDidLoad()
 
         navigationController = MockNavigationController(rootViewController: eventsContainerViewController)

--- a/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
@@ -16,7 +16,7 @@ class MatchViewControllerTests: TBATestCase {
 
         let match = insertMatch()
 
-        matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
     }
 
     override func tearDown() {
@@ -33,7 +33,7 @@ class MatchViewControllerTests: TBATestCase {
     func test_title_event() {
         let event = insertDistrictEvent()
         match.eventRaw = event
-        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
 
         XCTAssertEqual(vc.navigationTitle, "Quals 1")
         XCTAssertEqual(vc.navigationSubtitle, "@ 2018 Kettering University #1 District")
@@ -55,7 +55,7 @@ class MatchViewControllerTests: TBATestCase {
 
     func test_doesNotShowBreakdown() {
         let match = insertMatch(eventKey: "2014miket_qm1")
-        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         XCTAssertFalse(vc.children.contains(where: { (viewController) -> Bool in
             return viewController is MatchBreakdownViewController
         }))

--- a/tba-unit-tests/View Controllers/Settings/SettingsViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Settings/SettingsViewControllerTests.swift
@@ -13,9 +13,7 @@ class SettingsViewControllerTests: TBATestCase {
                                                         pushService: pushService,
                                                         searchService: searchService,
                                                         urlOpener: urlOpener,
-                                                        persistentContainer: persistentContainer,
-                                                        tbaKit: tbaKit,
-                                                        userDefaults: userDefaults)
+                                                        dependencies: dependencies)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/View Controllers/Teams/TeamViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamViewControllerTests.swift
@@ -16,7 +16,7 @@ class TeamViewControllerTests: TBATestCase {
 
         let team = insertTeam()
 
-        teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        teamViewController = TeamViewController(team: team, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
     }
 
     override func tearDown() {

--- a/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Teams/TeamsContainerViewControllerTests.swift
@@ -13,9 +13,7 @@ class TeamsContainerViewControllerTests: TBATestCase {
                                                                     searchService: searchService,
                                                                     statusService: statusService,
                                                                     urlOpener: urlOpener,
-                                                                    persistentContainer: persistentContainer,
-                                                                    tbaKit: tbaKit,
-                                                                    userDefaults: userDefaults)
+                                                                    dependencies: dependencies)
         navigationController = MockNavigationController(rootViewController: teamsContainerViewController)
     }
 

--- a/tba-unit-tests/View Controllers/myTBA/MyTBAPreferenceViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/myTBA/MyTBAPreferenceViewControllerTests.swift
@@ -18,7 +18,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         subscribableModel = insertDistrictEvent()
 
-        myTBAPreferencesViewController = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        myTBAPreferencesViewController = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         navigationController = MockNavigationController(rootViewController: myTBAPreferencesViewController)
     }
 
@@ -37,7 +37,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         // Insert a Favorite
         Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         XCTAssertNotNil(newPreferences.favorite)
         XCTAssert(newPreferences.isFavorite)
         XCTAssert(newPreferences.isFavoriteInitially)
@@ -50,7 +50,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
 
         // Insert a Subscription
         Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         XCTAssertNotNil(newPreferences.subscription)
         XCTAssertFalse(newPreferences.notifications.isEmpty)
         XCTAssertFalse(newPreferences.notificationsInitial.isEmpty)
@@ -126,7 +126,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let favorite = Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = false
 
         let deletionExpectation = expectation(description: "Favorite deleted")
@@ -151,7 +151,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let favorite = Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = false
 
         let deletionExpectation = expectation(description: "Favorite deleted")
@@ -176,7 +176,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let favorite = Favorite.insert(MyTBAFavorite(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = false
 
         let deletionExpectation = expectation(description: "Favorite deleted")
@@ -199,7 +199,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_favorite_insert() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = true
 
         // Sanity check
@@ -217,7 +217,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_favorite_insert_304() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = true
 
         // Sanity check
@@ -235,7 +235,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_favorite_insert_500() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.isFavorite = true
 
         // Sanity check
@@ -256,7 +256,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let subscription = Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = []
 
         let deletionExpectation = expectation(description: "Subscription deleted")
@@ -283,7 +283,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let subscription = Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = []
 
         let deletionExpectation = expectation(description: "Subscription deleted")
@@ -310,7 +310,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
         let subscription = Subscription.insert(MyTBASubscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, notifications: [.awards, .upcomingMatch]), in: persistentContainer.viewContext)
         try! persistentContainer.viewContext.save()
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = []
 
         let deletionExpectation = expectation(description: "Subscription deleted")
@@ -347,7 +347,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
             updateExpectation.fulfill()
         }
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.upcomingMatch]
 
         newPreferences.save()
@@ -374,7 +374,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
             updateExpectation.fulfill()
         }
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.upcomingMatch]
 
         newPreferences.save()
@@ -401,7 +401,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
             updateExpectation.fulfill()
         }
 
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.upcomingMatch]
 
         newPreferences.save()
@@ -416,7 +416,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_subscription_insert() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.awards, .upcomingMatch]
 
         // Sanity check
@@ -434,7 +434,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_subscription_insert_304() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.awards, .upcomingMatch]
 
         // Sanity check
@@ -452,7 +452,7 @@ class MyTBAPreferenceViewControllerTests: TBATestCase {
     }
 
     func test_save_hasChanges_subscription_insert_500() {
-        let newPreferences = MyTBAPreferenceViewController(subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
+        let newPreferences = MyTBAPreferenceViewController(errorRecorder: errorRecorder, subscribableModel: subscribableModel, myTBA: myTBA, persistentContainer: persistentContainer)
         newPreferences.notifications = [.awards, .upcomingMatch]
 
         // Sanity check

--- a/tba-unit-tests/View Controllers/myTBA/MyTBATableViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/myTBA/MyTBATableViewControllerTests.swift
@@ -12,7 +12,7 @@ class MyTBATableViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        myTBATableViewController = MyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        myTBATableViewController = MyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, dependencies: dependencies)
         myTBATableViewController.viewDidLoad()
     }
 
@@ -29,7 +29,7 @@ class MyTBATableViewControllerTests: TBATestCase {
 
     func test_refresh() {
         myTBA.authToken = "abcd123"
-        let mockMyTBATableViewController = MockMyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let mockMyTBATableViewController = MockMyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, dependencies: dependencies)
 
         let fetchEventExpectation = expectation(description: "Fetch event called")
         mockMyTBATableViewController.fetchEventExpectation = fetchEventExpectation
@@ -140,10 +140,10 @@ class MyTBATableViewControllerTests: TBATestCase {
     }
 
     func test_refreshKey() {
-        let favorites = MockMyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let favorites = MockMyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, dependencies: dependencies)
         XCTAssertEqual(favorites.refreshKey, "favorites")
 
-        let subscriptions = MockMyTBATableViewController<Subscription, MyTBASubscription>(myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let subscriptions = MockMyTBATableViewController<Subscription, MyTBASubscription>(myTBA: myTBA, dependencies: dependencies)
         XCTAssertEqual(subscriptions.refreshKey, "subscriptions")
     }
 
@@ -178,10 +178,10 @@ class MyTBATableViewControllerTests: TBATestCase {
     }
 
     func test_noDataText() {
-        let favorites = MockMyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let favorites = MockMyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, dependencies: dependencies)
         XCTAssertEqual(favorites.noDataText, "No favorites")
 
-        let subscriptions = MockMyTBATableViewController<Subscription, MyTBASubscription>(myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let subscriptions = MockMyTBATableViewController<Subscription, MyTBASubscription>(myTBA: myTBA, dependencies: dependencies)
         XCTAssertEqual(subscriptions.noDataText, "No subscriptions")
     }
 

--- a/tba-unit-tests/View Controllers/myTBA/MyTBAViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/myTBA/MyTBAViewControllerTests.swift
@@ -11,7 +11,7 @@ class MyTBAViewControllerTests: TBATestCase {
     override func setUp() {
         super.setUp()
 
-        myTBAViewController = MyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        myTBAViewController = MyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         navigationController = MockNavigationController(rootViewController: myTBAViewController)
     }
 
@@ -87,7 +87,7 @@ class MyTBAViewControllerTests: TBATestCase {
     
     func test_authenticated() {
         let ex = expectation(description: "Authenticated")
-        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         mock.viewDidLoad()
         mock.authenticatedExpectation = ex
         myTBA.authToken = "abcd123"
@@ -97,7 +97,7 @@ class MyTBAViewControllerTests: TBATestCase {
     func test_authenticated_noLoad() {
         let ex = expectation(description: "Authenticated")
         ex.isInverted = true
-        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         mock.authenticatedExpectation = ex
         myTBA.authToken = "abcd123"
         wait(for: [ex], timeout: 1.0)
@@ -106,7 +106,7 @@ class MyTBAViewControllerTests: TBATestCase {
     func test_unauthenticated() {
         myTBA.authToken = "abcd123"
         let ex = expectation(description: "Unauthenticated")
-        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         mock.viewDidLoad()
         mock.unauthenticatedExpectation = ex
         myTBA.authToken = nil
@@ -117,7 +117,7 @@ class MyTBAViewControllerTests: TBATestCase {
         myTBA.authToken = "abcd123"
         let ex = expectation(description: "Unauthenticated")
         ex.isInverted = true
-        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let mock = MockMyTBAViewController(myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         mock.unauthenticatedExpectation = ex
         myTBA.authToken = nil
         wait(for: [ex], timeout: 1.0)

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		92564C70216456800047917F /* Secrets_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92564C6F216456800047917F /* Secrets_Tests.swift */; };
 		92564C72216457060047917F /* TestSecrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 92564C71216457060047917F /* TestSecrets.plist */; };
 		92592F8423CB7F8900F3E124 /* TBASearchableTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92592F8323CB7F8900F3E124 /* TBASearchableTableViewController.swift */; };
+		92598CC724A92AFE007E08CB /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92598CC624A92AFE007E08CB /* Dependencies.swift */; };
 		925D10EB2394C7F300191D92 /* NSDiffableDataSourceSnapshot+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D10EA2394C7F300191D92 /* NSDiffableDataSourceSnapshot+TBA.swift */; };
 		926BE685238F7E4D008B960A /* RemoteConfig+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926BE684238F7E4D008B960A /* RemoteConfig+TBA.swift */; };
 		927309A423DC0F26006145E0 /* TBA Spotlight Index Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 9273099C23DC0F26006145E0 /* TBA Spotlight Index Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -293,6 +294,7 @@
 		92564C6F216456800047917F /* Secrets_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets_Tests.swift; sourceTree = "<group>"; };
 		92564C71216457060047917F /* TestSecrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = TestSecrets.plist; sourceTree = "<group>"; };
 		92592F8323CB7F8900F3E124 /* TBASearchableTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBASearchableTableViewController.swift; sourceTree = "<group>"; };
+		92598CC624A92AFE007E08CB /* Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dependencies.swift; sourceTree = "<group>"; };
 		925D10EA2394C7F300191D92 /* NSDiffableDataSourceSnapshot+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDiffableDataSourceSnapshot+TBA.swift"; sourceTree = "<group>"; };
 		926BE684238F7E4D008B960A /* RemoteConfig+TBA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RemoteConfig+TBA.swift"; sourceTree = "<group>"; };
 		9273099C23DC0F26006145E0 /* TBA Spotlight Index Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "TBA Spotlight Index Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -588,7 +590,7 @@
 				92B0AA3A20CB837A0074FDF1 /* main.swift */,
 				92942D951E2154DA008E79CA /* AppDelegate.swift */,
 				92B076F220FF948D00F9B2D7 /* TestAppDelegate.swift */,
-				92BA25B8238EEA4500EC796D /* Delegates */,
+				92598CC624A92AFE007E08CB /* Dependencies.swift */,
 			);
 			path = "App Delegate";
 			sourceTree = "<group>";
@@ -989,13 +991,6 @@
 				92B55629215FCB1300C1D9A3 /* Reusable.swift */,
 			);
 			path = Protocols;
-			sourceTree = "<group>";
-		};
-		92BA25B8238EEA4500EC796D /* Delegates */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Delegates;
 			sourceTree = "<group>";
 		};
 		92BB717920CE05770081F4E5 /* App Setup */ = {
@@ -1810,6 +1805,7 @@
 				929DB38C2095640000FB575F /* ReverseSubtitleTableViewCell.swift in Sources */,
 				9274E14721B10DB700F5D5D0 /* NotificationStatusCellViewModel.swift in Sources */,
 				1479694E215EC4B60075AF4E /* InfoCellViewModel.swift in Sources */,
+				92598CC724A92AFE007E08CB /* Dependencies.swift in Sources */,
 				92FF10F721A61AC2003BC5C4 /* MatchInfoViewController.swift in Sources */,
 				9279737D23CFF3A700FF9B86 /* EventStatsConfigurator2018.swift in Sources */,
 				92564C6B21644AA30047917F /* Secrets.swift in Sources */,

--- a/the-blue-alliance-ios/App Delegate/Dependencies.swift
+++ b/the-blue-alliance-ios/App Delegate/Dependencies.swift
@@ -1,0 +1,18 @@
+import CoreData
+import Foundation
+import TBAKit
+import TBAUtils
+
+class Dependencies {
+    let errorRecorder: ErrorRecorder
+    let persistentContainer: NSPersistentContainer
+    let tbaKit: TBAKit
+    let userDefaults: UserDefaults
+
+    init(errorRecorder: ErrorRecorder, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+        self.errorRecorder = errorRecorder
+        self.persistentContainer = persistentContainer
+        self.tbaKit = tbaKit
+        self.userDefaults = userDefaults
+    }
+}

--- a/the-blue-alliance-ios/Extensions/ContainerViewController+Team.swift
+++ b/the-blue-alliance-ios/Extensions/ContainerViewController+Team.swift
@@ -1,4 +1,3 @@
-import Crashlytics
 import MyTBAKit
 import Photos
 import TBAData
@@ -18,7 +17,7 @@ protocol ContainerTeamPushable {
 extension ContainerTeamPushable where Self: ContainerViewController {
 
     func pushTeam(team: Team) {
-        let teamViewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         navigationController?.pushViewController(teamViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/Info.plist
+++ b/the-blue-alliance-ios/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -91,6 +89,8 @@
 	<string>1</string>
 	<key>CoreSpotlightContinuation</key>
 	<true/>
+	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
+	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
@@ -104,17 +104,17 @@
 	<string>Enable photo library access to save images to your photo library directly from the app.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Enable photo library access to save images to your photo library directly from the app.</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>com.the-blue-alliance.tba.Team</string>
+		<string>com.the-blue-alliance.tba.Event</string>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>NSUserActivityTypes</key>
-	<array>
-		<string>com.the-blue-alliance.tba.Team</string>
-		<string>com.the-blue-alliance.tba.Event</string>
-	</array>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/the-blue-alliance-ios/Protocols/Persistable.swift
+++ b/the-blue-alliance-ios/Protocols/Persistable.swift
@@ -3,5 +3,5 @@ import CoreData
 
 // Persistable describes a class that uses a persistent data store
 protocol Persistable: AnyObject {
-    var persistentContainer: NSPersistentContainer { get set }
+    var persistentContainer: NSPersistentContainer { get }
 }

--- a/the-blue-alliance-ios/Protocols/SearchContainer.swift
+++ b/the-blue-alliance-ios/Protocols/SearchContainer.swift
@@ -12,7 +12,7 @@ protocol SearchContainer: ContainerViewController {
 extension SearchContainer where Self: SearchViewControllerDelegate {
 
     func setupSearchController() {
-        let searchViewController = SearchViewController(searchService: searchService, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let searchViewController = SearchViewController(searchService: searchService, dependencies: dependencies)
         searchViewController.delegate = self
 
         searchController = UISearchController(searchResultsController: searchViewController)
@@ -56,7 +56,7 @@ extension SearchContainerDelegate where Self: ContainerViewController {
 
     func eventSelected(_ event: Event) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let eventViewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: eventViewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)
@@ -67,7 +67,7 @@ extension SearchContainerDelegate where Self: ContainerViewController {
 
     func teamSelected(_ team: Team) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let teamViewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: teamViewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)

--- a/the-blue-alliance-ios/Protocols/Subscribable.swift
+++ b/the-blue-alliance-ios/Protocols/Subscribable.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MyTBAKit
+import TBAUtils
 import UIKit
 
 // Subscribable is a protocol view controllers can conform to if they want to have
@@ -7,6 +8,7 @@ import UIKit
 // Ex: The 'Event' view controller conforms to Subscribable, which shows the subscribe UI
 
 protocol Subscribable {
+    var errorRecorder: ErrorRecorder { get }
     var myTBA: MyTBA { get }
     var favoriteBarButtonItem: UIBarButtonItem { get }
     var subscribableModel: MyTBASubscribable { get }
@@ -15,7 +17,8 @@ protocol Subscribable {
 extension Subscribable where Self: UIViewController, Self: Persistable {
 
     func presentMyTBAPreferences() {
-        let myTBAPreferencesViewController = MyTBAPreferenceViewController(subscribableModel: subscribableModel,
+        let myTBAPreferencesViewController = MyTBAPreferenceViewController(errorRecorder: errorRecorder,
+                                                                           subscribableModel: subscribableModel,
                                                                            myTBA: myTBA,
                                                                            persistentContainer: persistentContainer)
         let navigationController = UINavigationController(rootViewController: myTBAPreferencesViewController)

--- a/the-blue-alliance-ios/Services/HandoffService.swift
+++ b/the-blue-alliance-ios/Services/HandoffService.swift
@@ -1,14 +1,15 @@
 import CoreData
 import CoreSpotlight
-import Crashlytics
+import Foundation
 import Search
 import TBAData
-import Foundation
+import TBAUtils
 import UIKit
 
 // Handles launching the app/setting up the view hiearchy from some handoff event
 class HandoffService {
 
+    private let errorRecorder: ErrorRecorder
     private let persistentContainer: NSPersistentContainer
     private let rootController: RootController
 
@@ -24,7 +25,8 @@ class HandoffService {
     private(set) var continueSearchText: String?
     private(set) var continueURI: URL?
 
-    init(persistentContainer: NSPersistentContainer, rootController: RootController) {
+    init(errorRecorder: ErrorRecorder, persistentContainer: NSPersistentContainer, rootController: RootController) {
+        self.errorRecorder = errorRecorder
         self.persistentContainer = persistentContainer
         self.rootController = rootController
     }
@@ -58,7 +60,7 @@ class HandoffService {
                 // If the Event doesn't exist, but our key matches what we consider a "safe" regex, insert the Event and push
                 if event == nil, let eventKeyRegex = eventKeyRegex, eventKeyRegex.numberOfMatches(in: key, options: [], range: NSRange(location: 0, length: key.count)) == 1 {
                     event = Event.insert(key, in: persistentContainer.viewContext)
-                    persistentContainer.viewContext.saveOrRollback(errorRecorder: Crashlytics.sharedInstance())
+                    persistentContainer.viewContext.saveOrRollback(errorRecorder: errorRecorder)
                 }
                 guard let uri = event?.objectID.uriRepresentation() else {
                     return false

--- a/the-blue-alliance-ios/Services/PushService.swift
+++ b/the-blue-alliance-ios/Services/PushService.swift
@@ -1,19 +1,21 @@
-import Crashlytics
 import FirebaseMessaging
 import Foundation
 import MyTBAKit
+import TBAUtils
 import UserNotifications
 
 // PushService handles registering push notification tokens with TBA and handling APNS messages
 // Has to be an NSObject subclass so we can be a UNUserNotificationCenterDelegate
 class PushService: NSObject {
 
+    private let errorRecorder: ErrorRecorder
     private var myTBA: MyTBA
     internal var retryService: RetryService
 
     private let operationQueue = OperationQueue()
 
-    init(myTBA: MyTBA, retryService: RetryService) {
+    init(errorRecorder: ErrorRecorder, myTBA: MyTBA, retryService: RetryService) {
+        self.errorRecorder = errorRecorder
         self.myTBA = myTBA
         self.retryService = retryService
 
@@ -34,7 +36,7 @@ class PushService: NSObject {
         }
         let registerOperation = myTBA.register { (_, error) in
             if let error = error {
-                Crashlytics.sharedInstance().recordError(error)
+                self.errorRecorder.recordError(error)
                 if !self.retryService.isRetryRegistered {
                     DispatchQueue.main.async {
                         self.registerRetryable()

--- a/the-blue-alliance-ios/View Controllers/Base/Containers/ContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Containers/ContainerViewController.swift
@@ -2,6 +2,7 @@ import CoreData
 import Foundation
 import TBAData
 import TBAKit
+import TBAUtils
 import UIKit
 
 protocol NavigationTitleDelegate: AnyObject {
@@ -41,9 +42,20 @@ class ContainerViewController: UIViewController, Persistable, Alertable {
         }
     }
 
-    var persistentContainer: NSPersistentContainer
-    private(set) var tbaKit: TBAKit
-    private(set) var userDefaults: UserDefaults
+    let dependencies: Dependencies
+
+    var errorRecorder: ErrorRecorder {
+        return dependencies.errorRecorder
+    }
+    var persistentContainer: NSPersistentContainer {
+        return dependencies.persistentContainer
+    }
+    var tbaKit: TBAKit {
+        return dependencies.tbaKit
+    }
+    var userDefaults: UserDefaults {
+        return dependencies.userDefaults
+    }
 
     // MARK: - Private View Elements
 
@@ -98,11 +110,9 @@ class ContainerViewController: UIViewController, Persistable, Alertable {
         return offlineEventView
     }()
 
-    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, dependencies: Dependencies) {
         self.viewControllers = viewControllers
-        self.persistentContainer = persistentContainer
-        self.tbaKit = tbaKit
-        self.userDefaults = userDefaults
+        self.dependencies = dependencies
 
         self.navigationTitle = navigationTitle
         self.navigationSubtitle = navigationSubtitle

--- a/the-blue-alliance-ios/View Controllers/Base/Containers/MyTBAContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Containers/MyTBAContainerViewController.swift
@@ -18,10 +18,10 @@ class MyTBAContainerViewController: ContainerViewController, Subscribable {
 
     // MARK: - Init
 
-    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, myTBA: MyTBA, dependencies: Dependencies) {
         self.myTBA = myTBA
 
-        super.init(viewControllers: viewControllers, navigationTitle: navigationTitle, navigationSubtitle: navigationSubtitle, segmentedControlTitles: segmentedControlTitles, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(viewControllers: viewControllers, navigationTitle: navigationTitle, navigationSubtitle: navigationSubtitle, segmentedControlTitles: segmentedControlTitles, dependencies: dependencies)
 
         updateFavoriteButton()
 

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBACollectionViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBACollectionViewController.swift
@@ -1,17 +1,29 @@
 import CoreData
 import Foundation
 import TBAKit
+import TBAUtils
 import UIKit
 
 class TBACollectionViewController: UICollectionViewController, DataController, Navigatable {
 
-    var persistentContainer: NSPersistentContainer
-    let tbaKit: TBAKit
+    private let dependencies: Dependencies
+
+    var errorRecorder: ErrorRecorder {
+        return dependencies.errorRecorder
+    }
+    var persistentContainer: NSPersistentContainer {
+        return dependencies.persistentContainer
+    }
+    var tbaKit: TBAKit {
+        return dependencies.tbaKit
+    }
+    var userDefaults: UserDefaults {
+        return dependencies.userDefaults
+    }
 
     // MARK: - Refreshable
 
     var refreshOperationQueue: OperationQueue = OperationQueue()
-    var userDefaults: UserDefaults
 
     // MARK: - Stateful
 
@@ -25,12 +37,10 @@ class TBACollectionViewController: UICollectionViewController, DataController, N
 
     // MARK: - Init
 
-    init(persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.persistentContainer = persistentContainer
-        self.tbaKit = tbaKit
-        self.userDefaults = userDefaults
+    init(collectionViewLayout: UICollectionViewLayout = UICollectionViewFlowLayout(), dependencies: Dependencies) {
+        self.dependencies = dependencies
 
-        super.init(collectionViewLayout: UICollectionViewFlowLayout())
+        super.init(collectionViewLayout: collectionViewLayout)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBATableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBATableViewController.swift
@@ -1,17 +1,29 @@
 import CoreData
 import Foundation
 import TBAKit
+import TBAUtils
 import UIKit
 
 class TBATableViewController: UITableViewController, TableViewDataSourceDelegate, DataController, Navigatable {
 
-    var persistentContainer: NSPersistentContainer
-    let tbaKit: TBAKit
+    let dependencies: Dependencies
+
+    var errorRecorder: ErrorRecorder {
+        return dependencies.errorRecorder
+    }
+    var persistentContainer: NSPersistentContainer {
+        return dependencies.persistentContainer
+    }
+    var tbaKit: TBAKit {
+        return dependencies.tbaKit
+    }
+    var userDefaults: UserDefaults {
+        return dependencies.userDefaults
+    }
 
     // MARK: - Refreshable
 
     var refreshOperationQueue: OperationQueue = OperationQueue()
-    var userDefaults: UserDefaults
 
     // MARK: - Stateful
 
@@ -25,10 +37,8 @@ class TBATableViewController: UITableViewController, TableViewDataSourceDelegate
 
     // MARK: - Init
 
-    init(style: UITableView.Style = .plain, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.persistentContainer = persistentContainer
-        self.tbaKit = tbaKit
-        self.userDefaults = userDefaults
+    init(style: UITableView.Style = .plain, dependencies: Dependencies) {
+        self.dependencies = dependencies
 
         super.init(style: style)
     }

--- a/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/Data Controllers/TBAViewController.swift
@@ -1,14 +1,27 @@
 import CoreData
 import Foundation
 import TBAKit
+import TBAUtils
 import UIKit
 
 typealias DataController = Persistable & Alertable
 
 class TBAViewController: UIViewController, DataController, Navigatable {
 
-    var persistentContainer: NSPersistentContainer
-    let tbaKit: TBAKit
+    private let dependencies: Dependencies
+
+    var errorRecorder: ErrorRecorder {
+        return dependencies.errorRecorder
+    }
+    var persistentContainer: NSPersistentContainer {
+        return dependencies.persistentContainer
+    }
+    var tbaKit: TBAKit {
+        return dependencies.tbaKit
+    }
+    var userDefaults: UserDefaults {
+        return dependencies.userDefaults
+    }
 
     let scrollView: UIScrollView = {
         let scrollView = UIScrollView(forAutoLayout: ())
@@ -20,7 +33,6 @@ class TBAViewController: UIViewController, DataController, Navigatable {
     // MARK: - Refreshable
 
     var refreshOperationQueue: OperationQueue = OperationQueue()
-    var userDefaults: UserDefaults
 
     // MARK: - Stateful
 
@@ -34,10 +46,8 @@ class TBAViewController: UIViewController, DataController, Navigatable {
 
     // MARK: - Init
 
-    init(persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
-        self.persistentContainer = persistentContainer
-        self.tbaKit = tbaKit
-        self.userDefaults = userDefaults
+    init(dependencies: Dependencies) {
+        self.dependencies = dependencies
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Base/SelectTableViewController.swift
@@ -23,12 +23,12 @@ class SelectTableViewController<Delegate: SelectTableViewControllerDelegate>: TB
     private let willPush: Bool
     weak var delegate: Delegate?
 
-    init(current: Delegate.OptionType?, options: [Delegate.OptionType], willPush: Bool = false, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(current: Delegate.OptionType?, options: [Delegate.OptionType], willPush: Bool = false, dependencies: Dependencies) {
         self.current = current
         self.options = options
         self.willPush = willPush
 
-        super.init(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(dependencies: dependencies)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictTeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictTeamsViewController.swift
@@ -1,5 +1,4 @@
 import CoreData
-import Crashlytics
 import Foundation
 import TBAData
 import TBAKit
@@ -10,10 +9,10 @@ class DistrictTeamsViewController: TeamsViewController {
 
     // MARK: Init
 
-    init(district: District, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(district: District, dependencies: Dependencies) {
         self.district = district
 
-        super.init(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(dependencies: dependencies)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -49,7 +48,7 @@ class DistrictTeamsViewController: TeamsViewController {
                 district.insert(teams)
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
-            }, errorRecorder: Crashlytics.sharedInstance())
+            }, errorRecorder: self.errorRecorder)
         }
         addRefreshOperations([operation])
     }

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
@@ -21,7 +21,7 @@ class DistrictViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(district: District, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(district: District, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.district = district
         self.myTBA = myTBA
         self.pasteboard = pasteboard
@@ -29,15 +29,13 @@ class DistrictViewController: ContainerViewController {
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        eventsViewController = DistrictEventsViewController(district: district, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        teamsViewController = DistrictTeamsViewController(district: district, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        rankingsViewController = DistrictRankingsViewController(district: district, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        eventsViewController = DistrictEventsViewController(district: district, dependencies: dependencies)
+        teamsViewController = DistrictTeamsViewController(district: district, dependencies: dependencies)
+        rankingsViewController = DistrictRankingsViewController(district: district, dependencies: dependencies)
 
         super.init(viewControllers: [eventsViewController, teamsViewController, rankingsViewController],
                    segmentedControlTitles: ["Events", "Teams", "Rankings"],
-                   persistentContainer: persistentContainer,
-                   tbaKit: tbaKit,
-                   userDefaults: userDefaults)
+                   dependencies: dependencies)
 
         title = "\(district.year) \(district.name) Districts"
 
@@ -61,7 +59,7 @@ class DistrictViewController: ContainerViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        CLSLogv("District: %@", getVaList([district.key]))
+        errorRecorder.log("District: %@", [district.key])
     }
 
 }
@@ -69,7 +67,7 @@ class DistrictViewController: ContainerViewController {
 extension DistrictViewController: EventsViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
-        let eventViewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         self.navigationController?.pushViewController(eventViewController, animated: true)
     }
 
@@ -86,7 +84,7 @@ extension DistrictViewController: EventsViewControllerDelegate {
 extension DistrictViewController: TeamsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
-        let teamViewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamViewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         self.navigationController?.pushViewController(teamViewController, animated: true)
     }
 
@@ -95,7 +93,7 @@ extension DistrictViewController: TeamsViewControllerDelegate {
 extension DistrictViewController: DistrictRankingsViewControllerDelegate {
 
     func districtRankingSelected(_ districtRanking: DistrictRanking) {
-        let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: districtRanking, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: districtRanking, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtDistrictViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
@@ -1,5 +1,4 @@
 import CoreData
-import Crashlytics
 import Foundation
 import TBAData
 import TBAKit
@@ -24,10 +23,10 @@ class DistrictTeamSummaryViewController: TBATableViewController {
 
     // MARK: Init
 
-    init(ranking: DistrictRanking, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(ranking: DistrictRanking, dependencies: Dependencies) {
         self.ranking = ranking
 
-        super.init(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(dependencies: dependencies)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -120,18 +119,18 @@ extension DistrictTeamSummaryViewController: Refreshable {
 
     @objc func refresh() {
         var operation: TBAKitOperation!
-        operation = tbaKit.fetchDistrictRankings(key: ranking.district.key) { (result, notModified) in
+        operation = tbaKit.fetchDistrictRankings(key: ranking.district.key) { [self] (result, notModified) in
             guard case .success(let rankings) = result, !notModified else {
                 return
             }
 
-            let context = self.persistentContainer.newBackgroundContext()
+            let context = persistentContainer.newBackgroundContext()
             context.performChangesAndWait({
                 let district = context.object(with: self.ranking.district.objectID) as! District
                 district.insert(rankings)
             }, saved: {
-                self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
-            }, errorRecorder: Crashlytics.sharedInstance())
+                markTBARefreshSuccessful(tbaKit, operation: operation)
+            }, errorRecorder: errorRecorder)
         }
         addRefreshOperations([operation])
     }

--- a/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -24,7 +24,7 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
 
     // MARK: Init
 
-    init(ranking: DistrictRanking, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(ranking: DistrictRanking, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.ranking = ranking
         self.myTBA = myTBA
         self.pasteboard = pasteboard
@@ -32,17 +32,15 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        let summaryViewController = DistrictTeamSummaryViewController(ranking: ranking, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let breakdownViewController = DistrictBreakdownViewController(ranking: ranking, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let summaryViewController = DistrictTeamSummaryViewController(ranking: ranking, dependencies: dependencies)
+        let breakdownViewController = DistrictBreakdownViewController(ranking: ranking, dependencies: dependencies)
 
         super.init(
             viewControllers: [summaryViewController, breakdownViewController],
             navigationTitle: ranking.team.teamNumberNickname,
             navigationSubtitle: "@ \(ranking.district.abbreviationWithYear)",
             segmentedControlTitles: ["Summary", "Breakdown"],
-            persistentContainer: persistentContainer,
-            tbaKit: tbaKit,
-            userDefaults: userDefaults
+            dependencies: dependencies
         )
 
         rightBarButtonItems = [
@@ -61,7 +59,7 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        CLSLogv("Team@District: District %@ | Team %@", getVaList([ranking.district.key, team.key]))
+        errorRecorder.log("Team@District: District %@ | Team %@", [ranking.district.key, team.key])
     }
 
     // MARK: - Private Methods
@@ -75,7 +73,7 @@ class TeamAtDistrictViewController: ContainerViewController, ContainerTeamPushab
 extension TeamAtDistrictViewController: DistrictTeamSummaryViewControllerDelegate {
 
     func eventPointsSelected(_ eventPoints: DistrictEventPoints) {
-        let teamAtEventViewController = TeamAtEventViewController(team: eventPoints.team, event: eventPoints.event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(team: eventPoints.team, event: eventPoints.event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/DistrictsContainerViewController.swift
@@ -23,20 +23,18 @@ class DistrictsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.myTBA = myTBA
         self.statusService = statusService
         self.urlOpener = urlOpener
 
         year = statusService.currentSeason
-        districtsViewController = DistrictsViewController(year: year, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        districtsViewController = DistrictsViewController(year: year, dependencies: dependencies)
 
         super.init(viewControllers: [districtsViewController],
                    navigationTitle: "Districts",
                    navigationSubtitle: ContainerViewController.yearSubtitle(year),
-                   persistentContainer: persistentContainer,
-                   tbaKit: tbaKit,
-                   userDefaults: userDefaults)
+                   dependencies: dependencies)
 
         title = RootType.districts.title
         tabBarItem.image = RootType.districts.icon
@@ -62,7 +60,7 @@ class DistrictsContainerViewController: ContainerViewController {
 extension DistrictsContainerViewController: NavigationTitleDelegate {
 
     func navigationTitleTapped() {
-        let selectTableViewController = SelectTableViewController<DistrictsContainerViewController>(current: year, options: Array(2009...statusService.maxSeason).reversed(), persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let selectTableViewController = SelectTableViewController<DistrictsContainerViewController>(current: year, options: Array(2009...statusService.maxSeason).reversed(), dependencies: dependencies)
         selectTableViewController.title = "Select Year"
         selectTableViewController.delegate = self
 
@@ -97,7 +95,7 @@ extension DistrictsContainerViewController: DistrictsViewControllerDelegate {
 
     func districtSelected(_ district: District) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let districtViewController = DistrictViewController(district: district, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let districtViewController = DistrictViewController(district: district, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: districtViewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)

--- a/the-blue-alliance-ios/View Controllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/EventViewController.swift
@@ -31,24 +31,22 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 
     // MARK: - Init
 
-    init(event: Event, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, dependencies: Dependencies) {
         self.event = event
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        infoViewController = EventInfoViewController(event: event, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        teamsViewController = EventTeamsViewController(event: event, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        rankingsViewController = EventRankingsViewController(event: event, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        matchesViewController = MatchesViewController(event: event, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        infoViewController = EventInfoViewController(event: event, urlOpener: urlOpener, dependencies: dependencies)
+        teamsViewController = EventTeamsViewController(event: event, dependencies: dependencies)
+        rankingsViewController = EventRankingsViewController(event: event, dependencies: dependencies)
+        matchesViewController = MatchesViewController(event: event, myTBA: myTBA, dependencies: dependencies)
 
         super.init(viewControllers: [infoViewController, teamsViewController, rankingsViewController, matchesViewController],
                    segmentedControlTitles: ["Info", "Teams", "Rankings", "Matches"],
                    myTBA: myTBA,
-                   persistentContainer: persistentContainer,
-                   tbaKit: tbaKit,
-                   userDefaults: userDefaults)
+                   dependencies: dependencies)
 
         title = event.friendlyNameWithYear
 
@@ -87,7 +85,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        CLSLogv("Event: %@", getVaList([event.key]))
+        errorRecorder.log("Event: %@", [event.key])
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -115,22 +113,22 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 extension EventViewController: EventInfoViewControllerDelegate {
 
     func showAlliances() {
-        let eventAlliancesViewController = EventAlliancesContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventAlliancesViewController = EventAlliancesContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(eventAlliancesViewController, animated: true)
     }
 
     func showAwards() {
-        let eventAwardsViewController = EventAwardsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventAwardsViewController = EventAwardsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(eventAwardsViewController, animated: true)
     }
 
     func showDistrictPoints() {
-        let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(eventDistrictPointsViewController, animated: true)
     }
 
     func showInsights() {
-        let eventInsightsContainerViewController = EventInsightsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventInsightsContainerViewController = EventInsightsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(eventInsightsContainerViewController, animated: true)
     }
 
@@ -139,7 +137,7 @@ extension EventViewController: EventInfoViewControllerDelegate {
 extension EventViewController: TeamsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
-        let teamAtEventViewController = TeamAtEventViewController(team: team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(team: team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -148,7 +146,7 @@ extension EventViewController: TeamsViewControllerDelegate {
 extension EventViewController: EventRankingsViewControllerDelegate {
 
     func rankingSelected(_ ranking: EventRanking) {
-        let teamAtEventViewController = TeamAtEventViewController(team: ranking.team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(team: ranking.team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -157,7 +155,7 @@ extension EventViewController: EventRankingsViewControllerDelegate {
 extension EventViewController: MatchesViewControllerDelegate, MatchesViewControllerQueryable {
 
     func matchSelected(_ match: Match) {
-        let matchViewController = MatchViewController(match: match, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let matchViewController = MatchViewController(match: match, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventInsightsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/Event/Stats/EventInsightsContainerViewController.swift
@@ -20,7 +20,7 @@ class EventInsightsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Event, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(event: Event, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
         self.pasteboard = pasteboard
@@ -28,23 +28,21 @@ class EventInsightsContainerViewController: ContainerViewController {
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        teamStatsViewController = EventTeamStatsTableViewController(event: event, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        teamStatsViewController = EventTeamStatsTableViewController(event: event, dependencies: dependencies)
 
         var eventStatsViewController: EventInsightsViewController?
         // Only show event insights if year is 2016 or onward
         var titles = ["Team Stats"]
         if event.year >= 2016 {
             titles.append("Event Insights")
-            eventStatsViewController = EventInsightsViewController(event: event, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+            eventStatsViewController = EventInsightsViewController(event: event, dependencies: dependencies)
         }
 
         super.init(viewControllers: [teamStatsViewController, eventStatsViewController].compactMap({ $0 }),
                    navigationTitle: "Stats",
                    navigationSubtitle: "@ \(event.friendlyNameWithYear)",
                    segmentedControlTitles: titles,
-                   persistentContainer: persistentContainer,
-                   tbaKit: tbaKit,
-                   userDefaults: userDefaults)
+                   dependencies: dependencies)
 
         teamStatsViewController.delegate = self
     }
@@ -58,13 +56,13 @@ class EventInsightsContainerViewController: ContainerViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        CLSLogv("Event Stats: %@", getVaList([event.key]))
+        errorRecorder.log("Event Stats: %@", [event.key])
     }
 
     // MARK: - Private Methods
 
     private func showFilter() {
-        let selectTableViewController = SelectTableViewController<EventInsightsContainerViewController>(current: teamStatsViewController.filter, options: EventTeamStatFilter.allCases, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let selectTableViewController = SelectTableViewController<EventInsightsContainerViewController>(current: teamStatsViewController.filter, options: EventTeamStatFilter.allCases, dependencies: dependencies)
         selectTableViewController.title = "Sort stats by"
         selectTableViewController.delegate = self
 
@@ -104,7 +102,7 @@ extension EventInsightsContainerViewController: EventTeamStatsSelectionDelegate 
     }
 
     func eventTeamStatSelected(_ eventTeamStat: EventTeamStat) {
-        let teamAtEventViewController = TeamAtEventViewController(team: eventTeamStat.team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(team: eventTeamStat.team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
@@ -23,7 +23,7 @@ class EventsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.myTBA = myTBA
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
@@ -32,14 +32,12 @@ class EventsContainerViewController: ContainerViewController {
         self.urlOpener = urlOpener
 
         year = statusService.currentSeason
-        eventsViewController = WeekEventsViewController(year: year, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        eventsViewController = WeekEventsViewController(year: year, dependencies: dependencies)
 
         super.init(viewControllers: [eventsViewController],
                    navigationTitle: EventsContainerViewController.eventsTitle(eventsViewController.weekEvent),
                    navigationSubtitle: ContainerViewController.yearSubtitle(year),
-                   persistentContainer: persistentContainer,
-                   tbaKit: tbaKit,
-                   userDefaults: userDefaults)
+                   dependencies: dependencies)
 
         // TODO: We should be able to move this somewhere else and DRY this code
         title = RootType.events.title
@@ -68,7 +66,7 @@ class EventsContainerViewController: ContainerViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        CLSLogv("Events: %ld", getVaList([year]))
+        errorRecorder.log("Events: %ld", [year])
     }
 
     // MARK: - Private Methods
@@ -91,7 +89,7 @@ class EventsContainerViewController: ContainerViewController {
 extension EventsContainerViewController: NavigationTitleDelegate {
 
     func navigationTitleTapped() {
-        let yearSelectViewController = YearSelectViewController(year: year, years: Array(1992...statusService.maxSeason).reversed(), week: eventsViewController.weekEvent, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let yearSelectViewController = YearSelectViewController(year: year, years: Array(1992...statusService.maxSeason).reversed(), week: eventsViewController.weekEvent, dependencies: dependencies)
         yearSelectViewController.delegate = self
 
         let nav = UINavigationController(rootViewController: yearSelectViewController)

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -1,5 +1,4 @@
 import CoreData
-import Crashlytics
 import Foundation
 import TBAData
 import TBAKit
@@ -31,11 +30,11 @@ class WeekEventsViewController: EventsViewController {
     }
     var weeks: [Event] = []
 
-    init(year: Int, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(year: Int, dependencies: Dependencies) {
         self.year = year
-        self.weekEvent = WeekEventsViewController.weekEvent(for: year, in: persistentContainer.viewContext)
+        self.weekEvent = WeekEventsViewController.weekEvent(for: year, in: dependencies.persistentContainer.viewContext)
 
-        super.init(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(dependencies: dependencies)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -77,7 +76,7 @@ class WeekEventsViewController: EventsViewController {
                 Event.insert(events, year: year, in: context)
             }, saved: {
                 self.markTBARefreshSuccessful(self.tbaKit, operation: operation)
-            }, errorRecorder: Crashlytics.sharedInstance())
+            }, errorRecorder: errorRecorder)
 
             // Only setup weeks if we don't have a currently selected week
             if self.weekEvent == nil {

--- a/the-blue-alliance-ios/View Controllers/Match/MatchQueryOptionsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchQueryOptionsViewController.swift
@@ -74,11 +74,11 @@ class MatchQueryOptionsViewController: TBATableViewController {
 
     weak var delegate: MatchQueryOptionsDelegate?
 
-    init(query: MatchQueryOptions, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(query: MatchQueryOptions, myTBA: MyTBA, dependencies: Dependencies) {
         self.query = query
         self.myTBA = myTBA
 
-        super.init(style: .plain, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(style: .plain, dependencies: dependencies)
 
         title = "Match Sort/Filter"
 

--- a/the-blue-alliance-ios/View Controllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Match/MatchViewController.swift
@@ -26,13 +26,13 @@ class MatchViewController: MyTBAContainerViewController {
 
     // MARK: Init
 
-    init(match: Match, team: Team? = nil, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(match: Match, team: Team? = nil, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, dependencies: Dependencies) {
         self.match = match
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
         self.urlOpener = urlOpener
-        infoViewController = MatchInfoViewController(match: match, team: team, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        infoViewController = MatchInfoViewController(match: match, team: team, dependencies: dependencies)
 
         // Only show match breakdown if year is 2015 or onward
         var titles: [String]  = ["Info"]
@@ -40,7 +40,7 @@ class MatchViewController: MyTBAContainerViewController {
             if match.event.year < 2015 {
                 return nil
             }
-            return MatchBreakdownViewController(match: match, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+            return MatchBreakdownViewController(match: match, dependencies: dependencies)
         }()
         if let _ = breakdownViewController {
             titles.append("Breakdown")
@@ -52,9 +52,7 @@ class MatchViewController: MyTBAContainerViewController {
             navigationSubtitle: "@ \(match.event.friendlyNameWithYear)",
             segmentedControlTitles: titles,
             myTBA: myTBA,
-            persistentContainer: persistentContainer,
-            tbaKit: tbaKit,
-            userDefaults: userDefaults
+            dependencies: dependencies
         )
 
         infoViewController.matchSummaryDelegate = self
@@ -78,7 +76,7 @@ class MatchViewController: MyTBAContainerViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        CLSLogv("Match: %@", getVaList([match.key]))
+        errorRecorder.log("Match: %@", [match.key])
     }
 
 }
@@ -89,7 +87,7 @@ extension MatchViewController: MatchSummaryViewDelegate {
         // get team key that matches the target teamNumber
         guard let team = match.teams.first(where: { Int($0.teamNumber) == teamNumber }) else { return }
 
-        let teamAtEventVC = TeamAtEventViewController(team: team, event: match.event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventVC = TeamAtEventViewController(team: team, event: match.event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         navigationController?.pushViewController(teamAtEventVC, animated: true)
     }
     

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAPreferenceViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAPreferenceViewController.swift
@@ -1,7 +1,7 @@
 import CoreData
-import Crashlytics
 import MyTBAKit
 import TBAData
+import TBAUtils
 import UIKit
 
 // Two sections are a single no-title section for "Favorite" cell,
@@ -32,6 +32,7 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
         }
     }
 
+    private let errorRecorder: ErrorRecorder
     let myTBA: MyTBA
     let persistentContainer: NSPersistentContainer
 
@@ -60,7 +61,8 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
                                                           action: #selector(save))
     internal var saveActivityIndicatorBarButtonItem = UIBarButtonItem.activityIndicatorBarButtonItem()
 
-    init(subscribableModel: MyTBASubscribable, myTBA: MyTBA, persistentContainer: NSPersistentContainer) {
+    init(errorRecorder: ErrorRecorder, subscribableModel: MyTBASubscribable, myTBA: MyTBA, persistentContainer: NSPersistentContainer) {
+        self.errorRecorder = errorRecorder
         self.subscribableModel = subscribableModel
         self.myTBA = myTBA
         self.persistentContainer = persistentContainer
@@ -155,7 +157,7 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
                         }
                     }
                 }
-            }, errorRecorder: Crashlytics.sharedInstance())
+            }, errorRecorder: self.errorRecorder)
         }
 
         let dismissOperation = BlockOperation(block: { [weak self] in

--- a/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/MyTBA/MyTBAViewController.swift
@@ -1,6 +1,4 @@
 import CoreData
-import Crashlytics
-import FirebaseAnalytics
 import FirebaseAuth
 import GoogleSignIn
 import MyTBAKit
@@ -42,21 +40,19 @@ class MyTBAViewController: ContainerViewController {
         return myTBA.isAuthenticated
     }
 
-    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.myTBA = myTBA
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        favoritesViewController = MyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        subscriptionsViewController = MyTBATableViewController<Subscription, MyTBASubscription>(myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        favoritesViewController = MyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, dependencies: dependencies)
+        subscriptionsViewController = MyTBATableViewController<Subscription, MyTBASubscription>(myTBA: myTBA, dependencies: dependencies)
 
         super.init(viewControllers: [favoritesViewController, subscriptionsViewController],
                    segmentedControlTitles: ["Favorites", "Subscriptions"],
-                   persistentContainer: persistentContainer,
-                   tbaKit: tbaKit,
-                   userDefaults: userDefaults)
+                   dependencies: dependencies)
 
         title = RootType.myTBA.title
         tabBarItem.image = RootType.myTBA.icon
@@ -119,7 +115,7 @@ class MyTBAViewController: ContainerViewController {
             self?.isLoggingOut = false
 
             if let error = error as? MyTBAError, error.code != 404 {
-                Crashlytics.sharedInstance().recordError(error)
+                self?.errorRecorder.recordError(error)
                 self?.showErrorAlert(with: "Unable to sign out of myTBA - \(error.localizedDescription)")
             } else {
                 // Run on main thread, since we delete our Core Data objects on the main thread.
@@ -152,7 +148,7 @@ class MyTBAViewController: ContainerViewController {
         persistentContainer.viewContext.deleteAllObjectsForEntity(entity: Subscription.entity())
 
         // Clear notifications
-        persistentContainer.viewContext.performSaveOrRollback(errorRecorder: Crashlytics.sharedInstance())
+        persistentContainer.viewContext.performSaveOrRollback(errorRecorder: errorRecorder)
     }
 
     // MARK: - Interface Methods
@@ -171,7 +167,7 @@ class MyTBAViewController: ContainerViewController {
 extension MyTBAViewController: MyTBATableViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
-        let viewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let viewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: viewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)
@@ -181,7 +177,7 @@ extension MyTBAViewController: MyTBATableViewControllerDelegate {
     }
 
     func teamSelected(_ team: Team) {
-        let viewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let viewController = TeamViewController(team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: viewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)
@@ -191,7 +187,7 @@ extension MyTBAViewController: MyTBATableViewControllerDelegate {
     }
 
     func matchSelected(_ match: Match) {
-        let viewController = MatchViewController(match: match, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let viewController = MatchViewController(match: match, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: viewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)

--- a/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PadRootViewController.swift
@@ -16,9 +16,7 @@ class PadRootViewController: UISplitViewController, RootController {
     let searchService: SearchService
     let urlOpener: URLOpener
     let statusService: StatusService
-    let persistentContainer: NSPersistentContainer
-    let tbaKit: TBAKit
-    let userDefaults: UserDefaults
+    let dependencies: Dependencies
 
     lazy fileprivate var masterViewController: PadMasterViewController = {
         return PadMasterViewController(fcmTokenProvider: fcmTokenProvider,
@@ -29,9 +27,7 @@ class PadRootViewController: UISplitViewController, RootController {
                                        searchService: searchService,
                                        statusService: statusService,
                                        urlOpener: urlOpener,
-                                       persistentContainer: persistentContainer,
-                                       tbaKit: tbaKit,
-                                       userDefaults: userDefaults)
+                                       dependencies: dependencies)
     }()
 
     lazy var emptyNavigationController: UINavigationController = {
@@ -45,7 +41,7 @@ class PadRootViewController: UISplitViewController, RootController {
         return navigationController
     }()
 
-    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.fcmTokenProvider = fcmTokenProvider
         self.myTBA = myTBA
         self.pasteboard = pasteboard
@@ -54,9 +50,7 @@ class PadRootViewController: UISplitViewController, RootController {
         self.searchService = searchService
         self.statusService = statusService
         self.urlOpener = urlOpener
-        self.persistentContainer = persistentContainer
-        self.tbaKit = tbaKit
-        self.userDefaults = userDefaults
+        self.dependencies = dependencies
 
         super.init(nibName: nil, bundle: nil)
 
@@ -99,7 +93,7 @@ private class PadMasterViewController: ContainerViewController, RootController {
 
     var searchController: UISearchController!
 
-    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard?, photoLibrary: PHPhotoLibrary?, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard?, photoLibrary: PHPhotoLibrary?, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.fcmTokenProvider = fcmTokenProvider
         self.myTBA = myTBA
         self.pasteboard = pasteboard
@@ -109,9 +103,9 @@ private class PadMasterViewController: ContainerViewController, RootController {
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        let rootTableViewController = PadRootTableViewController(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let rootTableViewController = PadRootTableViewController(dependencies: dependencies)
 
-        super.init(viewControllers: [rootTableViewController], persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(viewControllers: [rootTableViewController], dependencies: dependencies)
 
         rootTableViewController.delegate = self
     }
@@ -162,9 +156,7 @@ private class PadMasterViewController: ContainerViewController, RootController {
                                                       statusService: statusService,
                                                       urlOpener: urlOpener,
                                                       myTBA: myTBA,
-                                                      persistentContainer: persistentContainer,
-                                                      tbaKit: tbaKit,
-                                                      userDefaults: userDefaults)
+                                                      dependencies: dependencies)
         _push(eventViewController)
         return true
     }
@@ -176,9 +168,7 @@ private class PadMasterViewController: ContainerViewController, RootController {
                                                     statusService: statusService,
                                                     urlOpener: urlOpener,
                                                     myTBA: myTBA,
-                                                    persistentContainer: persistentContainer,
-                                                    tbaKit: tbaKit,
-                                                    userDefaults: userDefaults)
+                                                    dependencies: dependencies)
         _push(teamViewController)
         return true
     }

--- a/the-blue-alliance-ios/View Controllers/Root/PhoneRootViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/PhoneRootViewController.swift
@@ -16,11 +16,9 @@ class PhoneRootViewController: UITabBarController, RootController {
     let searchService: SearchService
     let statusService: StatusService
     let urlOpener: URLOpener
-    let persistentContainer: NSPersistentContainer
-    let tbaKit: TBAKit
-    let userDefaults: UserDefaults
+    let dependencies: Dependencies
 
-    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.fcmTokenProvider = fcmTokenProvider
         self.myTBA = myTBA
         self.pasteboard = pasteboard
@@ -29,9 +27,7 @@ class PhoneRootViewController: UITabBarController, RootController {
         self.searchService = searchService
         self.statusService = statusService
         self.urlOpener = urlOpener
-        self.persistentContainer = persistentContainer
-        self.tbaKit = tbaKit
-        self.userDefaults = userDefaults
+        self.dependencies = dependencies
 
         super.init(nibName: nil, bundle: nil)
 

--- a/the-blue-alliance-ios/View Controllers/Root/RootController.swift
+++ b/the-blue-alliance-ios/View Controllers/Root/RootController.swift
@@ -62,9 +62,7 @@ protocol RootController {
     var searchService: SearchService { get }
     var urlOpener: URLOpener { get }
     var statusService: StatusService { get }
-    var persistentContainer: NSPersistentContainer { get }
-    var tbaKit: TBAKit { get }
-    var userDefaults: UserDefaults { get }
+    var dependencies: Dependencies { get }
 
     // MARK: - Handoff Methods
     func continueSearch(_ searchText: String) -> Bool
@@ -82,9 +80,7 @@ extension RootController {
                                              searchService: searchService,
                                              statusService: statusService,
                                              urlOpener: urlOpener,
-                                             persistentContainer: persistentContainer,
-                                             tbaKit: tbaKit,
-                                             userDefaults: userDefaults)
+                                             dependencies: dependencies)
     }
 
     var teamsViewController: TeamsContainerViewController {
@@ -94,18 +90,14 @@ extension RootController {
                                             searchService: searchService,
                                             statusService: statusService,
                                             urlOpener: urlOpener,
-                                            persistentContainer: persistentContainer,
-                                            tbaKit: tbaKit,
-                                            userDefaults: userDefaults)
+                                            dependencies: dependencies)
     }
 
     var districtsViewController: DistrictsContainerViewController {
         return DistrictsContainerViewController(myTBA: myTBA,
                                                 statusService: statusService,
                                                 urlOpener: urlOpener,
-                                                persistentContainer: persistentContainer,
-                                                tbaKit: tbaKit,
-                                                userDefaults: userDefaults)
+                                                dependencies: dependencies)
     }
 
     var settingsViewController: SettingsViewController {
@@ -114,18 +106,16 @@ extension RootController {
                                       pushService: pushService,
                                       searchService: searchService,
                                       urlOpener: urlOpener,
-                                      persistentContainer: persistentContainer,
-                                      tbaKit: tbaKit,
-                                      userDefaults: userDefaults)
+                                      dependencies: dependencies)
     }
 
     var myTBAViewController: MyTBAViewController {
         return MyTBAViewController(myTBA: myTBA,
+                                   pasteboard: pasteboard,
+                                   photoLibrary: photoLibrary,
                                    statusService: statusService,
                                    urlOpener: urlOpener,
-                                   persistentContainer: persistentContainer,
-                                   tbaKit: tbaKit,
-                                   userDefaults: userDefaults)
+                                   dependencies: dependencies)
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Search/SearchViewController.swift
@@ -71,10 +71,10 @@ class SearchViewController: TBATableViewController {
     }()
     private var tableViewDataSource: TableViewDataSource<SearchSection, CSSearchableItem>!
 
-    init(searchService: SearchService, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(searchService: SearchService, dependencies: Dependencies) {
         self.searchService = searchService
 
-        super.init(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(dependencies: dependencies)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/the-blue-alliance-ios/View Controllers/Settings/Notifications/NotificationsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Settings/Notifications/NotificationsViewController.swift
@@ -54,13 +54,13 @@ class NotificationsViewController: TBATableViewController {
     private var myTBAPingResponse: MyTBABaseResponse?
     private var myTBAPingError: Error?
 
-    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pushService: PushService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pushService: PushService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.fcmTokenProvider = fcmTokenProvider
         self.myTBA = myTBA
         self.pushService = pushService
         self.urlOpener = urlOpener
 
-        super.init(style: .grouped, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(style: .grouped, dependencies: dependencies)
 
         title = "Troubleshoot Notifications"
         hidesBottomBarWhenPushed = true

--- a/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Settings/SettingsViewController.swift
@@ -1,5 +1,4 @@
 import CoreData
-import Crashlytics
 import MyTBAKit
 import Search
 import TBAKit
@@ -33,14 +32,14 @@ class SettingsViewController: TBATableViewController {
 
     // MARK: - Init
 
-    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pushService: PushService, searchService: SearchService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pushService: PushService, searchService: SearchService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.fcmTokenProvider = fcmTokenProvider
         self.myTBA = myTBA
         self.pushService = pushService
         self.searchService = searchService
         self.urlOpener = urlOpener
 
-        super.init(style: .grouped, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(style: .grouped, dependencies: dependencies)
 
         title = RootType.settings.title
         tabBarItem.image = RootType.settings.icon
@@ -337,7 +336,7 @@ class SettingsViewController: TBATableViewController {
         let alertController = UIAlertController(title: "Delete Search Index", message: "Are you sure you want to delete the local search index? Search may not work properly.", preferredStyle: .alert)
 
         let deleteCacheAction = UIAlertAction(title: "Delete", style: .destructive) { [unowned self] (deleteAction) in
-            self.searchService.deleteSearchIndex(errorRecorder: Crashlytics.sharedInstance())
+            self.searchService.deleteSearchIndex(errorRecorder: errorRecorder)
         }
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
 
@@ -348,7 +347,7 @@ class SettingsViewController: TBATableViewController {
     }
 
     private func pushTroubleshootNotifications() {
-        let notificationsViewController = NotificationsViewController(fcmTokenProvider: fcmTokenProvider, myTBA: myTBA, pushService: pushService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let notificationsViewController = NotificationsViewController(fcmTokenProvider: fcmTokenProvider, myTBA: myTBA, pushService: pushService, urlOpener: urlOpener, dependencies: dependencies)
         navigationController?.pushViewController(notificationsViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -24,7 +24,7 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
 
     // MARK: - Init
 
-    init(team: Team, event: Event, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(team: Team, event: Event, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.team = team
         self.event = event
         self.myTBA = myTBA
@@ -33,19 +33,17 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        let summaryViewController = TeamSummaryViewController(team: team, event: event, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        matchesViewController = MatchesViewController(event: event, team: team, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let mediaViewController = TeamMediaCollectionViewController(team: team, year: event.year, pasteboard: pasteboard, photoLibrary: photoLibrary, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let statsViewController = TeamStatsViewController(team: team, event: event, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
-        let awardsViewController = EventAwardsViewController(event: event, team: team, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let summaryViewController = TeamSummaryViewController(team: team, event: event, dependencies: dependencies)
+        matchesViewController = MatchesViewController(event: event, team: team, myTBA: myTBA, dependencies: dependencies)
+        let mediaViewController = TeamMediaCollectionViewController(team: team, year: event.year, pasteboard: pasteboard, photoLibrary: photoLibrary, urlOpener: urlOpener, dependencies: dependencies)
+        let statsViewController = TeamStatsViewController(team: team, event: event, dependencies: dependencies)
+        let awardsViewController = EventAwardsViewController(event: event, team: team, dependencies: dependencies)
 
         super.init(viewControllers: [summaryViewController, matchesViewController, mediaViewController, statsViewController, awardsViewController],
                    navigationTitle: team.teamNumberNickname,
                    navigationSubtitle: "@ \(event.friendlyNameWithYear)",
                    segmentedControlTitles: ["Summary", "Matches", "Media", "Stats", "Awards"],
-                   persistentContainer: persistentContainer,
-                   tbaKit: tbaKit,
-                   userDefaults: userDefaults)
+                   dependencies: dependencies)
 
         rightBarButtonItems = [
             UIBarButtonItem(image: UIImage.eventIcon, style: .plain, target: self, action: #selector(pushEvent))
@@ -66,7 +64,7 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        CLSLogv("Team@Event: Event %@ | Team %@", getVaList([event.key, team.key]))
+        errorRecorder.log("Team@Event: Event %@ | Team %@", [event.key, team.key])
 
         contextObserver.observeObject(object: event, state: .updated) { [weak self] (event, _) in
             guard let self = self else { return }
@@ -77,7 +75,7 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
     // MARK: - Private Methods
 
     @objc private func pushEvent() {
-        let eventViewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let eventViewController = EventViewController(event: event, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         navigationController?.pushViewController(eventViewController, animated: true)
     }
 
@@ -90,7 +88,7 @@ extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewC
     }
 
     func matchSelected(_ match: Match) {
-        let matchViewController = MatchViewController(match: match, team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let matchViewController = MatchViewController(match: match, team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 
@@ -115,7 +113,7 @@ extension TeamAtEventViewController: EventAwardsViewControllerDelegate {
         if self.team == team {
             return
         }
-        let teamAtEventViewController = TeamAtEventViewController(team: team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        let teamAtEventViewController = TeamAtEventViewController(team: team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsContainerViewController.swift
@@ -21,7 +21,7 @@ class TeamsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.myTBA = myTBA
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
@@ -29,12 +29,9 @@ class TeamsContainerViewController: ContainerViewController {
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        teamsViewController = TeamsViewController(refreshProvider: searchService, showSearch: false, persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        teamsViewController = TeamsViewController(refreshProvider: searchService, showSearch: false, dependencies: dependencies)
 
-        super.init(viewControllers: [teamsViewController],
-                   persistentContainer: persistentContainer,
-                   tbaKit: tbaKit,
-                   userDefaults: userDefaults)
+        super.init(viewControllers: [teamsViewController], dependencies: dependencies)
 
         title = RootType.teams.title
         tabBarItem.image = RootType.teams.icon

--- a/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/TeamsViewController.swift
@@ -1,5 +1,4 @@
 import CoreData
-import Crashlytics
 import Foundation
 import TBAData
 import TBAKit
@@ -34,10 +33,10 @@ class TeamsViewController: TBASearchableTableViewController, Refreshable, Statef
     private var tableViewDataSource: TableViewDataSource<String, Team>!
     private var fetchedResultsController: TableViewDataSourceFetchedResultsController<Team>!
 
-    init(refreshProvider: TeamsRefreshProvider? = nil, showSearch: Bool = true, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(refreshProvider: TeamsRefreshProvider? = nil, showSearch: Bool = true, dependencies: Dependencies) {
         self.showSearch = showSearch
 
-        super.init(persistentContainer: persistentContainer, tbaKit: tbaKit, userDefaults: userDefaults)
+        super.init(dependencies: dependencies)
 
         self.refreshProvider = refreshProvider ?? self
     }
@@ -183,7 +182,7 @@ extension TBASearchableTableViewController: TeamsRefreshProvider {
                 Team.insert(teams, in: context)
             }, saved: {
                 self.tbaKit.storeCacheHeaders(operation)
-            }, errorRecorder: Crashlytics.sharedInstance())
+            }, errorRecorder: errorRecorder)
         }
         return operation
     }


### PR DESCRIPTION
This got a little bit out of hand - the idea was to abstract the Crashlytics/Fabric reporting in to a protocol that can change based on the device, since building for macOS doesn't support any of the Firebase stuff. Of course, this meant injecting ANOTHER dependency in to all of our view controllers, which is incredibly painful. Instead, the base dependencies are now wrapped in a `Dependency` object that can get passed through the app.

## TODO
- [x] Tests still need to be updated for new inits