### PR TITLE
Team and Event Info

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -113,7 +113,7 @@ class EventInfoViewController: TBATableViewController, Observable {
                 return cell
             case .twitter:
                 let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
-                cell.textLabel?.text = "View #\(self.event.key) on Twitter"
+                cell.textLabel?.text = "View \(self.event.key) on Twitter"
                 return cell
             case .youtube:
                 let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -10,6 +10,7 @@ private enum TeamInfoSection: Int {
 
 private enum TeamInfoItem {
     case location
+    case rookieYear
     case sponsors
     case website
     case twitter
@@ -75,6 +76,8 @@ class TeamInfoViewController: TBATableViewController, Observable {
             switch item {
             case .location:
                 return self.tableView(tableView, locationCellForRowAt: indexPath)
+            case .rookieYear:
+                return self.tableView(tableView, rookieYearCellForRowAt: indexPath)
             case .sponsors:
                 return self.tableView(tableView, sponsorCellForRowAt: indexPath)
             case .website:
@@ -83,7 +86,7 @@ class TeamInfoViewController: TBATableViewController, Observable {
                 return cell
             case .twitter:
                 let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
-                cell.textLabel?.text = "View #\(self.team.key) on Twitter"
+                cell.textLabel?.text = "View \(self.team.key) on Twitter"
                 return cell
             case .youtube:
                 let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
@@ -108,7 +111,9 @@ class TeamInfoViewController: TBATableViewController, Observable {
             infoItems.append(.location)
         }
         if team.name != nil {
+            infoItems.append(.rookieYear)
             infoItems.append(.sponsors)
+            
         }
 
         if !infoItems.isEmpty {
@@ -140,6 +145,18 @@ class TeamInfoViewController: TBATableViewController, Observable {
 
         cell.titleLabel?.text = "Location"
         cell.subtitleLabel?.text = team.locationString
+
+        cell.accessoryType = .none
+        cell.selectionStyle = .none
+
+        return cell
+    }
+    
+    private func tableView(_ tableView: UITableView, rookieYearCellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(indexPath: indexPath) as ReverseSubtitleTableViewCell
+
+        cell.titleLabel?.text = "Rookie Year"
+        cell.subtitleLabel?.text = String(team.rookieYear!)
 
         cell.accessoryType = .none
         cell.selectionStyle = .none

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -112,8 +112,7 @@ class TeamInfoViewController: TBATableViewController, Observable {
         }
         if team.name != nil {
             infoItems.append(.rookieYear)
-            infoItems.append(.sponsors)
-            
+            infoItems.append(.sponsors)            
         }
 
         if !infoItems.isEmpty {

--- a/the-blue-alliance-ios/ViewElements/Info/InfoCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Info/InfoCellViewModel.swift
@@ -9,7 +9,7 @@ struct InfoCellViewModel {
 
     init(event: Event) {
         nameString = event.name ?? event.key
-        subtitleStrings = [event.locationString, event.dateString].compactMap({ $0 })
+        subtitleStrings = [event.locationString, event.dateString, event.weekString].compactMap({ $0 })
     }
 
     init(team: Team) {


### PR DESCRIPTION
## Description
display team rookie year, event week number, remove # to team and event information

## Motivation and Context
consistent with website version
## How Has This Been Tested?
local

## Screenshots
<img width="332" alt="image" src="https://github.com/user-attachments/assets/63671cf8-073c-4b4a-b470-c3d08f9a56ea">
<img width="343" alt="image" src="https://github.com/user-attachments/assets/621ed2c7-4a8c-49d4-9806-5874804a5acf">

