### PR TITLE
Mirror OpenAPI body nullability in TBAAPI wrapper returns

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
@@ -10,31 +10,31 @@ public protocol TBAAPIProtocol {
     // Teams
     func allTeams() async throws -> [Team]
     func allTeamsSimple() async throws -> [TeamSimple]
-    func team(key teamKey: String) async throws -> Team?
+    func team(key teamKey: String) async throws -> Team
     func teamYearsParticipated(key teamKey: String) async throws -> [Int]
     func teamEventsByYear(key teamKey: String, year: Int) async throws -> [Event]
     func teamEventMatches(teamKey: String, eventKey: String) async throws -> [Match]
     func teamEventAwards(teamKey: String, eventKey: String) async throws -> [Award]
-    func teamEventStatus(teamKey: String, eventKey: String) async throws -> TeamEventStatus?
+    func teamEventStatus(teamKey: String, eventKey: String) async throws -> TeamEventStatus
     func teamMediaByYear(teamKey: String, year: Int) async throws -> [Media]
 
     // Events
     func eventsByYear(_ year: Int) async throws -> [Event]
     func event(key eventKey: String) async throws -> Event
     func eventTeams(key eventKey: String) async throws -> [Team]
-    func eventRankings(key eventKey: String) async throws -> EventRanking?
+    func eventRankings(key eventKey: String) async throws -> EventRanking
     func eventAlliances(key eventKey: String) async throws -> [EliminationAlliance]?
     func eventAwards(key eventKey: String) async throws -> [Award]
-    func eventDistrictPoints(key eventKey: String) async throws -> EventDistrictPoints?
-    func eventInsights(key eventKey: String) async throws -> EventInsights?
+    func eventDistrictPoints(key eventKey: String) async throws -> EventDistrictPoints
+    func eventInsights(key eventKey: String) async throws -> EventInsights
     func eventMatches(key eventKey: String) async throws -> [Match]
-    func match(key matchKey: String) async throws -> Match?
-    func eventOPRs(key eventKey: String) async throws -> EventOPRs?
+    func match(key matchKey: String) async throws -> Match
+    func eventOPRs(key eventKey: String) async throws -> EventOPRs
 
     // Districts
     func districtsByYear(_ year: Int) async throws -> [District]
     func districtEvents(key districtKey: String) async throws -> [Event]
     func districtTeams(key districtKey: String) async throws -> [Team]
     func districtTeamsSimple(key districtKey: String) async throws -> [TeamSimple]
-    func districtRankings(key districtKey: String) async throws -> [DistrictRanking]
+    func districtRankings(key districtKey: String) async throws -> [DistrictRanking]?
 }

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Districts.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Districts.swift
@@ -67,11 +67,11 @@ extension TBAAPI {
         }
     }
 
