### PR TITLE
Fix updating Team@Event view Event Info/Status sections crashing when Event Info section does not exist yet

### DIFF
--- a/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -212,14 +212,15 @@ class TeamSummaryViewController: TBATableViewController {
             return nil
         }()
 
-        let eventInfoItems = snapshot.itemIdentifiers(inSection: .eventInfo)
+        let hasEventInfoSection = snapshot.indexOfSection(.eventInfo) != nil
+        let eventInfoItems = hasEventInfoSection ? snapshot.itemIdentifiers(inSection: .eventInfo) : []
         let existingTeamStatusSummaryItems = eventInfoItems.filter({ switch $0 { case .status(_): return true; default: return false } })
         snapshot.deleteItems(existingTeamStatusSummaryItems)
 
         if let teamStatusSummaryItem = teamStatusSummaryItem {
             snapshot.insertSection(.eventInfo, atIndex: TeamSummarySection.eventInfo.rawValue)
             snapshot.insertItem(teamStatusSummaryItem, inSection: .eventInfo, atIndex: 0)
-        } else if snapshot.itemIdentifiers(inSection: .eventInfo).isEmpty {
+        } else if hasEventInfoSection, eventInfoItems.isEmpty {
             snapshot.deleteSections([.eventInfo])
         }
 


### PR DESCRIPTION
Another very cool undocumented API change in iOS 14 - the [`NSDiffableDataSourceSnapshot.itemIdentifiersInSection` method](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot/3375775-itemidentifiers) no longer returns an empty array if the section doesn't exist in the snapshot, it throws an error. This PR adds a check in the Team@Event view before attempting to re-use/update the existing Event Info section Status row.

Fixes #892