### PR TITLE
Adjust spacing to show 5 number teams

### DIFF
--- a/the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.xib
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="landscape" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="d3J-C3-mc8" id="b4Q-6L-HOM">
-                <rect key="frame" x="0.0" y="0.0" width="347.5" height="70"/>
+                <rect key="frame" x="0.0" y="0.0" width="348.5" height="70"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Tyb-Ns-30f">
@@ -21,28 +22,28 @@
                             <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="QYQ-jO-saV">
                                 <rect key="frame" x="0.0" y="0.0" width="324.5" height="54"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="7332" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxL-kB-K0K">
-                                        <rect key="frame" x="0.0" y="0.0" width="44" height="54"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="10000" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxL-kB-K0K">
+                                        <rect key="frame" x="0.0" y="0.0" width="55" height="54"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="44" id="eAG-vi-jop"/>
+                                            <constraint firstAttribute="width" constant="55" id="eAG-vi-jop"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6eP-Ga-gQh">
-                                        <rect key="frame" x="59" y="0.0" width="265.5" height="54"/>
+                                        <rect key="frame" x="70" y="0.0" width="254.5" height="54"/>
                                         <subviews>
                                             <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Team Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5pm-5N-rYU">
-                                                <rect key="frame" x="0.0" y="0.0" width="265.5" height="37"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="254.5" height="37"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" text="Location" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ana-Js-nEd">
-                                                <rect key="frame" x="0.0" y="37" width="265.5" height="17"/>
+                                                <rect key="frame" x="0.0" y="37" width="254.5" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
@@ -64,7 +65,12 @@
                 <outlet property="nameLabel" destination="5pm-5N-rYU" id="g6B-eW-e1b"/>
                 <outlet property="numberLabel" destination="vxL-kB-K0K" id="ISd-rw-rp5"/>
             </connections>
-            <point key="canvasLocation" x="-72" y="16"/>
+            <point key="canvasLocation" x="-72.799999999999997" y="15.292353823088456"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.xib
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="landscape" appearance="light"/>
+    <device id="retina6_9" orientation="landscape" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -13,14 +13,14 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="d3J-C3-mc8" id="b4Q-6L-HOM">
-                <rect key="frame" x="0.0" y="0.0" width="348.5" height="70"/>
+                <rect key="frame" x="0.0" y="0.0" width="348.66666666666669" height="70"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Tyb-Ns-30f">
-                        <rect key="frame" x="16" y="8" width="324.5" height="54"/>
+                        <rect key="frame" x="16" y="8" width="324.66666666666669" height="54"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="QYQ-jO-saV">
-                                <rect key="frame" x="0.0" y="0.0" width="324.5" height="54"/>
+                                <rect key="frame" x="0.0" y="0.0" width="324.66666666666669" height="54"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="10000" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxL-kB-K0K">
                                         <rect key="frame" x="0.0" y="0.0" width="55" height="54"/>
@@ -32,16 +32,16 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6eP-Ga-gQh">
-                                        <rect key="frame" x="70" y="0.0" width="254.5" height="54"/>
+                                        <rect key="frame" x="69.999999999999986" y="0.0" width="254.66666666666663" height="54"/>
                                         <subviews>
                                             <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Team Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5pm-5N-rYU">
-                                                <rect key="frame" x="0.0" y="0.0" width="254.5" height="37"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="254.66666666666666" height="37"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" text="Location" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ana-Js-nEd">
-                                                <rect key="frame" x="0.0" y="37" width="254.5" height="17"/>
+                                                <rect key="frame" x="0.0" y="37" width="254.66666666666666" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>


### PR DESCRIPTION
## Description
Increase the width of the number label for team # in the TeamTableViewCell so 5 number teams show properly.

## Motivation and Context
Fixes #972 

## How Has This Been Tested?
Tested in iOS 26.3 with iPhone 17 Pro in simulator. The view itself was previewed in multiple devices to make sure that nothing looked wrong.

## Screenshots
<img width="568" height="1084" alt="Screenshot 2026-04-16 at 7 38 12 PM" src="https://github.com/user-attachments/assets/240ffa58-9551-4856-b048-a332f69a43d1" />
