### PR TITLE
Archive dSYMs as CI artifacts and fix Crashlytics upload

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -55,3 +55,13 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           SLACK_URL: ${{ secrets.SLACK_URL }}
+      - name: Archive dSYMs
+        if: ${{ always() && (contains(github.event.head_commit.message, '[beta]') || contains(github.event.head_commit.message, '[app_store]')) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsyms-${{ github.ref_name }}-${{ github.run_number }}
+          path: |
+            **/*.dSYM.zip
+            **/*.dSYM
+          if-no-files-found: warn
+          retention-days: 90

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,17 @@ platform :ios do
     set_info_plist_value(path: "the-blue-alliance-ios/Secrets.plist", key: "tba_api_key", value: ENV["TBA_API_KEY"])
   end
 
+  desc "Download dSYMs for a specific build. Usage: fastlane dsyms version:3.2.3 build:2"
+  lane :dsyms do |options|
+    setup_api
+    download_dsyms(
+      version: options[:version],
+      build_number: options[:build],
+      app_identifier: "com.the-blue-alliance.tba",
+      output_directory: options[:output] || "./dsyms"
+    )
+  end
+
   desc "Configure code signing"
   private_lane :configure_code_signing do
     if is_ci?
@@ -142,7 +153,10 @@ platform :ios do
       code_signing_identity: "iPhone Distribution"
     )
     gym(buildlog_path: "logs")
-    # upload_symbols_to_crashlytics(dsym_path: "The Blue Alliance.app.dSYM.zip", gsp_path: "the-blue-alliance-ios/GoogleService-Info.plist")
+    upload_symbols_to_crashlytics(
+      dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+      gsp_path: "the-blue-alliance-ios/GoogleService-Info.plist"
+    )
   end
 
   ## End Shipping Lanes for Release Lanes ##


### PR DESCRIPTION
- Add "Archive dSYMs" step to push workflow that uploads dSYM files as build artifacts (90-day retention) on beta and app_store runs
- Replace commented-out upload_symbols_to_crashlytics with working call using gym's DSYM_OUTPUT_PATH instead of a hardcoded filename
- Add `dsyms` lane to download dSYMs from ASC for a specific version/build

Ported from #1002.
