### PR TITLE
Fix async let LIFO tear-down crash in view controllers

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -59,8 +59,10 @@ class MatchViewController: MyTBAContainerViewController {
             async let matchTask = dependencies.api.match(key: matchKey)
             async let eventTask = dependencies.api.event(key: MatchKey.eventKey(from: matchKey))
 
-            // Await in reverse declaration order so async let child tasks are
-            // torn down LIFO — otherwise swift_task_dealloc traps.
+            // Await in reverse declaration order so async let child tasks are torn
+            // down LIFO; otherwise swift_task_dealloc traps. Workaround for a Swift
+            // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
+            // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
             let event = try? await eventTask
             let match = (try? await matchTask) ?? nil
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -56,17 +56,21 @@ class MatchViewController: MyTBAContainerViewController {
 
     private func loadMatchAndEvent() {
         Task { @MainActor in
-            async let matchTask = try? await dependencies.api.match(key: matchKey)
-            async let eventTask = try? await dependencies.api.event(key: MatchKey.eventKey(from: matchKey))
-            let (match, event) = await (matchTask, eventTask)
+            async let matchTask = dependencies.api.match(key: matchKey)
+            async let eventTask = dependencies.api.event(key: MatchKey.eventKey(from: matchKey))
 
-            if let match = match ?? nil {
+            // Await in reverse declaration order so async let child tasks are
+            // torn down LIFO — otherwise swift_task_dealloc traps.
+            let event = try? await eventTask
+            let match = (try? await matchTask) ?? nil
+
+            if let match {
                 self.match = match
                 self.navigationTitle = match.friendlyName
                 self.infoViewController.apply(match: match)
                 self.breakdownViewController.apply(match: match)
             }
-            if let event = event ?? nil {
+            if let event {
                 self.navigationSubtitle = "@ \(event.friendlyNameWithYear)"
             }
         }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -57,8 +57,10 @@ class TeamAtEventViewController: ContainerViewController {
             async let eventTask = dependencies.api.event(key: eventKey)
             async let teamTask = dependencies.api.team(key: teamKey)
 
-            // Await in reverse declaration order so async let child tasks are
-            // torn down LIFO — otherwise swift_task_dealloc traps.
+            // Await in reverse declaration order so async let child tasks are torn
+            // down LIFO; otherwise swift_task_dealloc traps. Workaround for a Swift
+            // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
+            // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
             let team = (try? await teamTask) ?? nil
             let event = try? await eventTask
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -54,14 +54,18 @@ class TeamAtEventViewController: ContainerViewController {
         super.viewDidLoad()
 
         Task { @MainActor in
-            async let eventTask = try? await dependencies.api.event(key: eventKey)
-            async let teamTask = try? await dependencies.api.team(key: teamKey)
-            let (event, team) = await (eventTask, teamTask)
+            async let eventTask = dependencies.api.event(key: eventKey)
+            async let teamTask = dependencies.api.team(key: teamKey)
 
-            if let team = team ?? nil {
+            // Await in reverse declaration order so async let child tasks are
+            // torn down LIFO — otherwise swift_task_dealloc traps.
+            let team = (try? await teamTask) ?? nil
+            let event = try? await eventTask
+
+            if let team {
                 self.navigationTitle = team.teamNumberNickname
             }
-            if let event = event ?? nil {
+            if let event {
                 self.navigationSubtitle = "@ \(event.friendlyNameWithYear)"
             }
         }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -288,8 +288,10 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             async let eventTask = self.dependencies.api.event(key: self.eventKey)
             async let statusTask = self.dependencies.api.teamEventStatus(teamKey: self.teamKey, eventKey: self.eventKey)
 
-            // Await in reverse declaration order so async let child tasks are
-            // torn down LIFO — otherwise swift_task_dealloc traps.
+            // Await in reverse declaration order so async let child tasks are torn
+            // down LIFO; otherwise swift_task_dealloc traps. Workaround for a Swift
+            // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
+            // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
             let statusResult = (try? await statusTask) ?? nil
             let event = try? await eventTask
             let team = (try? await teamTask) ?? nil

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -284,26 +284,31 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
     @objc func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            async let teamTask = try? await self.dependencies.api.team(key: self.teamKey)
-            async let eventTask = try? await self.dependencies.api.event(key: self.eventKey)
-            async let statusTask = try? await self.dependencies.api.teamEventStatus(teamKey: self.teamKey, eventKey: self.eventKey)
+            async let teamTask = self.dependencies.api.team(key: self.teamKey)
+            async let eventTask = self.dependencies.api.event(key: self.eventKey)
+            async let statusTask = self.dependencies.api.teamEventStatus(teamKey: self.teamKey, eventKey: self.eventKey)
 
-            let (team, event, statusResult) = await (teamTask, eventTask, statusTask)
-            self.team = team ?? nil
-            self.event = event ?? nil
-            self.eventStatus = statusResult ?? nil
+            // Await in reverse declaration order so async let child tasks are
+            // torn down LIFO — otherwise swift_task_dealloc traps.
+            let statusResult = (try? await statusTask) ?? nil
+            let event = try? await eventTask
+            let team = (try? await teamTask) ?? nil
+            self.team = team
+            self.event = event
+            self.eventStatus = statusResult
 
-            async let nextTask: Match?? = {
-                guard let key = self.eventStatus?.nextMatchKey else { return Optional<Match?>.none }
-                return try? await self.dependencies.api.match(key: key)
+            async let nextTask: Match? = {
+                guard let key = self.eventStatus?.nextMatchKey else { return nil }
+                return (try? await self.dependencies.api.match(key: key)) ?? nil
             }()
-            async let lastTask: Match?? = {
-                guard let key = self.eventStatus?.lastMatchKey else { return Optional<Match?>.none }
-                return try? await self.dependencies.api.match(key: key)
+            async let lastTask: Match? = {
+                guard let key = self.eventStatus?.lastMatchKey else { return nil }
+                return (try? await self.dependencies.api.match(key: key)) ?? nil
             }()
-            let (nextResult, lastResult) = await (nextTask, lastTask)
-            self.nextMatch = (nextResult ?? nil) ?? nil
-            self.lastMatch = (lastResult ?? nil) ?? nil
+            let lastResult = await lastTask
+            let nextResult = await nextTask
+            self.nextMatch = nextResult
+            self.lastMatch = lastResult
 
             self.rebuildSnapshot()
         }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -83,16 +83,20 @@ class TeamViewController: HeaderContainerViewController {
 
     private func loadTeamData() {
         Task { @MainActor in
-            async let teamTask = try? await dependencies.api.team(key: teamKey)
-            async let yearsTask = try? await dependencies.api.teamYearsParticipated(key: teamKey)
-            let (team, years) = await (teamTask, yearsTask)
+            async let teamTask = dependencies.api.team(key: teamKey)
+            async let yearsTask = dependencies.api.teamYearsParticipated(key: teamKey)
 
-            if let team = team ?? nil {
+            // Await in reverse declaration order so async let child tasks are
+            // torn down LIFO — otherwise swift_task_dealloc traps.
+            let years = try? await yearsTask
+            let team = (try? await teamTask) ?? nil
+
+            if let team {
                 self.team = team
                 self.navigationTitle = team.teamNumberNickname
                 self.infoViewController.apply(team: team)
             }
-            if let years = years ?? nil {
+            if let years {
                 self.yearsParticipated = years.sorted().reversed()
                 if year == nil {
                     year = Self.latestYear(currentSeason: statusService.currentSeason, years: yearsParticipated)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -86,8 +86,10 @@ class TeamViewController: HeaderContainerViewController {
             async let teamTask = dependencies.api.team(key: teamKey)
             async let yearsTask = dependencies.api.teamYearsParticipated(key: teamKey)
 
-            // Await in reverse declaration order so async let child tasks are
-            // torn down LIFO — otherwise swift_task_dealloc traps.
+            // Await in reverse declaration order so async let child tasks are torn
+            // down LIFO; otherwise swift_task_dealloc traps. Workaround for a Swift
+            // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
+            // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
             let years = try? await yearsTask
             let team = (try? await teamTask) ?? nil
 


### PR DESCRIPTION
## Summary

A beta tester reported a `SIGABRT` from `MatchViewController.loadMatchAndEvent()` — the Swift runtime trapped in `swift_task_dealloc` inside `asyncLet_finish_after_task_completion`:

```
4 libswift_Concurrency.dylib  swift::swift_Concurrency_fatalError
6 libswift_Concurrency.dylib  swift_task_dealloc + 128
7 libswift_Concurrency.dylib  asyncLet_finish_after_task_completion
8 The Blue Alliance           partial apply for closure #1 in MatchViewController.loadMatchAndEvent()
```

Root cause is a Swift 6.1 compiler bug ([swiftlang/swift#81771](https://github.com/swiftlang/swift/issues/81771)): the SIL `StackNesting` pass doesn't recognize `StartAsyncLetWithLocalBuffer` / `FinishAsyncLet` as stack operations, and the task-allocator intrinsics are annotated `ArgMemOnly` so LLVM can hoist dealloc calls across suspension boundaries. Result: `async let` child tasks can be torn down out of LIFO order, tripping the runtime's allocator consistency check.

The existing pattern in four view controllers:
```swift
async let aTask = try? await api.foo()
async let bTask = try? await api.bar()
let (a, b) = await (aTask, bTask)
```
awaits in declaration order, which happens to be the opposite of LIFO.

## Fix

Await each `async let` explicitly in reverse declaration order, and hoist `try?` out of the `async let` RHS (it was producing doubly-wrapped optionals like `Team??` that required `?? nil` flattening at each use site).

Applied to all four call sites:
- `MatchViewController` (the one that crashed)
- `TeamAtEventViewController`
- `TeamViewController`
- `TeamSummaryViewController`

This is a workaround, not a permanent fix — the upstream compiler fix is in [swiftlang/swift#88225](https://github.com/swiftlang/swift/pull/88225), expected in Swift 6.3. Tracking issue #996 filed to remove the workaround once Swift 6.3 is the project's minimum. Each workaround site has a comment pointing at that tracking issue.

## Test plan

All four are view-controller `viewDidLoad`/`refresh` paths that fan out two or three API calls in parallel. UI behavior should be identical to before; this fix is purely about task cleanup ordering.

- [ ] Open a match detail screen (tap any match in a schedule) — nav title updates to the match's friendly name, subtitle shows `@ <event name>`. This is the one the tester crashed on.
- [ ] Open a team detail screen (any team from Teams tab) — nav title shows "Team N", years-participated selector populates.
- [ ] Open a team@event screen (tap a team from an event's teams list) — nav title = "Team N", subtitle = `@ <event name>`.
- [ ] On a team@event, pull-to-refresh — status cell, next match, and last match all reload.
- [ ] Exercise the above on a throttled/offline connection (Network Link Conditioner) — partial failures should still render whatever succeeded, same as before.
- [ ] Rapidly push-then-pop a match VC (tap a match, tap back before it finishes loading) — exercises cancellation of the parent `Task`, which is the most likely scenario that triggered the original crash. Do ~20 times, no `swift_task_dealloc` trap should appear.

Screenshots of match detail and team detail screens welcome if anything looks off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)