-    public func districtRankings(key districtKey: String) async throws -> [DistrictRanking] {
+    public func districtRankings(key districtKey: String) async throws -> [DistrictRanking]? {
         let response = try await client.getDistrictRankings(path: .init(districtKey: districtKey))
         switch response {
         case .ok(let ok):
-            return try ok.body.json ?? []
+            return try ok.body.json
         case .notModified:
             throw TBAAPIError.notModified
         case .unauthorized:

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Events.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Events.swift
@@ -51,7 +51,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventRankings(key eventKey: String) async throws -> EventRanking? {
+    public func eventRankings(key eventKey: String) async throws -> EventRanking {
         let response = try await client.getEventRankings(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -99,7 +99,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventDistrictPoints(key eventKey: String) async throws -> EventDistrictPoints? {
+    public func eventDistrictPoints(key eventKey: String) async throws -> EventDistrictPoints {
         let response = try await client.getEventDistrictPoints(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -115,7 +115,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventInsights(key eventKey: String) async throws -> EventInsights? {
+    public func eventInsights(key eventKey: String) async throws -> EventInsights {
         let response = try await client.getEventInsights(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -147,7 +147,7 @@ extension TBAAPI {
         }
     }
 
-    public func match(key matchKey: String) async throws -> Match? {
+    public func match(key matchKey: String) async throws -> Match {
         let response = try await client.getMatch(path: .init(matchKey: matchKey))
         switch response {
         case .ok(let ok):
@@ -163,7 +163,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventOPRs(key eventKey: String) async throws -> EventOPRs? {
+    public func eventOPRs(key eventKey: String) async throws -> EventOPRs {
         let response = try await client.getEventOPRs(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift
@@ -47,7 +47,7 @@ extension TBAAPI {
         return all
     }
 
-    public func team(key teamKey: String) async throws -> Team? {
+    public func team(key teamKey: String) async throws -> Team {
         let response = try await client.getTeam(path: .init(teamKey: teamKey))
         switch response {
         case .ok(let ok):
@@ -127,7 +127,7 @@ extension TBAAPI {
         }
     }
 
-    public func teamEventStatus(teamKey: String, eventKey: String) async throws -> TeamEventStatus? {
+    public func teamEventStatus(teamKey: String, eventKey: String) async throws -> TeamEventStatus {
         let response = try await client.getTeamEventStatus(path: .init(teamKey: teamKey, eventKey: eventKey))
         switch response {
         case .ok(let ok):

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -88,7 +88,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey)
+            let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey) ?? []
             self.allRankings = fetched
             self.applyRankings(fetched)
         }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
@@ -86,7 +86,7 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Stat
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey)
-            if let updated = fetched.first(where: { $0.teamKey == self.teamKey }) {
+            if let updated = fetched?.first(where: { $0.teamKey == self.teamKey }) {
                 self.ranking = updated
                 self.tableView.reloadData()
             }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
@@ -89,7 +89,7 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable, St
         runRefresh { [weak self] in
             guard let self else { return }
             let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey)
-            if let updated = fetched.first(where: { $0.teamKey == self.teamKey }) {
+            if let updated = fetched?.first(where: { $0.teamKey == self.teamKey }) {
                 self.ranking = updated
                 self.tableView.reloadData()
             }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
@@ -136,8 +136,8 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
         runRefresh { [weak self] in
             guard let self else { return }
             let insights = try await self.dependencies.api.eventInsights(key: self.eventKey)
-            self.configureDataSource(qual: Self.toAnyDict(insights?.qual),
-                                     playoff: Self.toAnyDict(insights?.playoff))
+            self.configureDataSource(qual: Self.toAnyDict(insights.qual),
+                                     playoff: Self.toAnyDict(insights.playoff))
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -121,9 +121,8 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
         guard breakdownConfigurator != nil else { return }
         runRefresh { [weak self] in
             guard let self else { return }
-            if let fetched = try await self.dependencies.api.match(key: self.matchKey) {
-                self.apply(match: fetched)
-            }
+            let fetched = try await self.dependencies.api.match(key: self.matchKey)
+            self.apply(match: fetched)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -169,9 +169,8 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            if let fetched = try await self.api.match(key: self.matchKey) {
-                self.apply(match: fetched)
-            }
+            let fetched = try await self.api.match(key: self.matchKey)
+            self.apply(match: fetched)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -64,7 +64,8 @@ class MatchViewController: MyTBAContainerViewController {
             // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
             // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
             let event = try? await eventTask
-            let match = (try? await matchTask) ?? nil
+            let match = try? await matchTask
+
 
             if let match {
                 self.match = match

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -236,14 +236,14 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
                 case .team(let key) where teamsCache[key] == nil:
                     group.addTask { [weak self] in
                         guard let self = self else { return }
-                        if let team = try? await self.dependencies.api.team(key: key) ?? nil {
+                        if let team = try? await self.dependencies.api.team(key: key) {
                             await MainActor.run { self.teamsCache[key] = team }
                         }
                     }
                 case .match(let key) where matchesCache[key] == nil:
                     group.addTask { [weak self] in
                         guard let self = self else { return }
-                        if let match = try? await self.dependencies.api.match(key: key) ?? nil {
+                        if let match = try? await self.dependencies.api.match(key: key) {
                             await MainActor.run { self.matchesCache[key] = match }
                         }
                     }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -62,8 +62,9 @@ class TeamAtEventViewController: ContainerViewController {
             let eventHandle = Task { try? await self.dependencies.api.event(key: self.eventKey) }
             let teamHandle = Task { try? await self.dependencies.api.team(key: self.teamKey) }
 
-            let team = (await teamHandle.value) ?? nil
+            let team = await teamHandle.value
             let event = await eventHandle.value
+
 
             if let team {
                 self.navigationTitle = team.teamNumberNickname

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -293,17 +293,17 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             let eventHandle = Task { try? await self.dependencies.api.event(key: self.eventKey) }
             let statusHandle = Task { try? await self.dependencies.api.teamEventStatus(teamKey: self.teamKey, eventKey: self.eventKey) }
 
-            self.team = (await teamHandle.value) ?? nil
+            self.team = await teamHandle.value
             self.event = await eventHandle.value
-            self.eventStatus = (await statusHandle.value) ?? nil
+            self.eventStatus = await statusHandle.value
 
             let nextHandle = Task { () -> Match? in
                 guard let key = self.eventStatus?.nextMatchKey else { return nil }
-                return (try? await self.dependencies.api.match(key: key)) ?? nil
+                return try? await self.dependencies.api.match(key: key)
             }
             let lastHandle = Task { () -> Match? in
                 guard let key = self.eventStatus?.lastMatchKey else { return nil }
-                return (try? await self.dependencies.api.match(key: key)) ?? nil
+                return try? await self.dependencies.api.match(key: key)
             }
             self.nextMatch = await nextHandle.value
             self.lastMatch = await lastHandle.value

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -215,10 +215,9 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            if let fetched = try await self.api.team(key: self.teamKey) {
-                self.team = fetched
-                self.updateTeamInfo()
-            }
+            let fetched = try await self.api.team(key: self.teamKey)
+            self.team = fetched
+            self.updateTeamInfo()
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -112,7 +112,8 @@ class TeamViewController: HeaderContainerViewController {
             // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
             // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
             let years = try? await yearsTask
-            let team = (try? await teamTask) ?? nil
+            let team = try? await teamTask
+
 
             if let team {
                 self.team = team


### PR DESCRIPTION
## Summary
- Align every hand-written wrapper return type with the auto-generated OpenAPI client: 6 methods drop `?` (generated body is non-optional), `districtRankings` adopts `[DistrictRanking]?` (the spec declares `"type": ["null", "array"]` — the wrapper was hiding this with `?? []`), and `event(key:)` stops being the lone non-optional outlier by becoming the template.
- `TBAAPIError` unchanged — both `.notFound` (404) and `.notModified` (304, surfaced by URLSession's built-in conditional-GET handling) remain load-bearing so callers using `try?` naturally preserve existing view state when resources are missing or unchanged.
- Call sites updated to drop now-redundant `?? nil` double-optional unwraps; three `districtRankings` call sites updated to handle the newly-surfaced optional (`?? []` at the ranking list site; `fetched?.first(where:)` at the lookup sites).

## Test plan
- [x] `xcodebuild -project the-blue-alliance-ios.xcodeproj -scheme "The Blue Alliance" -destination 'platform=iOS Simulator,name=iPhone 17' build` — clean build passes
- [x] `swift test` in `Packages/TBAAPI` — passes
- [x] App launches in iOS 26.2 simulator and loads the Events list
- [ ] Smoke-test Team detail → `team(key:)`
- [ ] Smoke-test Team @ Event → `teamEventStatus`, `match(key:)` for next/last match
- [ ] Smoke-test Event detail → Rankings / Alliances / District Points / Insights / OPRs tabs
- [ ] Smoke-test District detail → Rankings tab + drill into a team row
- [ ] Smoke-test MyTBA favorites list — resolves team/match keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)