### PR TITLE
Add cache policy toggle and Settings networking section

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPI.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPI.swift
@@ -35,8 +35,6 @@ public final class TBAAPI {
     private let box: Box
     public private(set) var cachePolicy: CachePolicy
 
-    // Exposed so the `TBAAPI+*.swift` extensions can call the generated
-    // OpenAPI client. Read-only — policy changes go through setCachePolicy(_:).
     public var client: Client { box.client }
 
     public init(apiKey: String, cachePolicy: CachePolicy = .default) {

--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPI.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPI.swift
@@ -13,7 +13,12 @@ private struct APIConstants {
     static let baseURL = URL(string: "https://www.thebluealliance.com/api/v3/")!
 }
 
-public struct TBAAPI {
+public final class TBAAPI {
+
+    public enum CachePolicy: String, CaseIterable, Sendable {
+        case `default`
+        case bypass
+    }
 
     public static let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
@@ -21,22 +26,47 @@ public struct TBAAPI {
         return dateFormatter
     }()
 
-    // TODO: Add a way to set/change the cache strategy for debugging
+    private final class Box {
+        var client: Client
+        init(client: Client) { self.client = client }
+    }
 
-    public let client: Client
+    private let apiKey: String
+    private let box: Box
+    public private(set) var cachePolicy: CachePolicy
 
-    public init(apiKey: String, configuration: URLSessionConfiguration = .ephemeral) {
+    // Exposed so the `TBAAPI+*.swift` extensions can call the generated
+    // OpenAPI client. Read-only — policy changes go through setCachePolicy(_:).
+    public var client: Client { box.client }
+
+    public init(apiKey: String, cachePolicy: CachePolicy = .default) {
+        self.apiKey = apiKey
+        self.cachePolicy = cachePolicy
+        self.box = Box(client: Self.makeClient(apiKey: apiKey, policy: cachePolicy))
+    }
+
+    public func setCachePolicy(_ policy: CachePolicy) {
+        guard policy != cachePolicy else { return }
+        cachePolicy = policy
+        box.client = Self.makeClient(apiKey: apiKey, policy: policy)
+    }
+
+    public func clearCache() {
+        URLCache.shared.removeAllCachedResponses()
+    }
+
+    private static func makeClient(apiKey: String, policy: CachePolicy) -> Client {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = ["X-TBA-Auth-Key": apiKey]
+        switch policy {
+        case .default:
+            configuration.requestCachePolicy = .useProtocolCachePolicy
+        case .bypass:
+            configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        }
+
         let serverURL = (try? Servers.Server1.url()) ?? APIConstants.baseURL
-
-        configuration.httpAdditionalHeaders = [
-            "X-TBA-Auth-Key": apiKey,
-        ]
-
-        #if DEBUG
-        configuration.urlCache?.removeAllCachedResponses()
-        #endif
-
-        self.client = Client(
+        return Client(
             serverURL: serverURL,
             transport: URLSessionTransport(configuration: .init(
                 session: URLSession(configuration: configuration)

--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 public protocol TBAAPIProtocol {
+    // Networking
+    var cachePolicy: TBAAPI.CachePolicy { get }
+    func setCachePolicy(_ policy: TBAAPI.CachePolicy)
+    func clearCache()
+
     // Status
     func getStatus() async throws -> APIStatus
 

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		92564C6D21644ACA0047917F /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 92564C6C21644ACA0047917F /* Secrets.plist */; };
 		92592F8423CB7F8900F3E124 /* TBASearchableTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92592F8323CB7F8900F3E124 /* TBASearchableTableViewController.swift */; };
 		92598CC724A92AFE007E08CB /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92598CC624A92AFE007E08CB /* Dependencies.swift */; };
+		92AABBCC000000000000DD01 /* CachePolicyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AABBCC000000000000DD02 /* CachePolicyStore.swift */; };
+		92AABBCC000000000000DD11 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AABBCC000000000000DD12 /* AppSettings.swift */; };
 		92598CC924A92B00007E08CB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92598CC824A92B00007E08CB /* SceneDelegate.swift */; };
 		92598CCB24A92B00007E08CB /* AppServicesProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92598CCA24A92B00007E08CB /* AppServicesProviding.swift */; };
 		925D10EB2394C7F300191D92 /* NSDiffableDataSourceSnapshot+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D10EA2394C7F300191D92 /* NSDiffableDataSourceSnapshot+TBA.swift */; };
@@ -247,6 +249,8 @@
 		92564C6C21644ACA0047917F /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Secrets.plist; sourceTree = "<group>"; };
 		92592F8323CB7F8900F3E124 /* TBASearchableTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBASearchableTableViewController.swift; sourceTree = "<group>"; };
 		92598CC624A92AFE007E08CB /* Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dependencies.swift; sourceTree = "<group>"; };
+		92AABBCC000000000000DD02 /* CachePolicyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachePolicyStore.swift; sourceTree = "<group>"; };
+		92AABBCC000000000000DD12 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		92598CC824A92B00007E08CB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		92598CCA24A92B00007E08CB /* AppServicesProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServicesProviding.swift; sourceTree = "<group>"; };
 		925D10EA2394C7F300191D92 /* NSDiffableDataSourceSnapshot+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDiffableDataSourceSnapshot+TBA.swift"; sourceTree = "<group>"; };
@@ -484,6 +488,15 @@
 			path = AppDelegate;
 			sourceTree = "<group>";
 		};
+		92AABBCC000000000000DD10 /* LocalStore */ = {
+			isa = PBXGroup;
+			children = (
+				92AABBCC000000000000DD12 /* AppSettings.swift */,
+				92AABBCC000000000000DD02 /* CachePolicyStore.swift */,
+			);
+			path = LocalStore;
+			sourceTree = "<group>";
+		};
 		92435E2A23CBC21300CDD2D4 /* Stats */ = {
 			isa = PBXGroup;
 			children = (
@@ -577,6 +590,7 @@
 			children = (
 				927246C12AFFFC8900EF7796 /* Auth */,
 				923AEE8F2165966C00EF50C8 /* AppDelegate */,
+				92AABBCC000000000000DD10 /* LocalStore */,
 				923A0D7620D21D3800BF5E31 /* LaunchViews */,
 				92942D9E1E2154DA008E79CA /* Assets.xcassets */,
 				A11CF00E00000000000000FF /* AppIcon.icon */,
@@ -1254,6 +1268,8 @@
 				9274E14721B10DB700F5D5D0 /* NotificationStatusCellViewModel.swift in Sources */,
 				1479694E215EC4B60075AF4E /* InfoCellViewModel.swift in Sources */,
 				92598CC724A92AFE007E08CB /* Dependencies.swift in Sources */,
+				92AABBCC000000000000DD01 /* CachePolicyStore.swift in Sources */,
+				92AABBCC000000000000DD11 /* AppSettings.swift in Sources */,
 				92FF10F721A61AC2003BC5C4 /* MatchInfoViewController.swift in Sources */,
 				9279737D23CFF3A700FF9B86 /* EventInsightsConfigurator2018.swift in Sources */,
 				92564C6B21644AA30047917F /* Secrets.swift in Sources */,

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -20,6 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let subscriptionsStore = SubscriptionsStore()
     let urlOpener: URLOpener = UIApplication.shared
 
+    let appSettings = AppSettings()
+
     // Set in `application(_:didFinishLaunchingWithOptions:)` once `Secrets` are loaded.
     var api: TBAAPI!
 
@@ -38,6 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                                       retryService: RetryService())
 
     lazy var dependencies = Dependencies(api: api,
+                                         appSettings: appSettings,
                                          myTBA: myTBA,
                                          myTBAStores: myTBAStores,
                                          statusService: statusService,
@@ -106,7 +109,7 @@ private extension AppDelegate {
 
     func configureAPI() {
         let secrets = Secrets()
-        api = TBAAPI(apiKey: secrets.tbaAPIKey)
+        api = TBAAPI(apiKey: secrets.tbaAPIKey, cachePolicy: appSettings.cachePolicy.current)
     }
 
     func configurePushNotifications() {

--- a/the-blue-alliance-ios/AppDelegate/Dependencies.swift
+++ b/the-blue-alliance-ios/AppDelegate/Dependencies.swift
@@ -6,17 +6,20 @@ import UIKit
 
 class Dependencies {
     let api: any TBAAPIProtocol
+    let appSettings: AppSettings
     let myTBA: any MyTBAProtocol
     let myTBAStores: MyTBAStores
     let statusService: any StatusServiceProtocol
     let urlOpener: any URLOpener
 
     init(api: any TBAAPIProtocol,
+         appSettings: AppSettings,
          myTBA: any MyTBAProtocol,
          myTBAStores: MyTBAStores,
          statusService: any StatusServiceProtocol,
          urlOpener: any URLOpener = UIApplication.shared) {
         self.api = api
+        self.appSettings = appSettings
         self.myTBA = myTBA
         self.myTBAStores = myTBAStores
         self.statusService = statusService

--- a/the-blue-alliance-ios/LocalStore/AppSettings.swift
+++ b/the-blue-alliance-ios/LocalStore/AppSettings.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct AppSettings {
+
+    let cachePolicy: CachePolicyStore
+
+    init(defaults: UserDefaults = .standard) {
+        self.cachePolicy = CachePolicyStore(defaults: defaults)
+    }
+}

--- a/the-blue-alliance-ios/LocalStore/CachePolicyStore.swift
+++ b/the-blue-alliance-ios/LocalStore/CachePolicyStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+import TBAAPI
+
+private let kTBACachePolicy = "kTBACachePolicy"
+
+struct CachePolicyStore {
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var current: TBAAPI.CachePolicy {
+        get {
+            guard let raw = defaults.string(forKey: kTBACachePolicy),
+                  let policy = TBAAPI.CachePolicy(rawValue: raw) else {
+                return .default
+            }
+            return policy
+        }
+        nonmutating set {
+            defaults.set(newValue.rawValue, forKey: kTBACachePolicy)
+        }
+    }
+}

--- a/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
@@ -1,8 +1,10 @@
 import MyTBAKit
+import TBAAPI
 import UIKit
 
 private enum SettingsSection: Int, CaseIterable {
     case info
+    case networking
     case debug
 }
 
@@ -12,9 +14,22 @@ private enum InfoRow: String, CaseIterable {
     case testFlight = "https://testflight.apple.com/join/gz7RmdS7"
 }
 
-private enum DebugRow: Int, CaseIterable {
+private enum NetworkingRow: Int, CaseIterable {
+    case cachePolicy
     case deleteNetworkCache
+}
+
+private enum DebugRow: Int, CaseIterable {
     case troubleshootNotifications
+}
+
+private extension TBAAPI.CachePolicy {
+    var displayName: String {
+        switch self {
+        case .default: return "Default"
+        case .bypass:  return "Bypass Cache"
+        }
+    }
 }
 
 class SettingsViewController: TBATableViewController {
@@ -62,6 +77,8 @@ class SettingsViewController: TBATableViewController {
         switch section {
         case .info:
             return InfoRow.allCases.count
+        case .networking:
+            return NetworkingRow.allCases.count
         case .debug:
             return DebugRow.allCases.count
         }
@@ -75,6 +92,8 @@ class SettingsViewController: TBATableViewController {
         switch section {
         case .info:
             return "Info"
+        case .networking:
+            return "Networking"
         case .debug:
             return "Debug"
         }
@@ -112,14 +131,27 @@ class SettingsViewController: TBATableViewController {
             cell.textLabel?.text = titleString
 
             return cell
+        case .networking:
+            let networkingRow = NetworkingRow.allCases[indexPath.row]
+            switch networkingRow {
+            case .cachePolicy:
+                let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+                cell.textLabel?.text = "Cache Policy"
+                cell.detailTextLabel?.text = api.cachePolicy.displayName
+                cell.accessoryType = .disclosureIndicator
+                return cell
+            case .deleteNetworkCache:
+                let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+                cell.textLabel?.text = "Delete network cache"
+                cell.accessoryType = .disclosureIndicator
+                return cell
+            }
         case .debug:
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
 
             let debugRow = DebugRow.allCases[indexPath.row]
             let titleString: String = {
                 switch debugRow {
-                case .deleteNetworkCache:
-                    return "Delete network cache"
                 case .troubleshootNotifications:
                     return "Troubleshoot notifications"
                 }
@@ -150,11 +182,17 @@ class SettingsViewController: TBATableViewController {
             if let url = URL(string: infoRow.rawValue) {
                 openURL(url: url)
             }
+        case .networking:
+            let networkingRow = NetworkingRow.allCases[indexPath.row]
+            switch networkingRow {
+            case .cachePolicy:
+                showCachePolicyPicker(from: indexPath)
+            case .deleteNetworkCache:
+                showDeleteNetworkCache()
+            }
         case .debug:
             let debugRow = DebugRow.allCases[indexPath.row]
             switch debugRow {
-            case .deleteNetworkCache:
-                showDeleteNetworkCache()
             case .troubleshootNotifications:
                 pushTroubleshootNotifications()
             }
@@ -245,13 +283,39 @@ class SettingsViewController: TBATableViewController {
         }
     }
 
-    // MARK: - Debug Methods
+    // MARK: - Networking Methods
+
+    private func showCachePolicyPicker(from indexPath: IndexPath) {
+        let alertController = UIAlertController(title: "Cache Policy", message: nil, preferredStyle: .actionSheet)
+
+        for policy in TBAAPI.CachePolicy.allCases {
+            let action = UIAlertAction(title: policy.displayName, style: .default) { [weak self] _ in
+                guard let self else { return }
+                self.dependencies.appSettings.cachePolicy.current = policy
+                self.api.setCachePolicy(policy)
+                self.tableView.reloadRows(at: [indexPath], with: .none)
+            }
+            if api.cachePolicy == policy {
+                action.setValue(true, forKey: "checked")
+            }
+            alertController.addAction(action)
+        }
+        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+
+        if let popover = alertController.popoverPresentationController,
+           let cell = tableView.cellForRow(at: indexPath) {
+            popover.sourceView = cell
+            popover.sourceRect = cell.bounds
+        }
+
+        present(alertController, animated: true)
+    }
 
     private func showDeleteNetworkCache() {
         let alertController = UIAlertController(title: "Delete Network Cache", message: "Are you sure you want to delete all the network cache data?", preferredStyle: .alert)
 
-        let deleteCacheAction = UIAlertAction(title: "Delete", style: .destructive) { (deleteAction) in
-            URLCache.shared.removeAllCachedResponses()
+        let deleteCacheAction = UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
+            self?.api.clearCache()
         }
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
 
@@ -260,6 +324,8 @@ class SettingsViewController: TBATableViewController {
 
         self.present(alertController, animated: true, completion: nil)
     }
+
+    // MARK: - Debug Methods
 
     private func pushTroubleshootNotifications() {
         let notificationsViewController = NotificationsViewController(fcmTokenProvider: fcmTokenProvider, pushService: pushService, dependencies: dependencies)


### PR DESCRIPTION
## Summary

- Turns `TBAAPI` into a hot-swappable caching client. Struct → `final class` with an internal `Box` holding the generated OpenAPI `Client`; `public var client` stays exposed as a read-only computed property so every `TBAAPI+*.swift` extension keeps compiling with no callsite changes.
- Replaces `URLSessionConfiguration.ephemeral` with `URLSessionConfiguration.default` (which carries `URLCache.shared` at iOS-managed sizes — leans on platform defaults rather than custom memory/disk caps).
- New `TBAAPI.CachePolicy` enum with two cases: `.default` (`.useProtocolCachePolicy`) and `.bypass` (`.reloadIgnoringLocalCacheData`). `setCachePolicy(_:)` rebuilds the URLSession + Client in place so the toggle takes effect without an app restart. `clearCache()` calls through to `URLCache.shared.removeAllCachedResponses()`.
- New `LocalStore/` folder holding `AppSettings` (DI'd umbrella, `init(defaults: UserDefaults = .standard)`) and `CachePolicyStore` (persists the selected policy under `kTBACachePolicy`). `Dependencies` gains `appSettings: AppSettings`.
- `AppDelegate.configureAPI()` reads `appSettings.cachePolicy.current` at launch and passes it into `TBAAPI.init`.
- Settings: new **Networking** section between Info and Debug. **Cache Policy** row shows the active mode in a `value1` cell; tap opens an action-sheet picker that writes to the store and hot-swaps the API client. The existing **Delete network cache** row moves here from Debug and now routes through `api.clearCache()` (the old call to `URLCache.shared` was pointing at the wrong cache once we installed any custom session — this now uses the same cache that the session actually fills).

## Test plan

- [ ] Cold launch in Default mode, push an Event from the Events list. First push performs a network request; second push of the same event within freshness window hits `URLCache` with no network.
- [ ] Flip Settings → Networking → Cache Policy to **Bypass Cache** without restarting. Push the same Event — network request fires again; on-disk URLCache keeps growing (bypass only affects reads, not writes).
- [ ] Flip back to **Default** without restart. Push the same Event — URLCache hit.
- [ ] Tap **Delete network cache** in either mode — confirmation alert appears; on confirm, on-disk URLCache storage drops.
- [ ] Persisted selection survives relaunch (AppDelegate reads the store at launch).
- [ ] No callsite regressions — every existing `api.event(key:)` / `api.team(key:)` / etc. in the app still compiles and works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)