### PR TITLE
Drop async let in Team@Event VCs to dodge swift_task_dealloc LIFO trap

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -54,15 +54,16 @@ class TeamAtEventViewController: ContainerViewController {
         super.viewDidLoad()
 
         Task { @MainActor in
-            async let eventTask = dependencies.api.event(key: eventKey)
-            async let teamTask = dependencies.api.team(key: teamKey)
-
-            // Await in reverse declaration order so async let child tasks are torn
-            // down LIFO; otherwise swift_task_dealloc traps. Workaround for a Swift
-            // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
+            // Unstructured Task handles instead of `async let`: Swift 6.1's
+            // async-let stack allocator trips swift_task_dealloc's LIFO check
+            // here even with reverse-order awaits (#995 didn't fully fix it).
+            // Task handles heap-allocate and sidestep the allocator entirely.
             // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
-            let team = (try? await teamTask) ?? nil
-            let event = try? await eventTask
+            let eventHandle = Task { try? await self.dependencies.api.event(key: self.eventKey) }
+            let teamHandle = Task { try? await self.dependencies.api.team(key: self.teamKey) }
+
+            let team = (await teamHandle.value) ?? nil
+            let event = await eventHandle.value
 
             if let team {
                 self.navigationTitle = team.teamNumberNickname

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -284,33 +284,29 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            async let teamTask = self.dependencies.api.team(key: self.teamKey)
-            async let eventTask = self.dependencies.api.event(key: self.eventKey)
-            async let statusTask = self.dependencies.api.teamEventStatus(teamKey: self.teamKey, eventKey: self.eventKey)
-
-            // Await in reverse declaration order so async let child tasks are torn
-            // down LIFO; otherwise swift_task_dealloc traps. Workaround for a Swift
-            // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
+            // Unstructured Task handles instead of `async let`: Swift 6.1's
+            // async-let stack allocator trips swift_task_dealloc's LIFO check
+            // here even with reverse-order awaits (#995 didn't fully fix it).
+            // Task handles heap-allocate and sidestep the allocator entirely.
             // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
-            let statusResult = (try? await statusTask) ?? nil
-            let event = try? await eventTask
-            let team = (try? await teamTask) ?? nil
-            self.team = team
-            self.event = event
-            self.eventStatus = statusResult
+            let teamHandle = Task { try? await self.dependencies.api.team(key: self.teamKey) }
+            let eventHandle = Task { try? await self.dependencies.api.event(key: self.eventKey) }
+            let statusHandle = Task { try? await self.dependencies.api.teamEventStatus(teamKey: self.teamKey, eventKey: self.eventKey) }
 
-            async let nextTask: Match? = {
+            self.team = (await teamHandle.value) ?? nil
+            self.event = await eventHandle.value
+            self.eventStatus = (await statusHandle.value) ?? nil
+
+            let nextHandle = Task { () -> Match? in
                 guard let key = self.eventStatus?.nextMatchKey else { return nil }
                 return (try? await self.dependencies.api.match(key: key)) ?? nil
-            }()
-            async let lastTask: Match? = {
+            }
+            let lastHandle = Task { () -> Match? in
                 guard let key = self.eventStatus?.lastMatchKey else { return nil }
                 return (try? await self.dependencies.api.match(key: key)) ?? nil
-            }()
-            let lastResult = await lastTask
-            let nextResult = await nextTask
-            self.nextMatch = nextResult
-            self.lastMatch = lastResult
+            }
+            self.nextMatch = await nextHandle.value
+            self.lastMatch = await lastHandle.value
 
             self.rebuildSnapshot()
         }


### PR DESCRIPTION
## Summary

- Beta tester hit the same `swift_task_dealloc` → `asyncLet_finish_after_task_completion` SIGABRT that #995 was supposed to fix, this time reliably on initial load of the Team@Event view. The reverse-order-await workaround evidently doesn't cover every shape of call site the Swift 6.1 compiler miscompiles.
- Swap `async let` for unstructured `Task { ... }` handles in `TeamAtEventViewController.viewDidLoad` and `TeamSummaryViewController.refresh`. Unstructured Tasks heap-allocate their storage instead of using the enclosing task's stack allocator, so the LIFO consistency check has nothing to trip on. Parallelism is preserved.
- Leaving `MatchViewController` and `TeamViewController` on the reverse-order-await workaround for now — they haven't been reported as crashing, and #996 tracks reverting all four sites to a clean `async let` pattern once Swift 6.3 is our minimum.

## Test plan

- [ ] Build and run on the simulator
- [ ] Open any Team@Event view (e.g. from an event's teams list, or from the team-awards flow) — verify no SIGABRT on initial load
- [ ] Pull-to-refresh on Team@Event Summary — verify no crash and data reloads
- [ ] Rapid pull-to-refresh (cancel in-flight refresh) — verify no crash
- [ ] Navigate Team@Event → another Team@Event via the awards tap — verify no crash on the push
- [ ] Verify the other four VCs that still use the reverse-order-await pattern (`MatchViewController`, `TeamViewController`) still load cleanly

Fixes the reproducer on top of #995. Tracking issue: #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)