### PR TITLE
Seed EventViewController nav title from event key on push

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -46,9 +46,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
                    segmentedControlTitles: ["Info", "Teams", "Rankings", "Matches"],
                    dependencies: dependencies)
 
-        if let event {
-            title = event.friendlyNameWithYear
-        }
+        title = navTitle
 
         infoViewController.delegate = self
         teamsViewController.delegate = self


### PR DESCRIPTION
## Summary

- When `EventViewController` is pushed with only an eventKey (the common case from the Events list), `title` was left nil until the async `api.event(key:)` fetch completed.
- `ContainerViewController` only installs the custom `navigationStackView` as `titleView` when both `navigationTitle` AND `navigationSubtitle` are passed. `EventViewController` passes no subtitle, so the nav bar falls back to UIViewController.title — which was staying nil on push.
- Result: blank nav title through push, sometimes never updating if the async fetch silently failed.
- Fix: set `title = navTitle` at init time, using the same expression that already seeds `navigationTitle` (`event?.friendlyNameWithYear ?? eventKey`). Shows the event key immediately, friendly name overwrites once the async fetch resolves.

## Test plan

- [ ] Push an Event from the Events list with a cold cache — nav bar shows the event key immediately, then updates to the friendly name.
- [ ] Push an Event from myTBA / from a context that passes `init(event:)` — nav bar shows the friendly name immediately.
- [ ] No regression on Team nav (unaffected, already passes a subtitle so uses the custom titleView path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)