### PR TITLE
Fix year button stretching in TeamHeaderView

### DIFF
--- a/the-blue-alliance-ios/ViewElements/Teams/TeamHeaderView.swift
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamHeaderView.swift
@@ -58,6 +58,7 @@ class TeamHeaderView: UIView {
 
         let stackView = UIStackView(arrangedSubviews: [spacerView, yearButton])
         stackView.axis = .vertical
+        stackView.alignment = .trailing
         yearButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         yearButton.setContentHuggingPriority(.required, for: .vertical)
         return stackView
@@ -199,7 +200,7 @@ class YearButton: UIButton {
         config.baseForegroundColor = UIColor.navigationBarTintColor
         config.background.backgroundColor = UIColor.white
         config.cornerStyle = .capsule
-        config.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 6)
+        config.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 8)
         config.image = UIImage(systemName: "chevron.down")
         config.imagePlacement = .trailing
         config.imagePadding = 2


### PR DESCRIPTION
## Summary
- Set `yearStackView.alignment = .trailing` so the year button sizes to its intrinsic width instead of being stretched by the stack's default `.fill` alignment (which adds explicit width constraints that override content hugging).
- Revert the year button's `contentInsets` to `leading: 10, trailing: 8` — the prior shrink to `8/6` was over-eager; the real bug was the stretch, not the padding.

## Test plan
- [ ] Open a team page and confirm the year button is a compact pill anchored to the trailing edge of the header.
- [ ] Verify tap target still works (44pt minimum via `hitTest` override).
- [ ] Try with a long team nickname (multi-line) — year button should stay the same size and sit at the bottom-right.
- [ ] Try with no nickname and with a team that has no avatar — layout should still look right.
- [ ] Scroll the team page and confirm the header glides under the nav bar as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)