### PR TITLE
Modernize diffable data source adoption

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/Data Sources/CollectionViewDataSource.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/Data Sources/CollectionViewDataSource.swift
@@ -14,24 +14,31 @@ class CollectionViewDataSource<Section: Hashable, Item: Hashable>: UICollectionV
         return snapshot.numberOfSections == 0 && snapshot.numberOfItems == 0
     }
 
-    // MARK: UICollectionViewDataSource
+    // MARK: - Snapshot apply
 
-    override func numberOfSections(in collectionView: UICollectionView) -> Int {
-        let sections = super.numberOfSections(in: collectionView)
-        if sections == 0 {
-            delegate?.showNoDataView()
+    override func apply(_ snapshot: NSDiffableDataSourceSnapshot<Section, Item>,
+                        animatingDifferences: Bool = true,
+                        completion: (() -> Void)? = nil) {
+        super.apply(snapshot, animatingDifferences: animatingDifferences) { [weak self] in
+            self?.updateEmptyState()
+            completion?()
         }
-        return sections
     }
 
-    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let items = super.collectionView(collectionView, numberOfItemsInSection: section)
-        if items == 0 {
+    override func applySnapshotUsingReloadData(_ snapshot: NSDiffableDataSourceSnapshot<Section, Item>,
+                                                completion: (() -> Void)? = nil) {
+        super.applySnapshotUsingReloadData(snapshot) { [weak self] in
+            self?.updateEmptyState()
+            completion?()
+        }
+    }
+
+    private func updateEmptyState() {
+        if isDataSourceEmpty {
             delegate?.showNoDataView()
         } else {
             delegate?.removeNoDataView()
         }
-        return items
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
@@ -19,25 +19,34 @@ class TableViewDataSource<Section: Hashable, Item: Hashable>: UITableViewDiffabl
         return snapshot.itemIdentifiers.isEmpty
     }
 
-    // MARK: UITableViewDataSource
+    // MARK: - Snapshot apply
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        let sections = super.numberOfSections(in: tableView)
-        if sections == 0 {
-            statefulDelegate?.showNoDataView()
+    override func apply(_ snapshot: NSDiffableDataSourceSnapshot<Section, Item>,
+                        animatingDifferences: Bool = true,
+                        completion: (() -> Void)? = nil) {
+        super.apply(snapshot, animatingDifferences: animatingDifferences) { [weak self] in
+            self?.updateEmptyState()
+            completion?()
         }
-        return sections
     }
 
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let rows = super.tableView(tableView, numberOfRowsInSection: section)
-        if rows == 0 {
+    override func applySnapshotUsingReloadData(_ snapshot: NSDiffableDataSourceSnapshot<Section, Item>,
+                                                completion: (() -> Void)? = nil) {
+        super.applySnapshotUsingReloadData(snapshot) { [weak self] in
+            self?.updateEmptyState()
+            completion?()
+        }
+    }
+
+    private func updateEmptyState() {
+        if isDataSourceEmpty {
             statefulDelegate?.showNoDataView()
         } else {
             statefulDelegate?.removeNoDataView()
         }
-        return rows
     }
+
+    // MARK: UITableViewDataSource
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return delegate?.title(forSection: section)

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -78,7 +78,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
         var snapshot = NSDiffableDataSourceSnapshot<String, DistrictRanking>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - Refreshable

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
@@ -66,7 +66,7 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
         var snapshot = NSDiffableDataSourceSnapshot<String, District>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - Refreshable

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -105,7 +105,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
         var snapshot = NSDiffableDataSourceSnapshot<String, Award>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - Refreshable

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
@@ -112,7 +112,7 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
         var snapshot = NSDiffableDataSourceSnapshot<String, TeamDistrictPointsRow>()
         snapshot.appendSections([""])
         snapshot.appendItems(sortedRows, toSection: "")
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - Refreshable

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -162,7 +162,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         snapshot.appendSections([.link])
         snapshot.appendItems(linkItems, toSection: .link)
 
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - Table View Methods

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
@@ -68,7 +68,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
         var snapshot = NSDiffableDataSourceSnapshot<String, EventRanking.RankingsPayloadPayload>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: Ranking info string

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
@@ -124,7 +124,7 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
             eventStatsConfigurator.configureDataSource(&snapshot, qual, playoff)
         }
 
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - Refreshable

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -117,7 +117,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
         var snapshot = NSDiffableDataSourceSnapshot<String, TeamStatRow>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - Interface Actions

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
@@ -76,7 +76,7 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
             snapshot.appendSections([section])
             snapshot.appendItems(grouped[section] ?? [], toSection: section)
         }
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - UITableViewDelegate

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -110,7 +110,7 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
             breakdownConfigurator.configureDataSource(&snapshot, breakdown, red, blue)
         }
 
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: - Refreshable

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -103,7 +103,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
             snapshot.appendSections([section])
             snapshot.appendItems(grouped[section] ?? [], toSection: section)
         }
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     // MARK: TableViewDataSourceDelegate

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -145,7 +145,7 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
             snapshot.appendSections([section])
             snapshot.appendItems(sorted, toSection: section)
         }
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     private func sortItems(_ items: [MyTBAItem], in section: MyTBASection) -> [MyTBAItem] {

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -117,7 +117,7 @@ class SearchViewController: TBATableViewController {
         var snapshot = NSDiffableDataSourceSnapshot<SearchSection, SearchItem>()
 
         guard !query.isEmpty, let index else {
-            dataSource.apply(snapshot, animatingDifferences: false)
+            dataSource.applySnapshotUsingReloadData(snapshot)
             return
         }
 
@@ -152,7 +152,7 @@ class SearchViewController: TBATableViewController {
             }
         }
 
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     private func matches(team: SearchIndex.TeamsPayloadPayload, query: String) -> Bool {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -99,7 +99,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
         snapshot.deleteAllItems()
 
         guard let team else {
-            dataSource.apply(snapshot, animatingDifferences: false)
+            dataSource.applySnapshotUsingReloadData(snapshot)
             return
         }
 
@@ -125,7 +125,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
         snapshot.appendSections([.link])
         snapshot.appendItems(linkItems, toSection: .link)
 
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     private func reloadSponsors() {

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -69,7 +69,7 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>: T
         var snapshot = NSDiffableDataSourceSnapshot<String, APITeam>()
         snapshot.appendSections([""])
         snapshot.appendItems(narrowed, toSection: "")
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     private func searchMatch(team: APITeam) -> Bool {


### PR DESCRIPTION
## Summary

Two improvements to the existing `TableViewDataSource` / `CollectionViewDataSource` diffable wrappers:

### 1. Empty-state observation moves to `apply` / `applySnapshotUsingReloadData`

The old wrappers overrode `numberOfSections(in:)` and `numberOf…ItemsInSection` so they could call `showNoDataView` / `removeNoDataView` from inside those callbacks. The problem: those callbacks fire many times per layout pass, so the empty-state hops were running redundantly every scroll/update.

The new wrappers override the two snapshot-apply entry points — `apply(_:animatingDifferences:completion:)` and `applySnapshotUsingReloadData(_:completion:)` — and update empty state exactly once per apply, on the completion callback. `isDataSourceEmpty` is the source of truth, same semantics as before.

### 2. `animatingDifferences: false` → `applySnapshotUsingReloadData(_:)`

15 call sites across the app used `apply(snapshot, animatingDifferences: false)`. `applySnapshotUsingReloadData(_:)` is the iOS 15+ API specifically designed for this case — it skips diff computation entirely (faster on large snapshots) and more clearly signals intent at the call site ("full reload, not animating").

Migrated files:
- Search, Match breakdown, Matches, Events list
- Event team stats / insights / info / awards / district points / rankings
- Districts list / district rankings
- Teams list / team info, MyTBA table

The one `animatingDifferences: true` site in `TeamInfoViewController.reloadSponsors` is untouched — it genuinely wants the diff animation when the "Sponsors" row expands.

### Classic `tableView.reloadData()` sites are unaffected

A handful of VCs (`MyTBAPreferenceViewController`, `SettingsViewController`, `EventAlliancesViewController`, `DistrictBreakdownViewController`, `NotificationsViewController`) call `tableView.reloadData()` directly because they use classic `UITableViewDataSource`, not the diffable wrapper. Those calls never went through the wrapper's old `numberOf…` overrides, so removing those overrides doesn't change their behavior.

## Check out locally

```sh
git fetch origin zach/diffable-datasource-modernization
git worktree add .claude/worktrees/diffable origin/zach/diffable-datasource-modernization
cd .claude/worktrees/diffable
ln -s ../../../../the-blue-alliance-ios/Secrets.plist the-blue-alliance-ios/Secrets.plist
open "the-blue-alliance-ios.xcodeproj"
```

Build & run in Xcode (⌘R). When done:

```sh
cd -
git worktree remove .claude/worktrees/diffable
```

## Test plan

Exercise every list/grid screen to confirm loading, reload, and empty states all still work:

- [ ] Launch app → Events tab loads (week events list)
- [ ] Teams tab → list loads; pull-to-refresh re-renders
- [ ] Districts tab → list loads
- [ ] Open any event → Info, Rankings, Awards, Alliances, Matches, Insights, District Points tabs each render
- [ ] Open any team → Info, Events, Media tabs render; tap into a team@event → Summary + Stats tabs render
- [ ] Search tab → type a query → see matching teams/events; clear query → list empties cleanly (empty state shows on first search with no match)
- [ ] myTBA tab (signed in) → Favorites and Subscriptions render; favorite/subscribe to a team and confirm lists update
- [ ] Open a match detail → breakdown renders; year-specific breakdown applied
- [ ] Sort/filter a matches list → matches re-render with the new ordering
- [ ] Any screen that shows a no-data state when empty → confirm it still shows the "No X for …" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)