### PR TITLE
2026 Match Breakdown

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		304ED0411EF1D2D300E31791 /* RankingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 304ED03F1EF1D2D300E31791 /* RankingTableViewCell.xib */; };
 		304ED0421EF1D2D300E31791 /* RankingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304ED0401EF1D2D300E31791 /* RankingTableViewCell.swift */; };
 		371D9C9D2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371D9C9C2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift */; };
+		514C2EF52F8F0D5F00C674A9 /* MatchBreakdownConfigurator2026.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514C2EF42F8F0D5E00C674A9 /* MatchBreakdownConfigurator2026.swift */; };
 		92009B5723DD49A60058E567 /* HandoffServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92009B5623DD49A60058E567 /* HandoffServiceTests.swift */; };
 		920240072AEB6AAD0003D118 /* PureLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 920240062AEB6AAD0003D118 /* PureLayout */; };
 		920240092AEB6AC30003D118 /* TBAOperation in Frameworks */ = {isa = PBXBuildFile; productRef = 920240082AEB6AC30003D118 /* TBAOperation */; };
@@ -291,6 +292,7 @@
 		304ED03F1EF1D2D300E31791 /* RankingTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RankingTableViewCell.xib; sourceTree = "<group>"; };
 		304ED0401EF1D2D300E31791 /* RankingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RankingTableViewCell.swift; sourceTree = "<group>"; };
 		371D9C9C2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2024.swift; sourceTree = "<group>"; };
+		514C2EF42F8F0D5E00C674A9 /* MatchBreakdownConfigurator2026.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2026.swift; sourceTree = "<group>"; };
 		92009B5623DD49A60058E567 /* HandoffServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandoffServiceTests.swift; sourceTree = "<group>"; };
 		921D0B52222AF36A0056578A /* UIImage+TBATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+TBATests.swift"; sourceTree = "<group>"; };
 		921D0B54222AF94C0056578A /* UIBarButtonItem+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+TBA.swift"; sourceTree = "<group>"; };
@@ -608,6 +610,7 @@
 				D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */,
 				9263922727F0FD71003C302A /* MatchBreakdownConfigurator2022.swift */,
 				371D9C9C2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift */,
+				514C2EF42F8F0D5E00C674A9 /* MatchBreakdownConfigurator2026.swift */,
 			);
 			path = Breakdown;
 			sourceTree = "<group>";
@@ -1647,6 +1650,7 @@
 			files = (
 				927309B223DD1E66006145E0 /* HandoffService.swift in Sources */,
 				92A5E5DD21A22D550025CC85 /* Int16+Suffix.swift in Sources */,
+				514C2EF52F8F0D5F00C674A9 /* MatchBreakdownConfigurator2026.swift in Sources */,
 				92FF110E21A61AF6003BC5C4 /* EventInsightsViewController.swift in Sources */,
 				92A5E5D421A22D550025CC85 /* Bundle+Version.swift in Sources */,
 				929F57282092BA6500E5313A /* Observable.swift in Sources */,

--- a/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/The Blue Alliance.xcscheme
+++ b/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/The Blue Alliance.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1330"
-   version = "1.3">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/the-blue-alliance-ios/Info.plist
+++ b/the-blue-alliance-ios/Info.plist
@@ -140,5 +140,7 @@
 	<false/>
 	<key>FirebaseCrashlyticsCollectionEnabled</key>
 	<false/>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 </dict>
 </plist>

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -64,7 +64,10 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Observa
             breakdownConfigurator = MatchBreakdownConfigurator2022.self
         } else if match.event.year == 2024 {
             breakdownConfigurator = MatchBreakdownConfigurator2024.self
-        }else {
+        } else if match.event.year == 2026 {
+            breakdownConfigurator = MatchBreakdownConfigurator2026.self
+        }
+        else {
             breakdownConfigurator = nil
         }
 

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift
@@ -62,6 +62,54 @@ extension MatchBreakdownConfigurator {
 
         return BreakdownRow(title: title, red: [String(format: formatString, arguments: redValues)], blue: [String(format: formatString, arguments: blueValues)], type: type, offset: offset)
     }
