### PR TITLE
Scale static-sized fonts with UIFontMetrics

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Base/Containers/ContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Containers/ContainerViewController.swift
@@ -60,12 +60,12 @@ class ContainerViewController: UIViewController, Alertable {
     }()
     private lazy var navigationTitleLabel: UILabel = {
         let navigationTitleLabel = ContainerViewController.createNavigationLabel()
-        navigationTitleLabel.font = UIFont.systemFont(ofSize: 17)
+        navigationTitleLabel.font = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 17))
         return navigationTitleLabel
     }()
     private lazy var navigationSubtitleLabel: UILabel = {
         let navigationSubtitleLabel = ContainerViewController.createNavigationLabel()
-        navigationSubtitleLabel.font = UIFont.systemFont(ofSize: 11)
+        navigationSubtitleLabel.font = UIFontMetrics(forTextStyle: .caption2).scaledFont(for: UIFont.systemFont(ofSize: 11))
         return navigationSubtitleLabel
     }()
     weak var navigationTitleDelegate: NavigationTitleDelegate?
@@ -306,6 +306,7 @@ class ContainerViewController: UIViewController, Alertable {
         let label = UILabel(forAutoLayout: ())
         label.textColor = UIColor.white
         label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = true
         return label
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -29,7 +29,8 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     private lazy var infoStackView: UIStackView = {
         let labels = [teamsLabel, scoreTitleLabel]
         for label in labels {
-            label.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+            label.font = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 16, weight: .medium))
+            label.adjustsFontForContentSizeCategory = true
             label.textAlignment = .center
             label.backgroundColor = UIColor.systemFill
             label.translatesAutoresizingMaskIntoConstraints = false

--- a/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
@@ -19,8 +19,8 @@ class MatchSummaryView: UIView {
     // change this variable so that the teams are shown as buttons
     private var teamsTappable: Bool = false
 
-    private let winnerFont = UIFont.systemFont(ofSize: 14, weight: UIFont.Weight.bold)
-    private let notWinnerFont = UIFont.systemFont(ofSize: 14, weight: UIFont.Weight.medium)
+    private let winnerFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 14, weight: .bold))
+    private let notWinnerFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 14, weight: .medium))
 
     // MARK: - IBOutlet
 
@@ -80,9 +80,11 @@ class MatchSummaryView: UIView {
     private func styleInterface() {
         redContainerView.backgroundColor = UIColor.redAllianceBackgroundColor
         redScoreLabel.backgroundColor = UIColor.redAllianceScoreBackgroundColor
+        redScoreLabel.adjustsFontForContentSizeCategory = true
 
         blueContainerView.backgroundColor = UIColor.blueAllianceBackgroundColor
         blueScoreLabel.backgroundColor = UIColor.blueAllianceScoreBackgroundColor
+        blueScoreLabel.adjustsFontForContentSizeCategory = true
     }
 
     // MARK: - Public Methods


### PR DESCRIPTION
## Summary

Three sites in the app hard-coded `UIFont.systemFont(ofSize:)` without dynamic-type scaling, so users who enable **Larger Text** in Settings → Accessibility → Display & Text Size saw fixed-size labels. Wrapping each in `UIFontMetrics(forTextStyle:).scaledFont(for:)` keeps the original point size as the baseline and scales with the user's preference. Affected labels also opt in to `adjustsFontForContentSizeCategory` for live updates.

- **MatchInfoViewController**: "Teams" / "Score" header labels (16pt medium)
- **ContainerViewController**: navigation title (17pt) and subtitle (11pt) — these render under the nav bar on team / event / district detail screens
- **MatchSummaryView**: winner / non-winner score fonts (14pt bold / medium)

The `TeamHeaderView` already uses this `UIFontMetrics` pattern — these sites now match.

## Check out locally

```sh
git fetch origin zach/dynamic-type-fonts
git worktree add .claude/worktrees/dynamic-type origin/zach/dynamic-type-fonts
cd .claude/worktrees/dynamic-type
ln -s ../../../../the-blue-alliance-ios/Secrets.plist the-blue-alliance-ios/Secrets.plist
open "the-blue-alliance-ios.xcodeproj"
```

Build & run in Xcode (⌘R). When done:

```sh
cd -
git worktree remove .claude/worktrees/dynamic-type
```

## Test plan

- [ ] Settings → Accessibility → Display & Text Size → Larger Text → max slider
- [ ] Open a match detail → "Teams" / "Score" column headers scale
- [ ] Open a team or event detail → navigation title and subtitle scale
- [ ] Open a match → red/blue score numbers scale (both winning and losing sides)
- [ ] Reset Larger Text to default → everything returns to original sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)