### PR TITLE
Added Match Breakdown for the 2024 game, Crescendo

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -21,6 +21,7 @@
 		14F51704239AA70A00D9240F /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F51703239AA70A00D9240F /* SearchService.swift */; };
 		304ED0411EF1D2D300E31791 /* RankingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 304ED03F1EF1D2D300E31791 /* RankingTableViewCell.xib */; };
 		304ED0421EF1D2D300E31791 /* RankingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304ED0401EF1D2D300E31791 /* RankingTableViewCell.swift */; };
+		371D9C9D2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371D9C9C2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift */; };
 		92009B5723DD49A60058E567 /* HandoffServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92009B5623DD49A60058E567 /* HandoffServiceTests.swift */; };
 		920240072AEB6AAD0003D118 /* PureLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 920240062AEB6AAD0003D118 /* PureLayout */; };
 		920240092AEB6AC30003D118 /* TBAOperation in Frameworks */ = {isa = PBXBuildFile; productRef = 920240082AEB6AC30003D118 /* TBAOperation */; };
@@ -279,6 +280,7 @@
 		14F51703239AA70A00D9240F /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		304ED03F1EF1D2D300E31791 /* RankingTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RankingTableViewCell.xib; sourceTree = "<group>"; };
 		304ED0401EF1D2D300E31791 /* RankingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RankingTableViewCell.swift; sourceTree = "<group>"; };
+		371D9C9C2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2024.swift; sourceTree = "<group>"; };
 		92009B5623DD49A60058E567 /* HandoffServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandoffServiceTests.swift; sourceTree = "<group>"; };
 		921D0B52222AF36A0056578A /* UIImage+TBATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+TBATests.swift"; sourceTree = "<group>"; };
 		921D0B54222AF94C0056578A /* UIBarButtonItem+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+TBA.swift"; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 				9288BD1523D00BE500157F74 /* MatchBreakdownConfigurator2019.swift */,
 				D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */,
 				9263922727F0FD71003C302A /* MatchBreakdownConfigurator2022.swift */,
+				371D9C9C2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift */,
 			);
 			path = Breakdown;
 			sourceTree = "<group>";
@@ -1393,8 +1396,8 @@
 				92942D8E1E2154DA008E79CA /* Sources */,
 				92942D8F1E2154DA008E79CA /* Frameworks */,
 				92942D901E2154DA008E79CA /* Resources */,
-				924E826C208FE7D20053247C /* Run FirebaseCrashlytics */,
 				927309A323DC0F26006145E0 /* Embed App Extensions */,
+				924E826C208FE7D20053247C /* Run FirebaseCrashlytics */,
 			);
 			buildRules = (
 			);
