### PR TITLE
Add support for remote events, bump status defaults for 2021

### DIFF
--- a/Frameworks/TBAData/Tests/Event/EventTests.swift
+++ b/Frameworks/TBAData/Tests/Event/EventTests.swift
@@ -1456,6 +1456,13 @@ class EventTestCase: TBADataTestCase {
         XCTAssertTrue(event.isRegional)
     }
 
+    func test_isRemote() {
+        let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
+        XCTAssertFalse(event.isRemote)
+        event.eventTypeRaw = NSNumber(value: EventType.remote.rawValue)
+        XCTAssertTrue(event.isRemote)
+    }
+
     func test_isUnlabeled() {
         let event = Event.init(entity: Event.entity(), insertInto: persistentContainer.viewContext)
         XCTAssertFalse(event.isUnlabeled)

--- a/the-blue-alliance-ios/StatusDefaults.plist
+++ b/the-blue-alliance-ios/StatusDefaults.plist
@@ -3,12 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>max_season</key>
-	<integer>2020</integer>
+	<real>2021</real>
 	<key>min_app_version</key>
 	<integer>-1</integer>
 	<key>latest_app_version</key>
 	<integer>-1</integer>
 	<key>current_season</key>
-	<integer>2020</integer>
+	<real>2021</real>
 </dict>
 </plist>

--- a/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/EventsViewController.swift
@@ -152,6 +152,8 @@ class EventsViewController: TBATableViewController, Refreshable, Stateful, Event
             return "\(districtName) District Events"
         } else if event.isFoC {
             return "Festival of Champions"
+        } else if event.isRemote {
+            return "Remote Events"
         } else if event.isOffseason {
             return "\(event.weekString) Events"
         } else if event.isPreseason {

--- a/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/View Controllers/Events/WeekEventsViewController.swift
@@ -107,7 +107,10 @@ class WeekEventsViewController: EventsViewController {
                 return Event.unknownYearPredicate(year: weekEvent.year)
             }
 
-            if let week = weekEvent.week {
+            if eventType == .remote {
+                // Special case - group all remote events together
+                return Event.remoteYearPredicate(year: weekEvent.year)
+            } else if let week = weekEvent.week {
                 // Event has a week - filter based on the week
                 return Event.weekYearPredicate(week: week, year: weekEvent.year)
             } else {


### PR DESCRIPTION
Support `remote` type

![Simulator Screen Shot - iPhone 12 mini - 2020-12-31 at 20 26 55](https://user-images.githubusercontent.com/516458/103431968-8f8d7980-4ba6-11eb-94df-0082ee46f718.png)
