### PR TITLE
Fix Team@Event Summary section ordering and date-range timezone bugs

### DIFF
--- a/Packages/TBAUtils/Sources/TBAUtils/Calendar/Calendar+TBA.swift
+++ b/Packages/TBAUtils/Sources/TBAUtils/Calendar/Calendar+TBA.swift
@@ -11,6 +11,15 @@ public enum Weekday: Int {
 
 extension Calendar {
 
+    /// Gregorian calendar fixed to UTC. Use when the Date being operated on
+    /// was parsed in UTC (e.g. TBA's `yyyy-MM-dd` event dates), so day-level
+    /// math like `endOfDay` doesn't clip against the user's local offset.
+    public static let utc: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        return calendar
+    }()
+
     /**
      Number of weeks the season is - safely hardcoded to 6.
      */

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TBAAPI
+import TBAUtils
 
 // https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/event_type.py
 enum APIEventType: Int, CaseIterable {
@@ -75,6 +76,7 @@ extension Event {
         guard let date = startDateParsed else { return nil }
         let formatter = DateFormatter()
         formatter.dateFormat = "MMMM"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter.string(from: date)
     }
 
@@ -95,24 +97,30 @@ extension Event {
         return !website.isEmpty
     }
 
+    // Inclusive end of the event's final UTC day. Prefer this over raw
+    // `endDateParsed` for "is the event over?" checks — `endDateParsed` is
+    // UTC midnight of the end day, so comparing it directly to a wall-clock
+    // `Date()` clips the whole final day for users west of UTC.
+    var endOfEventDay: Date? {
+        endDateParsed?.endOfDay(calendar: .utc)
+    }
+
     // Event is currently going on, based on its start and end dates.
     var isHappeningNow: Bool {
-        guard let start = startDateParsed, let end = endDateParsed else { return false }
+        guard let start = startDateParsed, let end = endOfEventDay else { return false }
         let now = Date()
-        let endOfDay = Calendar.current.date(bySettingHour: 23, minute: 59, second: 59, of: end) ?? end
-        return now >= start && now <= endOfDay
+        return now >= start && now <= end
     }
 
     // Ported from TBAData.Event.isHappeningThisWeek: the event is going on
     // now or starts within the next week.
     var isHappeningThisWeek: Bool {
-        guard let start = startDateParsed, let end = endDateParsed else { return false }
-        let now = Date()
-        guard let startOfWeek = Calendar.current.date(byAdding: DateComponents(day: -7), to: start) else {
+        guard let start = startDateParsed, let end = endOfEventDay else { return false }
+        guard let startOfWeek = Calendar.utc.date(byAdding: .day, value: -7, to: start) else {
             return false
         }
-        let endOfDay = Calendar.current.date(bySettingHour: 23, minute: 59, second: 59, of: end) ?? end
-        return now >= startOfWeek && now <= endOfDay
+        let now = Date()
+        return now >= startOfWeek && now <= end
     }
 
     // Sort key used in place of the Core Data `hybridType` attribute — groups
@@ -134,6 +142,7 @@ extension Event {
         if eventTypeEnum == .offseason, let date = startDateParsed {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyyMM"
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
             return "\(eventType).\(formatter.string(from: date))"
         }
         return "\(eventType)"
@@ -156,18 +165,20 @@ extension Event {
 
     var dateString: String? {
         guard let start = startDateParsed, let end = endDateParsed else { return nil }
-        let calendar = Calendar.current
-
+        // Dates are UTC-midnight; format and compare year components in UTC so
+        // users west of UTC don't see the range shifted back a day.
         let shortFormatter = DateFormatter()
         shortFormatter.dateFormat = "MMM dd"
+        shortFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         let longFormatter = DateFormatter()
         longFormatter.dateFormat = "MMM dd, y"
+        longFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         if start == end {
             return shortFormatter.string(from: end)
         }
-        if calendar.component(.year, from: start) == calendar.component(.year, from: end) {
+        if Calendar.utc.component(.year, from: start) == Calendar.utc.component(.year, from: end) {
             return "\(shortFormatter.string(from: start)) to \(shortFormatter.string(from: end))"
         }
         return "\(shortFormatter.string(from: start)) to \(longFormatter.string(from: end))"

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TBAAPI
+import TBAUtils
 import UIKit
 
 protocol EventInfoViewControllerDelegate: AnyObject {
@@ -136,7 +137,8 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
                 .filter { $0.urlString != nil }
                 .filter { webcast in
                     guard let date = webcast.dateParsed else { return true }
-                    return Calendar.current.isDateInToday(date)
+                    // dateParsed is UTC-midnight; check "today" in UTC to match.
+                    return Calendar.utc.isDateInToday(date)
                 }
                 .map { EventInfoItem.webcast($0) }
             if !webcasts.isEmpty, event.isHappeningThisWeek {

--- a/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
@@ -54,8 +54,9 @@ class WeekEventsViewController: EventsListViewController {
             }
         case .offseason:
             guard let start = weekEvent.startDateParsed, let end = weekEvent.endDateParsed else { return [] }
-            let firstOfMonth = start.startOfMonth()
-            let lastOfMonth = end.endOfMonth()
+            // UTC-midnight dates need a UTC calendar or month boundaries shift a day.
+            let firstOfMonth = start.startOfMonth(calendar: .utc)
+            let lastOfMonth = end.endOfMonth(calendar: .utc)
             return sameYear.filter {
                 guard $0.isOffseason, let d = $0.startDateParsed else { return false }
                 return d >= firstOfMonth && d <= lastOfMonth
@@ -103,7 +104,7 @@ class WeekEventsViewController: EventsListViewController {
         let unplayed = events
             .filter { $0.year == year }
             .filter { !$0.isChampionshipDivision }
-            .filter { ($0.endDateParsed ?? .distantPast) >= today }
+            .filter { ($0.endOfEventDay ?? .distantPast) >= today }
             .sorted { ($0.endDateParsed ?? .distantPast) < ($1.endDateParsed ?? .distantPast) }
             .first
         if let unplayed { return unplayed }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -11,9 +11,9 @@ private enum TeamSummarySection: Int {
     case teamInfo
     case eventInfo
     case nextMatch
+    case lastMatch
     case playoffInfo
     case qualInfo
-    case lastMatch
 }
 
 private enum TeamSummaryItem: Hashable {
@@ -120,6 +120,12 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             snapshot.appendItems([.match(match: nextMatch, baseTeamKey: teamKey)], toSection: .nextMatch)
         }
 
+        // Last match
+        if let lastMatch, event?.isHappeningNow == true {
+            snapshot.appendSections([.lastMatch])
+            snapshot.appendItems([.match(match: lastMatch, baseTeamKey: teamKey)], toSection: .lastMatch)
+        }
+
         // Playoff info
         let playoffItems = self.playoffItems()
         if !playoffItems.isEmpty {
@@ -132,12 +138,6 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
         if !qualItems.isEmpty {
             snapshot.appendSections([.qualInfo])
             snapshot.appendItems(qualItems, toSection: .qualInfo)
-        }
-
-        // Last match
-        if let lastMatch, event?.isHappeningNow == true {
-            snapshot.appendSections([.lastMatch])
-            snapshot.appendItems([.match(match: lastMatch, baseTeamKey: teamKey)], toSection: .lastMatch)
         }
 
         dataSource.applySnapshotUsingReloadData(snapshot)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -140,7 +140,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             snapshot.appendItems([.match(match: lastMatch, baseTeamKey: teamKey)], toSection: .lastMatch)
         }
 
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     private func statusItem() -> TeamSummaryItem? {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -150,7 +150,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
             snapshot.appendSections([""])
             snapshot.appendItems(items, toSection: "")
         }
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
 }


### PR DESCRIPTION
## Summary

Three bugs surfaced while viewing a team at a live event. All three are visible on Team@Event > Summary, and two of them stem from the same underlying timezone asymmetry between UTC-parsed event dates and `Calendar.current` math.

### 1. Section reordering on tab switches (9fd05531)

`UITableViewDiffableDataSource.apply(_:animatingDifferences: false)` still runs the diff and unreliably re-seats surviving sections when the snapshot's section order changes (e.g. when `nextMatch` transitions from absent to present between applies). Swapped to `applySnapshotUsingReloadData(_:)` on the two remaining full-rebuild sites that the #994 sweep missed:
- `TeamSummaryViewController.rebuildSnapshot`
- `TeamMediaCollectionViewController.applyMedia`

Left the `reconfigureItems` site in `TeamMediaCollectionViewController` alone — that one is a targeted per-cell update, not a full rebuild, and `applySnapshotUsingReloadData` would reload every cell on every image download.

### 2. Event dates clipped for users west of UTC (a72510b4)

`APIEventDateFormatter` parses `startDate`/`endDate` as UTC-midnight, but multiple callers were computing end-of-day, start/end-of-month, year-components, and `isDateInToday` with `Calendar.current`. For any user in a negative-offset timezone, this shifted the final day of the event backwards, producing:
- `isHappeningNow == false` on the last day of the event → "Next Match" and "Most Recent Match" gated out on the Summary tab
- "Today's webcasts" hidden until UTC midnight rolled over (~8 PM EDT)
- Event date ranges rendered a day earlier than reality (e.g. "Apr 16–17" for an April 16–18 event)
- Offseason month grouping misaligned for events starting on the 1st
- The app-open "current week event" picker dropped events ending today

Fix: added `Calendar.utc` in TBAUtils, introduced `Event.endOfEventDay` as the single "practical end of event" primitive, and pinned all formatters that stringify parsed event dates to UTC. Three call sites now consume `endOfEventDay`; five stringify/comparison sites now pin their calendar/formatter to UTC.

### 3. Most Recent Match buried at the bottom of Summary (8af393aa)

`Most Recent Match` was the last section in the enum, separated from `Next Match` by Playoffs and Qualifications. During playoffs that's a long scroll past three other sections to find "what just happened." Moved `lastMatch` to sit directly under `nextMatch` so the two time-sensitive sections appear together under the status row, matching the "Last Matches | Upcoming Matches" pairing on TBA web.

## Test plan

- [ ] Open a team at an event that is currently happening, on the event's final local day (e.g. Team 2337 @ 2026micmp3 — event runs Apr 16–18, test on the 18th). Confirm Summary shows:
    - Team info → Summary status → **Next Match → Most Recent Match** → Playoffs → Qualifications
    - Both match sections render with correct match keys and times
- [ ] Pull-to-refresh Summary multiple times, switch tabs (Summary ↔ Matches ↔ Stats), come back. Section order stable every time.
- [ ] Open a team at an event that has ended. Next/Most Recent Match sections hidden (expected — event not happening).
- [ ] Open a team at an event that hasn't started yet. Same — sections hidden.
- [ ] Change device timezone to `America/Los_Angeles` while viewing a live Michigan event on its final local day. Confirm Next/Most Recent Match still appear.
- [ ] Change device timezone to `Pacific/Honolulu` (UTC-10). Same check.
- [ ] Look at an event's `dateString` on an Events list — range should read correctly for a Friday-Sunday event (e.g. "Apr 17 to Apr 19" not "Apr 16 to Apr 18").
- [ ] Open an event page with a webcast scheduled for today and confirm the webcast row shows in the Info tab.
- [ ] Kill and re-launch the app during a week with live events. The week picker should default to a week containing events ending today (not skip past them).
- [ ] myTBA tab and Team Media grid — sanity-check that swap to `applySnapshotUsingReloadData` didn't regress anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)