### PR TITLE
Load TeamSimple for all-teams/district lists, keep Team for events

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
@@ -18,4 +18,5 @@ public typealias Media = Components.Schemas.Media
 public typealias SearchIndex = Components.Schemas.SearchIndex
 public typealias Team = Components.Schemas.Team
 public typealias TeamEventStatus = Components.Schemas.TeamEventStatus
+public typealias TeamSimple = Components.Schemas.TeamSimple
 public typealias Webcast = Components.Schemas.Webcast

--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
@@ -9,6 +9,7 @@ public protocol TBAAPIProtocol {
 
     // Teams
     func allTeams() async throws -> [Team]
+    func allTeamsSimple() async throws -> [TeamSimple]
     func team(key teamKey: String) async throws -> Team?
     func teamYearsParticipated(key teamKey: String) async throws -> [Int]
     func teamEventsByYear(key teamKey: String, year: Int) async throws -> [Event]
@@ -34,5 +35,6 @@ public protocol TBAAPIProtocol {
     func districtsByYear(_ year: Int) async throws -> [District]
     func districtEvents(key districtKey: String) async throws -> [Event]
     func districtTeams(key districtKey: String) async throws -> [Team]
+    func districtTeamsSimple(key districtKey: String) async throws -> [TeamSimple]
     func districtRankings(key districtKey: String) async throws -> [DistrictRanking]
 }

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APITeam+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APITeam+Helpers.swift
@@ -1,8 +1,17 @@
 import Foundation
 import TBAAPI
 
-extension Team {
+protocol TeamDisplayable {
+    var key: String { get }
+    var teamNumber: Int { get }
+    var nickname: String { get }
+    var name: String { get }
+    var city: String? { get }
+    var stateProv: String? { get }
+    var country: String? { get }
+}
 
+extension TeamDisplayable {
     // Matches the TBAData.Team.teamNumberNickname ("Team 254").
     var teamNumberNickname: String { "Team \(teamNumber)" }
 
@@ -11,11 +20,23 @@ extension Team {
         nickname.isEmpty ? teamNumberNickname : nickname
     }
 
+    var locationString: String? {
+        let parts = [city, stateProv, country].compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}
+
+extension TeamSimple: TeamDisplayable {}
+
+extension Team: TeamDisplayable {
+
     var hasWebsite: Bool {
         guard let website else { return false }
         return !website.isEmpty
     }
 
+    // `Team` carries the parsed `locationName` field; use it as a fallback when
+    // city/state/country are all empty. `TeamSimple` lacks this field.
     var locationString: String? {
         let parts = [city, stateProv, country].compactMap { $0 }.filter { !$0.isEmpty }
         return parts.isEmpty ? locationName : parts.joined(separator: ", ")

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Districts.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Districts.swift
@@ -51,6 +51,22 @@ extension TBAAPI {
         }
     }
 
+    public func districtTeamsSimple(key districtKey: String) async throws -> [TeamSimple] {
+        let response = try await client.getDistrictTeamsSimple(path: .init(districtKey: districtKey))
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json
+        case .notModified:
+            throw TBAAPIError.notModified
+        case .unauthorized:
+            throw TBAAPIError.unauthorized
+        case .notFound:
+            throw TBAAPIError.notFound
+        case .undocumented(let statusCode, _):
+            throw TBAAPIError.unexpectedStatus(statusCode)
+        }
+    }
+
     public func districtRankings(key districtKey: String) async throws -> [DistrictRanking] {
         let response = try await client.getDistrictRankings(path: .init(districtKey: districtKey))
         switch response {

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift
@@ -26,6 +26,27 @@ extension TBAAPI {
         return all
     }
 
+    public func allTeamsSimple() async throws -> [TeamSimple] {
+        var all: [TeamSimple] = []
+        var page = 0
+        while true {
+            let response = try await client.getTeamsSimple(path: .init(pageNum: page))
+            let batch: [TeamSimple]
+            switch response {
+            case .ok(let ok):
+                batch = try ok.body.json
+            case .notModified, .unauthorized, .notFound:
+                return all
+            case .undocumented(let statusCode, _):
+                throw TBAAPIError.unexpectedStatus(statusCode)
+            }
+            if batch.isEmpty { break }
+            all.append(contentsOf: batch)
+            page += 1
+        }
+        return all
+    }
+
     public func team(key teamKey: String) async throws -> Team? {
         let response = try await client.getTeam(path: .init(teamKey: teamKey))
         switch response {

--- a/the-blue-alliance-ios/Protocols/SearchContainer.swift
+++ b/the-blue-alliance-ios/Protocols/SearchContainer.swift
@@ -63,8 +63,8 @@ extension SearchContainerDelegate where Self: ContainerViewController {
         navigationController?.pushViewController(teamViewController, animated: true)
     }
 
-    func teamSelected(_ team: Team) {
-        let teamViewController = TeamViewController(team: team, dependencies: dependencies)
+    func teamSelected(_ team: any TeamDisplayable) {
+        let teamViewController = TeamViewController(teamKey: team.key, nickname: team.nickname, dependencies: dependencies)
         navigationController?.pushViewController(teamViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictTeamsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictTeamsViewController.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TBAAPI
 
-class DistrictTeamsViewController: TeamsListViewController {
+class DistrictTeamsViewController: TeamsListViewController<TeamSimple> {
 
     let districtKey: String
     let year: Int
@@ -17,8 +17,8 @@ class DistrictTeamsViewController: TeamsListViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func loadTeams() async throws -> [APITeam] {
-        try await dependencies.api.districtTeams(key: districtKey)
+    override func loadTeams() async throws -> [TeamSimple] {
+        try await dependencies.api.districtTeamsSimple(key: districtKey)
     }
 
     override var noDataText: String? { "No teams for district" }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictViewController.swift
@@ -62,8 +62,8 @@ extension DistrictViewController: EventsListViewControllerDelegate {
 
 extension DistrictViewController: TeamsListViewControllerDelegate {
 
-    func teamSelected(_ team: Team) {
-        let teamViewController = TeamViewController(team: team, dependencies: dependencies)
+    func teamSelected(_ team: any TeamDisplayable) {
+        let teamViewController = TeamViewController(teamKey: team.key, nickname: team.nickname, dependencies: dependencies)
         self.navigationController?.pushViewController(teamViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TBAAPI
 
-class EventTeamsViewController: TeamsListViewController {
+class EventTeamsViewController: TeamsListViewController<Team> {
 
     let eventKey: String
 
@@ -17,7 +17,7 @@ class EventTeamsViewController: TeamsListViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func loadTeams() async throws -> [APITeam] {
+    override func loadTeams() async throws -> [Team] {
         try await dependencies.api.eventTeams(key: eventKey)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -127,7 +127,7 @@ extension EventViewController: EventInfoViewControllerDelegate {
 
 extension EventViewController: TeamsListViewControllerDelegate {
 
-    func teamSelected(_ team: Team) {
+    func teamSelected(_ team: any TeamDisplayable) {
         pushTeamAtEvent(teamKey: team.key)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -2,12 +2,10 @@ import TBAAPI
 import UIKit
 
 protocol TeamsListViewControllerDelegate: AnyObject {
-    func teamSelected(_ team: Team)
+    func teamSelected(_ team: any TeamDisplayable)
 }
 
-class TeamsListViewController: TBASearchableTableViewController, Refreshable, Stateful {
-
-    typealias APITeam = Team
+class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>: TBASearchableTableViewController, Refreshable, Stateful {
 
     weak var delegate: TeamsListViewControllerDelegate?
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsViewController.swift
@@ -1,9 +1,9 @@
 import Foundation
 import TBAAPI
 
-class TeamsViewController: TeamsListViewController {
+class TeamsViewController: TeamsListViewController<TeamSimple> {
 
-    override func loadTeams() async throws -> [APITeam] {
-        try await dependencies.api.allTeams()
+    override func loadTeams() async throws -> [TeamSimple] {
+        try await dependencies.api.allTeamsSimple()
     }
 }


### PR DESCRIPTION
## Summary
- Make `TeamsListViewController` generic over `APITeam: TeamDisplayable & Hashable & Sendable`, so each subclass picks the concrete model that fits its endpoint instead of the base class dictating one
- `TeamsViewController` and `DistrictTeamsViewController` now fetch `TeamSimple` (new `allTeamsSimple()` / `districtTeamsSimple(key:)` helpers wrapping the existing TBA `/simple` endpoints); the ~9k-team all-teams list is the main perf win
- `EventTeamsViewController` keeps loading the full `Team` — per-event lists are small and the extra fields stay available downstream
- Small `TeamDisplayable` protocol carries the fields the shared list cell and search filter actually use; `Team` and `TeamSimple` both conform, delegate methods take `any TeamDisplayable`

## Test plan
- [x] Launch app; open the Teams tab — list populates with all teams, scrolls smoothly, and loads noticeably faster than before
- [x] Search in the Teams tab by number, nickname, name, city, state, country — each still matches
- [x] Tap a team from the Teams tab — detail view opens and loads the full team
- [x] Open a District → Teams tab — list populates; tap a team, detail view opens correctly
- [x] Open an Event → Teams tab — list populates (still loading full `Team`); tap a team, `TeamAtEvent` pushes as before
- [x] Pull-to-refresh works in each of the three team lists