### PR TITLE
Migrate Google sign-in button to UIButton.Configuration

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBASignInViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBASignInViewController.swift
@@ -58,29 +58,29 @@ class MyTBASignInViewController: UIViewController, ASAuthorizationControllerPres
         })
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        updateInterface(previousTraitCollection: previousTraitCollection)
-    }
-
     // MARK: - Interface Methods
 
     private func styleInterface() {
         view.backgroundColor = UIColor.systemGroupedBackground
-        signInButton.setTitleColor(UIColor.googleSignInTextColor, for: .normal)
 
-        updateInterface(previousTraitCollection: nil)
-    }
+        var config = UIButton.Configuration.plain()
+        config.baseForegroundColor = UIColor.googleSignInTextColor
+        signInButton.configuration = config
 
-    private func updateInterface(previousTraitCollection: UITraitCollection?) {
-        if let previousTraitCollection = previousTraitCollection, previousTraitCollection.userInterfaceStyle != traitCollection.userInterfaceStyle {
-            // There's some bug (or - possibly misconfigured on my part) with stretching + the trait collection changing.
-            // As a workaround, we need to manually reset all the background images for the sign in button
-            signInButton.setBackgroundImage(UIImage(named: "btn_google_signin_normal"), for: .normal)
-            signInButton.setBackgroundImage(UIImage(named: "btn_google_signin_pressed"), for: .selected)
-            signInButton.setBackgroundImage(UIImage(named: "btn_google_signin_focus"), for: .focused)
-            signInButton.setBackgroundImage(UIImage(named: "btn_google_signin_disabled"), for: .disabled)
+        signInButton.configurationUpdateHandler = { button in
+            guard var config = button.configuration else { return }
+            let imageName: String
+            if button.state.contains(.disabled) {
+                imageName = "btn_google_signin_disabled"
+            } else if button.state.contains(.focused) {
+                imageName = "btn_google_signin_focus"
+            } else if button.state.contains(.highlighted) {
+                imageName = "btn_google_signin_pressed"
+            } else {
+                imageName = "btn_google_signin_normal"
+            }
+            config.background.image = UIImage(named: imageName)
+            button.configuration = config
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the trait-collection-change workaround in `MyTBASignInViewController` with a proper `UIButton.Configuration` + `configurationUpdateHandler` (iOS 15+).

The previous code set four state-specific background images via `setBackgroundImage(_:for:)` in the XIB, then manually re-applied them inside `traitCollectionDidChange` / `updateInterface(previousTraitCollection:)` because trait changes were dropping the images. The comment in the old code said: *"There's some bug (or - possibly misconfigured on my part) with stretching + the trait collection changing."*

With the configuration-based approach, UIKit invokes the update handler whenever the button's state or traits change, so the correct background image is applied declaratively. The workaround and both override methods are gone; foreground color moves to `configuration.baseForegroundColor`.

Also corrects a latent bug: the legacy code set the "pressed" image for `UIControl.State.selected`, but press state is `.highlighted` — the handler now reads from the right state.

## Check out locally

```sh
git fetch origin zach/google-signin-button-configuration
git worktree add .claude/worktrees/signin-button origin/zach/google-signin-button-configuration
cd .claude/worktrees/signin-button
ln -s ../../../../the-blue-alliance-ios/Secrets.plist the-blue-alliance-ios/Secrets.plist
open "the-blue-alliance-ios.xcodeproj"
```

Build & run in Xcode (⌘R). When done:

```sh
cd -
git worktree remove .claude/worktrees/signin-button
```

## Test plan

- [ ] Sign out of myTBA, stay on the Sign In screen
- [ ] Verify the Google sign-in button renders the normal image
- [ ] Settings → Developer → Dark Appearance (or Display & Brightness → Dark) and back to Light; confirm the button still renders correctly after each toggle (this was the original bug)
- [ ] Press and hold the Google button; verify the "pressed" image shows while held
- [ ] Tap through Google sign-in end-to-end; confirm sign-in still succeeds and dismisses the screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)