### PR TITLE
Only alert on FMS datafeed going down, not when it recovers

### DIFF
--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -191,7 +191,9 @@ extension AppDelegate: StatusSubscribable {
 extension AppDelegate: FMSStatusSubscribable {
 
     func fmsStatusChanged(isDatafeedDown: Bool) {
-        showAlert(.fmsStatus(isDatafeedDown: isDatafeedDown))
+        if isDatafeedDown {
+            showAlert(.fmsStatus(isDatafeedDown: isDatafeedDown))
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

- `fmsStatusChanged(isDatafeedDown:)` fires on every transition of the FMS status, including recovery.
- Before this guard, the \"datafeed is down\" alert was presented with `isDatafeedDown: false` on the way back up, surfacing a recovery notification as a spurious modal.
- Only present the alert when the datafeed is actually down.

## Test plan

- [ ] Launch the app while FMS status is healthy — no alert.
- [ ] Simulate/await FMS going down — alert presents with the \"datafeed is down\" copy.
- [ ] Simulate/await FMS recovering — no alert presents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)