### PR TITLE
Remove force unwraps around eventType to handle unknown events

### DIFF
--- a/Frameworks/TBAData/Tests/Event/EventTests.swift
+++ b/Frameworks/TBAData/Tests/Event/EventTests.swift
@@ -6,6 +6,10 @@ import XCTest
 
 class EventTestCase: TBADataTestCase {
 
+    func test_EventType_caseIterable() {
+        XCTAssertFalse(EventType.allCases.isEmpty)
+    }
+
     func test_address() {
         let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
         XCTAssertNil(event.address)
@@ -324,7 +328,6 @@ class EventTestCase: TBADataTestCase {
 
     func test_champsYearPredicate() {
         let predicate = Event.champsYearPredicate(key: "2020cmpmi", year: 2020)
-        print(predicate.predicateFormat)
         XCTAssertEqual(predicate.predicateFormat, "yearRaw == 2020 AND ((eventTypeRaw == 4 OR eventTypeRaw == 3) AND (keyRaw == \"2020cmpmi\" OR parentEventRaw.keyRaw == \"2020cmpmi\"))")
 
         let parentEvent = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
@@ -476,13 +479,16 @@ class EventTestCase: TBADataTestCase {
 
     func test_yearPredicate() {
         let p = Event.yearPredicate(year: 2020)
-        print(p.predicateFormat)
         XCTAssertEqual(p.predicateFormat, "yearRaw == 2020")
     }
 
+    func test_unknownYearPredicate() {
+        let p = Event.unknownYearPredicate(year: 2021)
+        XCTAssertEqual(p.predicateFormat, "yearRaw == 2021 AND (NOT eventTypeRaw IN {0, 1, 2, 3, 4, 5, 6, 99, 100, -1})")
+    }
+    
     func test_nonePredicate() {
         let p = Event.nonePredicate()
-        print(p.predicateFormat)
         XCTAssertEqual(p.predicateFormat, "yearRaw == -1")
     }
 
@@ -1254,8 +1260,7 @@ class EventTestCase: TBADataTestCase {
 
     func test_weekString_noEventType() {
         let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
-        // No eventType
-        XCTAssertNil(event.weekString)
+        XCTAssertEqual(event.weekString, "Unknown")
     }
 
     func test_weekString_championship() {

--- a/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Districts/District/DistrictViewController.swift
@@ -72,11 +72,7 @@ extension DistrictViewController: EventsViewControllerDelegate {
     }
 
     func title(for event: Event) -> String? {
-        if let weekString = event.weekString {
-            return "\(weekString) Events"
-        } else {
-            return "--- Events"
-        }
+        return "\(event.weekString) Events"
     }
 
 }

--- a/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsContainerViewController.swift
@@ -72,8 +72,8 @@ class EventsContainerViewController: ContainerViewController {
     // MARK: - Private Methods
 
     private static func eventsTitle(_ event: Event?) -> String {
-        if let event = event, let weekString = event.weekString {
-            return "\(weekString) Events"
+        if let event = event {
+            return "\(event.weekString) Events"
         } else {
             return "---- Events"
         }

--- a/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
@@ -134,7 +134,7 @@ class EventsViewController: TBATableViewController, Refreshable, Stateful, Event
         let district = event.district
         let districtName = district?.name
 
-        let eventType = event.eventType!
+        let eventType = event.eventType
         let eventTypeString = event.eventTypeString
 
         if event.isDistrictChampionshipEvent {
@@ -153,17 +153,13 @@ class EventsViewController: TBATableViewController, Refreshable, Stateful, Event
         } else if event.isFoC {
             return "Festival of Champions"
         } else if event.isOffseason {
-            if let weekString = event.weekString {
-                return "\(weekString) Events"
-            } else {
-                return "Offseason Events"
-            }
+            return "\(event.weekString) Events"
         } else if event.isPreseason {
             return "Preseason Events"
         } else if event.isRegional {
             return "Regional Events"
         }
-        return "Other Events"
+        return "Unknown Events"
     }
 
     // MARK: - EventsViewControllerDataSourceConfiguration

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -103,7 +103,9 @@ class WeekEventsViewController: EventsViewController {
 
     override var fetchRequestPredicate: NSPredicate {
         if let weekEvent = weekEvent {
-            let eventType = weekEvent.eventType!
+            guard let eventType = weekEvent.eventType else {
+                return Event.unknownYearPredicate(year: weekEvent.year)
+            }
 
             if let week = weekEvent.week {
                 // Event has a week - filter based on the week

--- a/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/YearSelectViewController.swift
@@ -147,10 +147,7 @@ extension EventWeekSelectViewController: SelectTableViewControllerDelegate {
     }
 
     func titleForOption(_ option: OptionType) -> String {
-        if let weekString = option.weekString {
-            return weekString
-        }
-        return "---"
+        return option.weekString
     }
 
 }


### PR DESCRIPTION
Right now, 2021 events have a new type (`remote`) and are crashing in the app. This code allows for more gracefully handling unknown events by grouping all events without an event type together in to an "Unknown" section, so they're still displayed and things don't crash

![Simulator Screen Shot - iPhone 12 mini - 2020-12-31 at 19 15 27](https://user-images.githubusercontent.com/516458/103431595-8ef1e480-4ba0-11eb-9732-f02e102f13a2.png)
![Simulator Screen Shot - iPhone 12 mini - 2020-12-31 at 19 38 24](https://user-images.githubusercontent.com/516458/103431598-91543e80-4ba0-11eb-9c31-69968f1325a1.png)