+    static func nestedValue(keys: [String], in dictionary: [String: Any]?) -> Any? {
+        guard let dict = dictionary else {
+            return nil
+        }
+        
+        var current: Any = dict
+        for key in keys {
+            guard let currentDict = current as? [String: Any] else {
+                return nil
+            }
+            guard let next = currentDict[key] else {
+                return nil
+            }
+            current = next
+        }
+        return current
+    }
+
+    static func nestedValues(keyPath: [String], red: [String: Any]?, blue: [String: Any]?) -> (Any?, Any?)? {
+        guard let redValue = nestedValue(keys: keyPath, in: red),
+              let blueValue = nestedValue(keys: keyPath, in: blue) else {
+            return nil
+        }
+        return (redValue, blueValue)
+    }
+
+    static func nestedBreakdownValueSupported(keyPath: [String], red: [String: Any], blue: [String: Any]) -> Bool {
+        return nestedValue(keys: keyPath, in: red) != nil && nestedValue(keys: keyPath, in: blue) != nil
+    }
+
+    static func nestedRow(title: String, keyPath: [String], formatString: String = "%@", red: [String: Any]?, blue: [String: Any]?, type: BreakdownRow.BreakdownRowType = .normal, offset: Int = 0) -> BreakdownRow? {
+        guard let red = red, let blue = blue else {
+            return nil
+        }
+        guard nestedBreakdownValueSupported(keyPath: keyPath, red: red, blue: blue) else {
+            return nil
+        }
+        
+        guard let redValue = nestedValue(keys: keyPath, in: red) as? CustomStringConvertible,
+              let blueValue = nestedValue(keys: keyPath, in: blue) as? CustomStringConvertible else {
+            return nil
+        }
+        
+        let redString = String(describing: redValue)
+        let blueString = String(describing: blueValue)
+        
+        return BreakdownRow(title: title, red: [String(format: formatString, redString)], blue: [String(format: formatString, blueString)], type: type, offset: offset)
+    }
 
     // Images
 

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2026.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2026.swift
@@ -16,7 +16,7 @@ struct MatchBreakdownConfigurator2026: MatchBreakdownConfigurator {
         var rows: [BreakdownRow?] = []
         
         // Auto
-        rows.append(nestedRow(title: "Auto Tower", keyPath: ["hubScore", "autoPoints"], red: red, blue: blue))
+        rows.append(autoClimb(red: red, blue: blue))
         rows.append(row(title: "Auto Tower Points", key: "autoTowerPoints", red: red, blue: blue))
         rows.append(nestedRow(title: "Auto Fuel", keyPath: ["hubScore", "autoPoints"], red: red, blue: blue))
         rows.append(row(title: "Total Auto", key: "totalAutoPoints", red: red, blue: blue, type:.total))
@@ -37,12 +37,18 @@ struct MatchBreakdownConfigurator2026: MatchBreakdownConfigurator {
         rows.append(row(title: "Total Tower Points", key: "totalTowerPoints", red: red, blue: blue, type:.subtotal))
         rows.append(nestedRow(title: "Total Fuel Points", keyPath: ["hubScore", "totalPoints"], red: red, blue: blue, type:.subtotal))
         rows.append(row(title: "Total Teleop", key: "totalTeleopPoints", red: red, blue: blue, type:.total))
-        // RP/Fouls
+        // RP
         rows.append(boolImageRow(title: "Engergized Bonus", key: "energizedAchieved", red: red, blue: blue))
         rows.append(boolImageRow(title: "Supercharged Bonus", key: "superchargedAchieved", red: red, blue: blue))
         rows.append(boolImageRow(title: "Traversal Bonus", key: "traversalAchieved", red: red, blue: blue))
+        // Fouls/Total
         rows.append(foulRow(title: "Fouls / Major Fouls", red: red, blue: blue))
         rows.append(row(title: "Foul Points", key: "foulPoints", red: red, blue: blue, type:.subtotal))
+        rows.append(row(title: "Adjustments", key: "adjustPoints", red: red, blue: blue))
+        rows.append(row(title: "Total Score", key: "totalPoints", red: red, blue: blue, type:.total))
+        rows.append(row(title: "Ranking Points", key: "rp", formatString: "+%@ RP", red: red, blue: blue))
+
+
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })
         if !validRows.isEmpty {
@@ -58,7 +64,7 @@ struct MatchBreakdownConfigurator2026: MatchBreakdownConfigurator {
         guard let redFouls = rf as? Int, let blueFouls = bf as? Int else {
             return nil
         }
-
+        
         guard let minorFoulValues = values(key: "majorFoulCount", red: red, blue: blue) else {
             return nil
         }
@@ -66,11 +72,53 @@ struct MatchBreakdownConfigurator2026: MatchBreakdownConfigurator {
         guard let redMajorFouls = rmf as? Int, let blueMajorFouls = bmf as? Int else {
             return nil
         }
-
+        
         let elements = [(redFouls, redMajorFouls), (blueFouls, blueMajorFouls)].map { (fouls, majorFouls) -> AnyHashable in
             return "\(fouls) / \(majorFouls)"
         }
         return BreakdownRow(title: title, red: [elements.first], blue: [elements.last])
     }
+    
+    private static func autoClimb(red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        var redClimbStrings: [String] = []
+        var blueClimbStrings: [String] = []
+        
+        for i in [1, 2, 3] {
+            guard let taxiValues = values(key: "autoTowerRobot\(i)", red: red, blue: blue) else {
+                return nil
+            }
+            let (rv, bv) = taxiValues
+            guard let redClimb = rv as? String, let blueClimb = bv as? String else {
+                return nil
+            }
+            redClimbStrings.append(redClimb)
+            blueClimbStrings.append(blueClimb)
+        }
+        
+        let mode = UIView.ContentMode.scaleAspectFit
+        let elements = [redClimbStrings, blueClimbStrings].map { (climbStrings) -> [AnyHashable] in
+            return climbStrings.map { (climb) -> AnyHashable in
+                switch climb {
+                case "None":
+                    return BreakdownStyle.imageView(image: BreakdownStyle.xImage, contentMode: mode, forceSquare: false)
+                case "Level1":
+                    return BreakdownStyle.imageView(image: BreakdownStyle.checkImage, contentMode: mode, forceSquare: false)
+                default:
+                    return "?"
+                }
+            }
+        }
+        let (redElements, blueElements) = (elements[0], elements[1])
+        guard let redBreakdownElements = redElements as? [BreakdownElement], let blueBreakdownElements = blueElements as? [BreakdownElement] else {
+            return nil
+        }
 
+        let redStackView = UIStackView(arrangedSubviews: redBreakdownElements.map { $0.toView() })
+        redStackView.distribution = .fillEqually
+        let blueStackView = UIStackView(arrangedSubviews: blueBreakdownElements.map { $0.toView() })
+        blueStackView.distribution = .fillEqually
+
+        return BreakdownRow(title: "Auto Tower", red: [redStackView], blue: [blueStackView], type: .subtotal)
+
+    }
 }

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2026.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2026.swift
@@ -1,0 +1,76 @@
+import Foundation
+import UIKit
+
+private class BreakdownStyle2026 {
+    public static let bottomImage = UIImage(systemName: "rectangle")
+    public static let outerImage = UIImage(systemName: "hexagon")
+    public static let innerImage = UIImage(systemName: "circle")
+    public static let trueImage = UIImage(systemName: "checkmark")
+    public static let falseImage = UIImage(systemName: "xmark")
+}
+
+struct MatchBreakdownConfigurator2026: MatchBreakdownConfigurator {
+    
+    static func configureDataSource(_ snapshot: inout NSDiffableDataSourceSnapshot<String?, BreakdownRow>, _ breakdown: [String: Any]?, _ red: [String: Any]?, _ blue: [String: Any]?) {
+        
+        var rows: [BreakdownRow?] = []
+        
+        // Auto
+        rows.append(nestedRow(title: "Auto Tower", keyPath: ["hubScore", "autoPoints"], red: red, blue: blue))
+        rows.append(row(title: "Auto Tower Points", key: "autoTowerPoints", red: red, blue: blue))
+        rows.append(nestedRow(title: "Auto Fuel", keyPath: ["hubScore", "autoPoints"], red: red, blue: blue))
+        rows.append(row(title: "Total Auto", key: "totalAutoPoints", red: red, blue: blue, type:.total))
+        // Teleop
+        rows.append(nestedRow(title: "Transition Shift Fuel", keyPath: ["hubScore", "transitionCount"], red: red, blue: blue))
+        rows.append(nestedRow(title: "Shift 1 Fuel", keyPath: ["hubScore", "shift1Count"], red: red, blue: blue))
+        rows.append(nestedRow(title: "Shift 2 Fuel", keyPath: ["hubScore", "shift2Count"], red: red, blue: blue))
+        rows.append(nestedRow(title: "Shift 3 Fuel", keyPath: ["hubScore", "shift3Count"], red: red, blue: blue))
+        rows.append(nestedRow(title: "Shift 4 Fuel", keyPath: ["hubScore", "shift4Count"], red: red, blue: blue))
+        rows.append(nestedRow(title: "Endgame Fuel", keyPath: ["hubScore", "endgameCount"], red: red, blue: blue))
+        rows.append(nestedRow(title: "Teleop Fuel Points", keyPath: ["hubScore", "teleopPoints"], red: red, blue: blue, type:.subtotal))
+        // Endgame
+        rows.append(row(title: "Robot 1 Endgame", key: "endGameTowerRobot1", red: red, blue: blue))
+        rows.append(row(title: "Robot 2 Endgame", key: "endGameTowerRobot2", red: red, blue: blue))
+        rows.append(row(title: "Robot 3 Endgame", key: "endGameTowerRobot3", red: red, blue: blue))
+        
+        rows.append(row(title: "Endgame Tower Points", key: "endGameTowerPoints", red: red, blue: blue, type:.subtotal))
+        rows.append(row(title: "Total Tower Points", key: "totalTowerPoints", red: red, blue: blue, type:.subtotal))
+        rows.append(nestedRow(title: "Total Fuel Points", keyPath: ["hubScore", "totalPoints"], red: red, blue: blue, type:.subtotal))
+        rows.append(row(title: "Total Teleop", key: "totalTeleopPoints", red: red, blue: blue, type:.total))
+        // RP/Fouls
+        rows.append(boolImageRow(title: "Engergized Bonus", key: "energizedAchieved", red: red, blue: blue))
+        rows.append(boolImageRow(title: "Supercharged Bonus", key: "superchargedAchieved", red: red, blue: blue))
+        rows.append(boolImageRow(title: "Traversal Bonus", key: "traversalAchieved", red: red, blue: blue))
+        rows.append(foulRow(title: "Fouls / Major Fouls", red: red, blue: blue))
+        rows.append(row(title: "Foul Points", key: "foulPoints", red: red, blue: blue, type:.subtotal))
+        // Clean up any empty rows
+        let validRows = rows.compactMap({ $0 })
+        if !validRows.isEmpty {
+            snapshot.appendSections([nil])
+            snapshot.appendItems(validRows)
+        }
+    }
+    private static func foulRow(title: String, red: [String: Any]?, blue: [String: Any]?) -> BreakdownRow? {
+        guard let foulValues = values(key: "minorFoulCount", red: red, blue: blue) else {
+            return nil
+        }
+        let (rf, bf) = foulValues
+        guard let redFouls = rf as? Int, let blueFouls = bf as? Int else {
+            return nil
+        }
+
+        guard let minorFoulValues = values(key: "majorFoulCount", red: red, blue: blue) else {
+            return nil
+        }
+        let (rmf, bmf) = minorFoulValues
+        guard let redMajorFouls = rmf as? Int, let blueMajorFouls = bmf as? Int else {
+            return nil
+        }
+
+        let elements = [(redFouls, redMajorFouls), (blueFouls, blueMajorFouls)].map { (fouls, majorFouls) -> AnyHashable in
+            return "\(fouls) / \(majorFouls)"
+        }
+        return BreakdownRow(title: title, red: [elements.first], blue: [elements.last])
+    }
+
+}


### PR DESCRIPTION
Adds a page for the 2026 FRC match breakdown.

## Description
- Configurator was added for 2026 mirroring the website
- Methods were added to support the nested API calls that are required for this year's game (due to the shifts)
- Flag added for iOS 26 ui compatibility (uses old style - not liquid glass)

## Motivation and Context
Adds much needed info for 2026 to the breakdown page, showing more than just the final score.

## How Has This Been Tested?
This has been tested in the Xcode simulator on the following devices:
- iPhone 17 Pro (iOS 26.3)
- iPhone 16e (iOS 18.6)

## Screenshots
<img width="568" height="1084" alt="Screenshot 2026-04-14 at 10 42 10 PM" src="https://github.com/user-attachments/assets/1e6a7582-f78a-4ed9-b9bf-20bb84c3a09f" /><img width="568" height="1084" alt="Screenshot 2026-04-14 at 10 42 19 PM" src="https://github.com/user-attachments/assets/602d8bdc-77e1-4397-ad25-bca1207c0831" />

