### PR TITLE
Migrate target/action + @objc to UIAction closures

### DIFF
--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -70,7 +70,9 @@ extension Refreshable {
 
     func enableRefreshing() {
         let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: Selector(("refresh")), for: .valueChanged)
+        refreshControl.addAction(UIAction { [weak self] _ in
+            self?.refresh()
+        }, for: .valueChanged)
 
         self.refreshControl = refreshControl
     }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -85,7 +85,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
 
     var isDataSourceEmpty: Bool { allRankings.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey)

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
@@ -82,7 +82,7 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Stat
 
     var isDataSourceEmpty: Bool { eventPoints.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey)

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
@@ -85,7 +85,7 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable, St
 
     var isDataSourceEmpty: Bool { eventPoints.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey)

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsContainerViewController.swift
@@ -54,13 +54,11 @@ extension DistrictsContainerViewController: NavigationTitleDelegate {
 
         let nav = UINavigationController(rootViewController: selectTableViewController)
         nav.modalPresentationStyle = .formSheet
-        nav.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissSelectYear))
+        nav.navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, primaryAction: UIAction { [weak self] _ in
+            self?.navigationController?.dismiss(animated: true)
+        })
 
-        navigationController?.present(nav, animated: true, completion: nil)
-    }
-
-    @objc private func dismissSelectYear() {
-        navigationController?.dismiss(animated: true, completion: nil)
+        navigationController?.present(nav, animated: true)
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
@@ -73,7 +73,7 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
 
     var isDataSourceEmpty: Bool { districts.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.districtsByYear(self.year)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
@@ -100,7 +100,7 @@ private class EventAlliancesViewController: TBATableViewController, Refreshable,
 
     var isDataSourceEmpty: Bool { alliances.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.eventAlliances(key: self.eventKey)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -112,7 +112,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
 
     var isDataSourceEmpty: Bool { awards.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.eventAwards(key: self.eventKey)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
@@ -119,7 +119,7 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
 
     var isDataSourceEmpty: Bool { rows.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let response = try await self.dependencies.api.eventDistrictPoints(key: self.eventKey)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -224,7 +224,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
 
     var isDataSourceEmpty: Bool { event == nil }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.event(key: self.eventKey)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
@@ -95,7 +95,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
 
     var isDataSourceEmpty: Bool { rankings.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let response = try await self.dependencies.api.eventRankings(key: self.eventKey)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsContainerViewController.swift
@@ -47,15 +47,11 @@ class EventInsightsContainerViewController: ContainerViewController {
 
         let nav = UINavigationController(rootViewController: selectTableViewController)
         nav.modalPresentationStyle = .formSheet
-        nav.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissFilter))
+        nav.navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, primaryAction: UIAction { [weak self] _ in
+            self?.navigationController?.dismiss(animated: true)
+        })
 
-        navigationController?.present(nav, animated: true, completion: nil)
-    }
-
-    // MARK: - Interface Actions
-
-    @objc private func dismissFilter() {
-        navigationController?.dismiss(animated: true, completion: nil)
+        navigationController?.present(nav, animated: true)
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
@@ -131,7 +131,7 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
 
     var isDataSourceEmpty: Bool { dataSource.isDataSourceEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         guard eventStatsConfigurator != nil else { return }
         runRefresh { [weak self] in
             guard let self else { return }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -130,7 +130,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
 
     var isDataSourceEmpty: Bool { rows.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let response = try await self.dependencies.api.eventOPRs(key: self.eventKey)

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
@@ -128,7 +128,7 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
 
     var isDataSourceEmpty: Bool { events.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let loaded = try await self.loadEvents()

--- a/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
@@ -67,7 +67,7 @@ class WeekEventsViewController: EventsListViewController {
 
     // MARK: - Refresh
 
-    @objc override func refresh() {
+    override func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.eventsByYear(self.currentYear)

--- a/the-blue-alliance-ios/ViewControllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/YearSelectViewController.swift
@@ -36,7 +36,9 @@ class YearSelectViewController: ContainerViewController {
 
         selectViewController.delegate = self
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonTapped))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(systemItem: .cancel, primaryAction: UIAction { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -57,10 +59,6 @@ class YearSelectViewController: ContainerViewController {
     }
 
     // MARK: - Private Methods
-
-    @objc private func cancelButtonTapped() {
-        dismiss(animated: true, completion: nil)
-    }
 
     private func pushToEventWeekSelect(year: Int) {
         eventWeekSelectViewController = EventWeekSelectViewController(year: year, week: week, dependencies: dependencies)
@@ -108,17 +106,13 @@ private class EventWeekSelectViewController: ContainerViewController {
         selectViewController.delegate = self
         selectViewController.enableRefreshing()
 
-        rightBarButtonItems = [UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))]
+        rightBarButtonItems = [UIBarButtonItem(systemItem: .done, primaryAction: UIAction { [weak self] _ in
+            self?.dismiss(animated: true)
+        })]
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - Private Methods
-
-    @objc private func doneButtonTapped() {
-        dismiss(animated: true, completion: nil)
     }
 
 }
@@ -155,7 +149,7 @@ private class WeeksSelectTableViewController: SelectTableViewController<EventWee
 
     override var isDataSourceEmpty: Bool { options.isEmpty }
 
-    @objc override func refresh() {
+    override func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let events = try await self.dependencies.api.eventsByYear(self.year)

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -117,7 +117,7 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
 
     var isDataSourceEmpty: Bool { dataSource.isDataSourceEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         guard breakdownConfigurator != nil else { return }
         runRefresh { [weak self] in
             guard let self else { return }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -166,7 +166,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
         (match?.videos.count ?? 0) == 0
     }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             if let fetched = try await self.api.match(key: self.matchKey) {

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchQueryOptionsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchQueryOptionsViewController.swift
@@ -78,7 +78,9 @@ class MatchQueryOptionsViewController: TBATableViewController {
 
         title = "Match Sort/Filter"
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissMatchQuery))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, primaryAction: UIAction { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -149,7 +149,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
         return allMatches.isEmpty
     }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.eventMatches(key: self.eventKey)

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAPreferenceViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAPreferenceViewController.swift
@@ -42,14 +42,16 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
             }
         }
     }
-    internal lazy var closeBarButtonItem = UIBarButtonItem(title: "Close",
-                                                           style: .plain,
-                                                           target: self,
-                                                           action: #selector(close))
-    internal lazy var saveBarButtonItem = UIBarButtonItem(title: "Save",
-                                                          style: .done,
-                                                          target: self,
-                                                          action: #selector(save))
+    internal lazy var closeBarButtonItem = UIBarButtonItem(title: "Close", primaryAction: UIAction { [weak self] _ in
+        self?.close()
+    })
+    internal lazy var saveBarButtonItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(title: "Save", primaryAction: UIAction { [weak self] _ in
+            self?.save()
+        })
+        item.style = .done
+        return item
+    }()
     internal var saveActivityIndicatorBarButtonItem = UIBarButtonItem.activityIndicatorBarButtonItem()
 
     init(subscribableModel: MyTBASubscribable, dependencies: Dependencies) {
@@ -113,7 +115,7 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
         confirmClose()
     }
 
-    @objc func save() {
+    func save() {
         isSaving = true
         preferencesTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -147,7 +149,7 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
         }
     }
 
-    @objc func close() {
+    func close() {
         dismiss(animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -280,7 +280,7 @@ class MyTBAFavoritesViewController: MyTBATableViewController, Refreshable, State
         await MainActor.run { favoritesStore.replaceAll(with: favorites) }
     }
 
-    @objc func refresh() {
+    func refresh() {
         guard myTBA.isAuthenticated else { return }
         refreshFromRemote()
     }
@@ -329,7 +329,7 @@ class MyTBASubscriptionsViewController: MyTBATableViewController, Refreshable, S
         await MainActor.run { subscriptionsStore.replaceAll(with: subs) }
     }
 
-    @objc func refresh() {
+    func refresh() {
         guard myTBA.isAuthenticated else { return }
         refreshFromRemote()
     }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
@@ -16,9 +16,9 @@ class MyTBAViewController: ContainerViewController {
     private var signInView: UIView! {
         return signInViewController.view
     }
-    private lazy var signOutBarButtonItem: UIBarButtonItem = {
-         return UIBarButtonItem(title: "Sign Out", style: .plain, target: self, action: #selector(logoutTapped))
-    }()
+    private lazy var signOutBarButtonItem = UIBarButtonItem(title: "Sign Out", primaryAction: UIAction { [weak self] _ in
+        self?.confirmLogout()
+    })
     private var signOutActivityIndicatorBarButtonItem = UIBarButtonItem.activityIndicatorBarButtonItem()
 
     var isLoggingOut: Bool = false {
@@ -127,13 +127,13 @@ class MyTBAViewController: ContainerViewController {
 
     // MARK: - Interface Methods
 
-    @objc func logoutTapped() {
+    private func confirmLogout() {
         let signOutAlertController = UIAlertController(title: "Log Out?", message: "Are you sure you want to sign out of myTBA?", preferredStyle: .alert)
-        signOutAlertController.addAction(UIAlertAction(title: "Log Out", style: .default, handler: { (_) in
-            self.logout()
+        signOutAlertController.addAction(UIAlertAction(title: "Log Out", style: .default, handler: { [weak self] _ in
+            self?.logout()
         }))
-        signOutAlertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        present(signOutAlertController, animated: true, completion: nil)
+        signOutAlertController.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(signOutAlertController, animated: true)
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -197,7 +197,7 @@ extension SearchViewController: UISearchBarDelegate {
 extension SearchViewController: Refreshable {
     var isDataSourceEmpty: Bool { dataSource.isDataSourceEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         loadIndex()
     }
 }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamStatsViewController.swift
@@ -61,7 +61,7 @@ class TeamStatsViewController: TBATableViewController, Refreshable, Stateful {
 
     var isDataSourceEmpty: Bool { stats == nil }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let oprs = try await self.dependencies.api.eventOPRs(key: self.eventKey)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -281,7 +281,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
 
     var isDataSourceEmpty: Bool { eventStatus == nil }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             async let teamTask = try? await self.dependencies.api.team(key: self.teamKey)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -208,7 +208,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
 
     var isDataSourceEmpty: Bool { team == nil }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             if let fetched = try await self.api.team(key: self.teamKey) {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -188,7 +188,7 @@ extension TeamMediaCollectionViewController: Refreshable {
         return media.isEmpty
     }
 
-    @objc func refresh() {
+    func refresh() {
         guard let year = year else { return }
         runRefresh { [weak self] in
             guard let self else { return }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -64,7 +64,9 @@ class TeamViewController: HeaderContainerViewController {
         eventsViewController.delegate = self
         mediaViewController.delegate = self
 
-        teamHeaderView.yearButton.addTarget(self, action: #selector(showSelectYear), for: .touchUpInside)
+        teamHeaderView.yearButton.addAction(UIAction { [weak self] _ in
+            self?.showSelectYear()
+        }, for: .touchUpInside)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -122,7 +124,7 @@ class TeamViewController: HeaderContainerViewController {
         navigationSubtitle = year?.description ?? "----"
     }
 
-    @objc private func showSelectYear() {
+    private func showSelectYear() {
         guard !yearsParticipated.isEmpty else { return }
 
         let selectTableViewController = SelectTableViewController<TeamViewController>(current: year, options: yearsParticipated, dependencies: dependencies)
@@ -131,13 +133,11 @@ class TeamViewController: HeaderContainerViewController {
 
         let nav = UINavigationController(rootViewController: selectTableViewController)
         nav.modalPresentationStyle = .formSheet
-        nav.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissSelectYear))
+        nav.navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, primaryAction: UIAction { [weak self] _ in
+            self?.navigationController?.dismiss(animated: true)
+        })
 
-        navigationController?.present(nav, animated: true, completion: nil)
-    }
-
-    @objc private func dismissSelectYear() {
-        navigationController?.dismiss(animated: true, completion: nil)
+        navigationController?.present(nav, animated: true)
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -106,7 +106,7 @@ class TeamsListViewController: TBASearchableTableViewController, Refreshable, St
 
     var isDataSourceEmpty: Bool { teams.isEmpty }
 
-    @objc func refresh() {
+    func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.loadTeams()

--- a/the-blue-alliance-ios/ViewElements/Base/SwitchTableViewCell.swift
+++ b/the-blue-alliance-ios/ViewElements/Base/SwitchTableViewCell.swift
@@ -29,12 +29,11 @@ class SwitchTableViewCell: UITableViewCell {
 
     public lazy var switchView: UISwitch! = {
         let switchView = UISwitch(frame: .zero)
-        switchView.addTarget(self, action: #selector(switchValueChanged(_:)), for: .valueChanged)
+        switchView.addAction(UIAction { [weak self] action in
+            guard let sender = action.sender as? UISwitch else { return }
+            self?.switchToggled(sender)
+        }, for: .valueChanged)
         return switchView
     }()
-
-    @objc func switchValueChanged(_ sender: UISwitch) {
-        self.switchToggled(sender)
-    }
 
 }

--- a/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
@@ -205,7 +205,10 @@ class MatchSummaryView: UIView {
 
         button.titleLabel?.attributedText = customAttributedString(text: text, isBold: isBold, isStrikethrough: isStrikethrough)
 
-        button.addTarget(self, action: #selector(teamPressed(sender:)), for: .touchUpInside)
+        button.addAction(UIAction { [weak self, weak button] _ in
+            guard let button, button.tag != 0 else { return }
+            self?.delegate?.teamPressed(teamNumber: button.tag)
+        }, for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }
@@ -217,11 +220,6 @@ class MatchSummaryView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = UIColor.label
         return label
-    }
-    
-    @objc private func teamPressed(sender: UIButton) {
-        if sender.tag == 0 { return }
-        delegate?.teamPressed(teamNumber: sender.tag)
     }
     
     private func customAttributedString(text: String, isBold: Bool, isStrikethrough: Bool = false) -> NSMutableAttributedString {


### PR DESCRIPTION
Uses iOS 14+ UIAction closures in place of target/action + selectors:
- UIRefreshControl in Refreshable protocol now calls refresh() via a closure, dropping the string-based Selector(("refresh")) lookup. Removes @objc from 25 conforming refresh() implementations.
- 8 UIBarButtonItems (dismiss / done / cancel / save / close / sign out) switch to UIBarButtonItem(systemItem:primaryAction:) or UIBarButtonItem(title:primaryAction:).
- 3 in-view controls (year button, team button in match summary, switch in settings) use addAction(UIAction) in place of addTarget(#selector).

Deletes the thin @objc forwarders that only existed to bridge to selectors. save() and close() in MyTBAPreferenceViewController stay as regular methods (still called from the confirm-close alert actions) but drop @objc.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