@@ -1564,7 +1567,7 @@
 			);
 			inputPaths = (
 				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF",
 				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
 				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
 				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
@@ -1709,6 +1712,7 @@
 				929FCD981EC7F51B00A38E46 /* DistrictsContainerViewController.swift in Sources */,
 				9263922827F0FD71003C302A /* MatchBreakdownConfigurator2022.swift in Sources */,
 				14796944215EAF7A0075AF4E /* TeamCellViewModel.swift in Sources */,
+				371D9C9D2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift in Sources */,
 				92B07371235CB47800967FC3 /* TableViewDataSourceFetchedResultsController.swift in Sources */,
 				92FA4D2D228606BB00030BA3 /* TeamHeaderView.swift in Sources */,
 				92CAF550240775180078CA0A /* PhoneRootViewController.swift in Sources */,

--- a/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/TBA Spotlight Index Extension.xcscheme
+++ b/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/TBA Spotlight Index Extension.xcscheme
@@ -57,12 +57,8 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
-      <RemoteRunnable
-         runnableDebuggingMode = "1"
-         BundleIdentifier = "com.apple.PreviewShell"
-         RemotePath = "/Library/Developer/CoreSimulator/Volumes/iOS_21A342/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.0.simruntime/Contents/Resources/RuntimeRoot/Applications/PreviewShell.app">
-      </RemoteRunnable>
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "92942D911E2154DA008E79CA"
@@ -70,7 +66,7 @@
             BlueprintName = "The Blue Alliance"
             ReferencedContainer = "container:the-blue-alliance-ios.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/TBA Spotlight Index Extension.xcscheme
+++ b/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/TBA Spotlight Index Extension.xcscheme
@@ -57,8 +57,12 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "1"
+         BundleIdentifier = "com.apple.PreviewShell"
+         RemotePath = "/Library/Developer/CoreSimulator/Volumes/iOS_21A342/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.0.simruntime/Contents/Resources/RuntimeRoot/Applications/PreviewShell.app">
+      </RemoteRunnable>
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "92942D911E2154DA008E79CA"
@@ -66,7 +70,7 @@
             BlueprintName = "The Blue Alliance"
             ReferencedContainer = "container:the-blue-alliance-ios.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -62,7 +62,9 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Observa
             breakdownConfigurator = MatchBreakdownConfigurator2020.self
         } else if match.event.year == 2022 {
             breakdownConfigurator = MatchBreakdownConfigurator2022.self
-        } else {
+        } else if match.event.year == 2024 {
+            breakdownConfigurator = MatchBreakdownConfigurator2024.self
+        }else {
             breakdownConfigurator = nil
         }
 

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2024.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2024.swift
@@ -1,0 +1,356 @@
+import Foundation
+import UIKit
+
+private class BreakdownStyle2024 {
+    public static let upperImage = UIImage(systemName: "chevron.up", withConfiguration: UIImage.SymbolConfiguration(weight: .bold))
+    public static let lowerImage = UIImage(systemName: "chevron.down", withConfiguration: UIImage.SymbolConfiguration(weight: .bold))
+    public static let standardSpeaker = UIImage(systemName: "speaker.wave.1.fill")
+    public static let amplifiedSpeaker = UIImage(systemName: "speaker.wave.3.fill")
+    
+}
+
+struct MatchBreakdownConfigurator2024: MatchBreakdownConfigurator {
+
+    
+    static func configureDataSource(_ snapshot: inout NSDiffableDataSourceSnapshot<String?, BreakdownRow>, _ breakdown: [String: Any]?, _ red: [String: Any]?, _ blue: [String: Any]?) {
+
+        var rows: [BreakdownRow?] = []
+
+        // Auto
+        rows.append(leave(red: red, blue: blue))
+        rows.append(row(title: "Auto Amp Note Count", key: "autoAmpNoteCount", red: red, blue: blue))
+        rows.append(row(title: "Auto Speaker Note Count", key: "autoSpeakerNoteCount", red: red, blue: blue))
+        //rows.append(notesRow(title: "Auto Note Count", period: "auto", red: red, blue: blue))
+        rows.append(row(title: "Auto Note Points", key: "autoTotalNotePoints", red: red, blue: blue, type: .subtotal))
+        rows.append(row(title: "Total Auto", key: "autoPoints", red: red, blue: blue, type: .total))
+
+        // Teleop
+        rows.append(row(title: "Teleop Amp Note Count", key: "teleopAmpNoteCount", red: red, blue: blue))
+        rows.append(speakerRow(title:"Teleop Speaker Note Count", red: red, blue: blue))
+        //rows.append(notesRow(title: "Teleop Note Count", period: "teleop", red: red, blue: blue))
+        
+        rows.append(row(title: "Teleop Note Points", key: "teleopTotalNotePoints", red: red, blue: blue, type: .subtotal))
+        for i in [1, 2, 3] {
+            rows.append(endgameRow(i: i, red: red, blue: blue))
+        }
+        
+        rows.append(row(title: "Harmony Points", key: "endGameHarmonyPoints", red: red, blue: blue, type: .subtotal))
+        rows.append(row(title: "Trap Points", key: "endGameNoteInTrapPoints", red: red, blue: blue, type: .subtotal))
+        rows.append(row(title: "Total Teleop", key: "teleopPoints", red: red, blue: blue, type: .total))
+        rows.append(boolImageRow(title: "Coopertition Criteria Met", key: "coopertitionBonusAchieved", red: red, blue: blue))
+        rows.append(totalNotesScoredRow(title: "Total Notes Scored", red: red, blue: blue))
+
+        rows.append(bonusRankingPointRow(title: "Melody Bonus", key: "melody", red: red, blue: blue))
+        rows.append(row(title: "Stage Points", key: "endGameTotalStagePoints", red: red, blue: blue))
+        rows.append(bonusRankingPointRow(title: "Ensemble Bonus", key: "ensemble", red: red, blue: blue))
+
+        // Match totals
+        rows.append(foulRow(title: "Fouls / Tech Fouls", red: red, blue: blue))
+        rows.append(row(title: "Adjustments", key: "adjustPoints", red: red, blue: blue))
+        rows.append(row(title: "Total Score", key: "totalPoints", red: red, blue: blue, type: .total))
+
+        // RP
+        rows.append(row(title: "Ranking Points", key: "rp", formatString: "+%@ RP", red: red, blue: blue))
+
+        // Clean up any empty rows
+        let validRows = rows.compactMap({ $0 })
+        if !validRows.isEmpty {
+            snapshot.appendSections([nil])
+            snapshot.appendItems(validRows)
+        }
+    }
+
+    private static func leave(red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        var redLeaveStrings: [String] = []
+        var blueLeaveStrings: [String] = []
+
+        for i in [1, 2, 3] {
+            guard let taxiValues = values(key: "autoLineRobot\(i)", red: red, blue: blue) else {
+                return nil
+            }
+            let (rv, bv) = taxiValues
+            guard let redTaxi = rv as? String, let blueTaxi = bv as? String else {
+                return nil
+            }
+            redLeaveStrings.append(redTaxi)
+            blueLeaveStrings.append(blueTaxi)
+        }
+
+        let mode = UIView.ContentMode.scaleAspectFit
+        let elements = [redLeaveStrings, blueLeaveStrings].map { (taxiStrings) -> [AnyHashable] in
+            return taxiStrings.map { (taxi) -> AnyHashable in
+                switch taxi {
+                case "No":
+                    return BreakdownStyle.imageView(image: BreakdownStyle.xImage, contentMode: mode, forceSquare: false)
+                case "Yes":
+                    return BreakdownStyle.imageView(image: BreakdownStyle.checkImage, contentMode: mode, forceSquare: false)
+                default:
+                    return "?"
+                }
+            }
+        }
+
+        let (redElements, blueElements) = (elements[0], elements[1])
+        guard let redBreakdownElements = redElements as? [BreakdownElement], let blueBreakdownElements = blueElements as? [BreakdownElement] else {
+            return nil
+        }
+
+        let redStackView = UIStackView(arrangedSubviews: redBreakdownElements.map { $0.toView() })
+        redStackView.distribution = .fillEqually
+        let blueStackView = UIStackView(arrangedSubviews: blueBreakdownElements.map { $0.toView() })
+        blueStackView.distribution = .fillEqually
+
+        // Add the point totals for the taxi
+        guard let leavePoints = values(key: "autoLeavePoints", red: red, blue: blue) else {
+            return nil
+        }
+
+        let (redLinePoints, blueLinePoints) = leavePoints
+        let redLeavePointsString = "(+\(redLinePoints ?? 0))"
+        let blueLeavePointsString = "(+\(blueLinePoints ?? 0))"
+
+        return BreakdownRow(title: "Auto Leave", red: [redStackView, redLeavePointsString], blue: [blueStackView, blueLeavePointsString], type: .subtotal)
+    }
+
+    private static func notesRow(title: String, period: String, red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        let heightKeys = ["Amp", "Speaker"]
+    
+        let images = [BreakdownStyle2024.lowerImage, BreakdownStyle2024.upperImage]
+
+        var redCells: [Int] = []
+        var blueCells: [Int] = []
+
+        for heightKey in heightKeys {
+            var redHeightValues: [Int] = []
+            var blueHeightValues: [Int] = []
+        
+            let key = "\(period)\(heightKey)NoteCount"
+            guard let cellValues = values(key: key, red: red, blue: blue) else {
+                return nil
+            }
+
+            let (rv, bv) = cellValues
+
+            guard let redCellValue = rv as? Int, let blueCellValue = bv as? Int else {
+                return nil
+            }
+            redHeightValues.append(redCellValue)
+            blueHeightValues.append(blueCellValue)
+        
+            redCells.append(redHeightValues.reduce(0, +))
+            blueCells.append(blueHeightValues.reduce(0, +))
+        }
+
+        let mode = UIView.ContentMode.scaleAspectFit
+        let redValues = zip((images).map {
+            return BreakdownStyle.imageView(image: $0, contentMode: mode)
+        }, redCells).flatMap { (imgV: UIImageView, v: Int) -> [AnyHashable?] in [imgV, String(v) ] }
+
+        let blueValues = zip((images).map {
+            return BreakdownStyle.imageView(image: $0, contentMode: mode)
+        }, blueCells).flatMap { (imgV: UIImageView, v: Int) -> [AnyHashable?] in [imgV, String(v) ] }
+
+        return BreakdownRow(title: title, red: redValues, blue: blueValues)
+    }
+
+           
+    private static func endgameRow(i: Int, red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        guard let endgameValues = values(key: "endGameRobot\(i)", red: red, blue: blue) else {
+            return nil
+        }
+        let (rw, bw) = endgameValues
+        guard var redEndgame = rw as? String, var blueEndgame = bw as? String else {
+            return nil
+        }
+        var micScoredRed: [Bool] = []
+        var micScoredBlue: [Bool] = []
+        enum MicLocations: String, CaseIterable {
+            case CenterStage, StageLeft, StageRight
+        }
+        
+        for micLocation in MicLocations.allCases{
+            guard let micValues = values(key: "mic\(micLocation)", red: red, blue: blue) else{
+                return nil
+            }
+            let (rm,bm) = micValues
+            guard let redMic = rm as? Bool, let blueMic = bm as? Bool else {
+                return nil
+            }
+            micScoredRed.insert(redMic, at: getArrayPosition(micPosition: micLocation.rawValue))
+            micScoredBlue.insert(blueMic, at: getArrayPosition(micPosition: micLocation.rawValue))
+
+        }
+        var newRedEndgame = ""
+        let redArrayPos = getArrayPosition(micPosition: redEndgame)
+        if ( redArrayPos > -1 && micScoredRed[redArrayPos]) {
+            redEndgame = "Spotlit"
+        }
+        let blueArrayPos = getArrayPosition(micPosition: blueEndgame)
+        if ( blueArrayPos > -1 && micScoredBlue[blueArrayPos]) {
+            blueEndgame = "Spotlit"
+        }
+                
+        
+
+        let elements = [redEndgame, blueEndgame].map { (endgame) -> AnyHashable in
+            if endgame == "None" {
+                return BreakdownStyle.xImage
+            }
+            else if endgame == "Parked" {
+                return "Park (+1)"
+            } else if endgame == "Spotlit" {
+                return "Spotlit (+4)"
+            } 
+            else if didRobotHang(endgame: endgame) {
+                return "Onstage (+3)"
+            }
+            return BreakdownStyle.xImage
+        }
+        return BreakdownRow(title: "Robot \(i) Endgame", red: [elements.first], blue: [elements.last])
+    }
+    
+    private static func didRobotHang(endgame: String) -> Bool{
+        return endgame.contains("Stage")
+    }
+    
+    private static func getArrayPosition(micPosition: String) -> Int
+    {
+        switch micPosition{
+        case "CenterStage":
+            return 0
+        case "StageLeft":
+            return 1
+        case "StageRight":
+            return 2
+        default:
+            return -1
+        }
+    }
+    
+    private static func foulRow(title: String, red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        guard let foulValues = values(key: "foulCount", red: red, blue: blue) else {
+            return nil
+        }
+        let (rf, bf) = foulValues
+        guard let redFouls = rf as? Int, let blueFouls = bf as? Int else {
+            return nil
+        }
+
+        guard let techFoulValues = values(key: "techFoulCount", red: red, blue: blue) else {
+            return nil
+        }
+        let (rtf, btf) = techFoulValues
+        guard let redTechFouls = rtf as? Int, let blueTechFouls = btf as? Int else {
+            return nil
+        }
+
+        // NOTE: red and blue are passed in backwards here intentionally, because
+        // the fouls returned are what the opposite alliance received
+        let elements = [(blueFouls, blueTechFouls), (redFouls, redTechFouls)].map { (fouls, techFouls) -> AnyHashable in
+            return "+\(fouls * 2) / +\(techFouls * 5)"
+        }
+        return BreakdownRow(title: title, red: [elements.first], blue: [elements.last])
+    }
+
+    private static func bonusRankingPointRow(title: String, key: String, red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        guard let bonusRankingPointValues = values(key: "\(key)BonusAchieved", red: red, blue: blue) else {
+            return nil
+        }
+        let (rw, bw) = bonusRankingPointValues
+        guard let redBonusRankingPoint = rw as? Bool, let blueBonusRankingPoint = bw as? Bool else {
+            return nil
+        }
+
+        let elements = [redBonusRankingPoint, blueBonusRankingPoint].map { (bonusRankingPoint) -> [AnyHashable] in
+            if bonusRankingPoint {
+                let result: [AnyHashable] = [BreakdownStyle.imageView(image: BreakdownStyle.checkImage), "(+1 RP)"]
+                return result
+            }
+            let result: [AnyHashable] = [BreakdownStyle.imageView(image: BreakdownStyle.xImage)]
+            return result
+        }
+        return BreakdownRow(title: title, red: elements.first ?? [], blue: elements.last ?? [])
+    }
+    
+    private static func totalNotesScoredRow(title: String, red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        
+        let scoringElementKeys = ["Amp", "Speaker"]
+        let periodKeys = ["auto", "teleop"]
+        guard let melodyBonusThresholdValues = values(key: "melodyBonusThreshold", red: red, blue: blue)
+        else{
+            return nil
+        }
+        let (threshold,_) = melodyBonusThresholdValues
+        guard let melodyBonusThreshold = threshold as? Int else{
+            return nil
+        }
+
+        var redNotes: [Int] = []
+        var blueNotes: [Int] = []
+
+        for scoringElementKey in scoringElementKeys {
+            var redScoringElementValues: [Int] = []
+            var blueScoringElementValues: [Int] = []
+            for periodKey in periodKeys {
+                let key = "\(periodKey)\(scoringElementKey)NoteCount"
+                guard let noteValues = values(key: key, red: red, blue: blue) else {
+                    return nil
+                }
+
+                let (rv, bv) = noteValues
+                guard let redCellValue = rv as? Int, let blueCellValue = bv as? Int else {
+                    return nil
+                }
+                redScoringElementValues.append(redCellValue)
+                blueScoringElementValues.append(blueCellValue)
+            }
+            redNotes.append(redScoringElementValues.reduce(0, +))
+            blueNotes.append(blueScoringElementValues.reduce(0, +))
+        }
+        
+        return BreakdownRow(title: title, red: ["\(redNotes.reduce(0, +)) / \(melodyBonusThreshold)"], blue: ["\(blueNotes.reduce(0, +)) / \(melodyBonusThreshold)"])
+    }
+    
+    private static func speakerRow(title: String, red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        let amplificationKeys = ["Count", "AmplifiedCount"]
+
+        let images = [BreakdownStyle2024.standardSpeaker, BreakdownStyle2024.amplifiedSpeaker]
+
+        var redNotes: [Int] = []
+        var blueNotes: [Int] = []
+
+        for amplificationKey in amplificationKeys {
+            var redHeightValues: [Int] = []
+            var blueHeightValues: [Int] = []
+            
+            let key = "teleopSpeakerNote\(amplificationKey)"
+            guard let cellValues = values(key: key, red: red, blue: blue) else {
+                return nil
+            }
+
+            let (rv, bv) = cellValues
+
+            guard let redCellValue = rv as? Int, let blueCellValue = bv as? Int else {
+                return nil
+            }
+            
+            redHeightValues.append(redCellValue)
+            blueHeightValues.append(blueCellValue)
+        
+            redNotes.append(redHeightValues.reduce(0, +))
+            blueNotes.append(blueHeightValues.reduce(0, +))
+        }
+
+        let mode = UIView.ContentMode.scaleAspectFit
+        let redValues = zip((images).map {
+            return BreakdownStyle.imageView(image: $0, contentMode: mode)
+        }, redNotes).flatMap { (imgV: UIImageView, v: Int) -> [AnyHashable?] in [imgV, String(v) ] }
+
+        let blueValues = zip((images).map {
+            return BreakdownStyle.imageView(image: $0, contentMode: mode)
+        }, blueNotes).flatMap { (imgV: UIImageView, v: Int) -> [AnyHashable?] in [imgV, String(v) ] }
+
+        return BreakdownRow(title: title, red: redValues, blue: blueValues)
+    }
+
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added Match Breakdown for the 2024 game, Crescendo
Based layout on the site version of the Match Breakdown 
Based functionality on previous year's standards


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is no breakdown for 2024 yet, so I wanted to get that going before the season is over.
Will probably work on 2023 next since it's also missing :) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since this was only a change on the match breakdown page, I tested this against the full site on many different matches to make sure the information was correct.
I also added a couple more rows of data that aren't on the site (and let @dracco1993 know about these) that provide more data to uses about the extra RPs:
- How many notes were scored out of the total needed for a Melody RP
- How many Stage points an alliances scored for the match

## Screenshots
![image](https://github.com/the-blue-alliance/the-blue-alliance-ios/assets/22030969/efa89c22-7687-49b7-979e-43bafda9ed1d)

