### PR TITLE
Migrate team media grid to compositional layout + CellRegistration

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -15,7 +15,7 @@ struct TeamMediaItem: Hashable {
 
 class TeamMediaCollectionViewController: TBACollectionViewController {
 
-    private let spacerSize: CGFloat = 3.0
+    private static let spacerSize: CGFloat = 3.0
     private static let imageTypes: Set<String> = ["imgur", "cdphotothread", "avatar", "instagram-image"]
 
     private let teamKey: String
@@ -39,6 +39,17 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
     private var imageErrors: [String: Error] = [:]
     private var downloadTasks: [String: Task<Void, Never>] = [:]
 
+    private lazy var cellRegistration = UICollectionView.CellRegistration<MediaCollectionViewCell, TeamMediaItem> { [weak self] cell, _, item in
+        guard let self else { return }
+        if let image = self.imageCache[item.foreignKey] {
+            cell.state = .loaded(image)
+        } else if let error = self.imageErrors[item.foreignKey] {
+            cell.state = .error("Error loading media - \(error.localizedDescription)")
+        } else {
+            cell.state = .loading
+        }
+    }
+
     // MARK: Init
 
     init(teamKey: String, year: Int? = nil, pasteboard: UIPasteboard = .general, photoLibrary: PHPhotoLibrary = .shared(), dependencies: Dependencies) {
@@ -47,11 +58,36 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
 
-        super.init(dependencies: dependencies)
+        super.init(collectionViewLayout: Self.makeLayout(), dependencies: dependencies)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    private static func makeLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { _, env in
+            let columns = env.traitCollection.horizontalSizeClass == .regular ? 3 : 2
+            let spacer = TeamMediaCollectionViewController.spacerSize
+            let containerWidth = env.container.effectiveContentSize.width
+            let itemWidth = (containerWidth - spacer * CGFloat(columns - 1) - 2 * spacer) / CGFloat(columns)
+
+            let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(itemWidth),
+                                                  heightDimension: .absolute(itemWidth))
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                   heightDimension: .absolute(itemWidth))
+            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, repeatingSubitem: item, count: columns)
+            group.interItemSpacing = .fixed(spacer)
+
+            let section = NSCollectionLayoutSection(group: group)
+            section.interGroupSpacing = spacer
+            section.contentInsets = NSDirectionalEdgeInsets(top: spacer, leading: spacer, bottom: spacer, trailing: spacer)
+            return section
+        }
     }
 
     // MARK: - View Lifecycle
@@ -59,7 +95,6 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        collectionView.registerReusableCell(MediaCollectionViewCell.self)
         setupDataSource()
         collectionView.dataSource = dataSource
     }
@@ -68,13 +103,6 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         super.viewWillDisappear(animated)
         downloadTasks.values.forEach { $0.cancel() }
         downloadTasks.removeAll()
-    }
-
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        DispatchQueue.main.async {
-            self.collectionView.collectionViewLayout.invalidateLayout()
-        }
     }
 
     // MARK: UICollectionView Delegate
@@ -127,18 +155,9 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
     // MARK: Data Source
 
     private func setupDataSource() {
-        dataSource = CollectionViewDataSource<String, TeamMediaItem>(collectionView: collectionView) { [weak self] collectionView, indexPath, item -> UICollectionViewCell? in
-            let cell = collectionView.dequeueReusableCell(indexPath: indexPath) as MediaCollectionViewCell
-            if let image = self?.imageCache[item.foreignKey] {
-                cell.state = .loaded(image)
-            } else if let error = self?.imageErrors[item.foreignKey] {
-                cell.state = .error("Error loading media - \(error.localizedDescription)")
-            } else if self?.isRefreshing ?? false {
-                cell.state = .loading
-            } else {
-                cell.state = .loading
-            }
-            return cell
+        dataSource = CollectionViewDataSource<String, TeamMediaItem>(collectionView: collectionView) { [weak self] collectionView, indexPath, item in
+            guard let self else { return UICollectionViewCell() }
+            return collectionView.dequeueConfiguredReusableCell(using: self.cellRegistration, for: indexPath, item: item)
         }
         dataSource.delegate = self
     }
@@ -151,33 +170,6 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
             snapshot.appendItems(items, toSection: "")
         }
         dataSource.apply(snapshot, animatingDifferences: false)
-    }
-
-}
-
-extension TeamMediaCollectionViewController: UICollectionViewDelegateFlowLayout {
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let horizontalSizeClass = traitCollection.horizontalSizeClass
-        var numberPerLine = 2
-        if horizontalSizeClass == .regular {
-            numberPerLine = 3
-        }
-        let viewWidth = collectionView.frame.size.width
-        let cellWidth = (viewWidth - CGFloat(Int(spacerSize) * (numberPerLine + 1))) / CGFloat(numberPerLine)
-        return CGSize(width: cellWidth, height: cellWidth)
-    }
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: spacerSize, left: spacerSize, bottom: spacerSize, right: spacerSize)
-    }
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return spacerSize
-    }
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return spacerSize
     }
 
 }


### PR DESCRIPTION
## Summary

Replaces the legacy `UICollectionViewFlowLayout` + `UICollectionViewDelegateFlowLayout` pipeline on `TeamMediaCollectionViewController` with an environment-aware `UICollectionViewCompositionalLayout` (iOS 13+), and folds cell registration + dequeue into a single `UICollectionView.CellRegistration<MediaCollectionViewCell, TeamMediaItem>` (iOS 14+).

**Layout**
- 2 columns on compact size class, 3 columns on regular — same as before
- Square cells sized to fill the container minus the 3pt gutters
- 3pt inter-item spacing, 3pt inter-group spacing, 3pt section insets

**Side-effects of the migration**
- `viewWillTransition(to:with:)` override + manual `invalidateLayout()` is gone — compositional layout re-resolves against the layout environment on container size changes automatically.
- The four `UICollectionViewDelegateFlowLayout` shim methods (cell size, section insets, line/inter-item spacing) are gone.
- The separate `collectionView.registerReusableCell(MediaCollectionViewCell.self)` + `dequeueReusableCell` path is replaced by one typed closure.

## Check out locally

```sh
git fetch origin zach/team-media-compositional-layout
git worktree add .claude/worktrees/team-media origin/zach/team-media-compositional-layout
cd .claude/worktrees/team-media
ln -s ../../../../the-blue-alliance-ios/Secrets.plist the-blue-alliance-ios/Secrets.plist
open "the-blue-alliance-ios.xcodeproj"
```

Build & run in Xcode (⌘R). When done:

```sh
cd -
git worktree remove .claude/worktrees/team-media
```

## Test plan

- [ ] Open any team with photos → Media tab → grid renders with 2 columns on iPhone portrait
- [ ] Rotate to landscape / iPad split screen → grid re-lays to 3 columns (regular horizontal size class) without flicker
- [ ] Scroll the grid — cell contents (loading / loaded / error) still display correctly
- [ ] Long-press a cell → context menu (View / View Online / Copy / Save) still works
- [ ] Tap a cell → image viewer opens
- [ ] Pull-to-refresh on the grid → spinner triggers and data reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)