### PR TITLE
[WIP] Support remote events in 2021

### DIFF
--- a/Packages/TBAData/Sources/TBAData/Event/Event.swift
+++ b/Packages/TBAData/Sources/TBAData/Event/Event.swift
@@ -16,6 +16,7 @@ public enum EventType: Int, CaseIterable {
     case championshipFinals = 4
     case districtChampionshipDivision = 5
     case festivalOfChampions = 6
+    case remote = 7
     case offseason = 99
     case preseason = 100
     case unlabeled = -1
@@ -248,7 +249,8 @@ extension Event {
         }
 
         if eventType == .championshipDivision || eventType == .championshipFinals {
-            if self.year >= 2017, let city = city {
+            // 2021 was remote - only had one CMP
+            if (self.year >= 2017 && year != 2021), let city = city {
                 return "Championship - \(city)"
             }
             return "Championship"
@@ -280,6 +282,21 @@ extension Event {
                         return "Week 0.5"
                     }
                     return "Week \(week)"
+                } else if year == 2021 {
+                    /**
+                     * Group 2021 Events by their type - depends on both
+                     */
+                    if week == 0 {
+                        return "Participation"
+                    } else if week == 6 {
+                        return "FIRST Innovation Challenge"
+                    } else if week == 7 {
+                        return "INFINITE RECHARGE At Home Challenge"
+                    } else if week == 8 {
+                        return "Game Design Challenge"
+                    } else {
+                        return "Awards"
+                    }
                 }
                 return "Week \(week + 1)"
             }
@@ -385,6 +402,16 @@ extension Event {
             return false
         }
         return eventType == .festivalOfChampions
+    }
+
+    /**
+     If the event is a remote event.
+     */
+    public var isRemote: Bool {
+        guard let eventType = eventType else {
+            return false
+        }
+        return eventType == .remote
     }
 
     /**
@@ -1224,6 +1251,9 @@ extension Event {
             // each character's hex value one-by-one, which means we'll fail at "9" < "1".
             let monthString = String(format: "%02d", month)
             return "\(eventType).\(monthString)"
+        }
+        if eventType == EventType.remote.rawValue {
+            return "\(EventType.regional.rawValue).\(eventType)"
         }
         return "\(eventType)"
     }

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsViewController.swift
@@ -159,6 +159,8 @@ class EventsViewController: TBATableViewController, Refreshable, Stateful, Event
             return "Preseason Events"
         } else if event.isRegional {
             return "Regional Events"
+        } else if event.isRemote {
+            return event.weekString
         }
         return "Unknown Events"
     }


### PR DESCRIPTION
Looking to close both https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/901 and https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/908 and add better support for remote events in 2021

Considerations should include -

We should try to float up the week events above the CMP event - something about the sorting isn't working, as this is how it should work
![Simulator Screenshot - iPhone 15 Pro - 2024-03-27 at 02 01 19](https://github.com/the-blue-alliance/the-blue-alliance-ios/assets/516458/c697a613-d18c-450a-9336-8ce3904e5c34)

There are these "parent" events we should look to float to the top for the different types
![Simulator Screenshot - iPhone 15 Pro - 2024-03-27 at 01 59 18](https://github.com/the-blue-alliance/the-blue-alliance-ios/assets/516458/41c1e86b-9477-4c86-82fc-6369bba1a27e)

The headers are not refreshing inbetween the group switching.
https://github.com/the-blue-alliance/the-blue-alliance-ios/assets/516458/3e55455a-3f18-485c-a261-32f0cc17298e

