### PR TITLE
Mark imported-to-imported conformances @retroactive

### DIFF
--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -241,7 +241,7 @@ extension AppDelegate: RemoteNotificationRegistering {
 
 // MARK: - FCMTokenProvider conformance for Firebase Messaging
 
-extension Messaging: FCMTokenProvider {}
+extension Messaging: @retroactive FCMTokenProvider {}
 
 // MARK: - Appearance
 

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Status.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Status.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TBAAPI
 
-extension TBAAPI: TBAAPIProtocol {}
+extension TBAAPI: @retroactive TBAAPIProtocol {}
 
 extension TBAAPI {
 

--- a/the-blue-alliance-ios/Extensions/TBAAPI/WeekEventsGrouping.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/WeekEventsGrouping.swift
@@ -62,7 +62,7 @@ enum WeekEventsGrouping {
 
 // MARK: - Comparable port
 
-extension Event: Comparable {
+extension Event: @retroactive Comparable {
 
     // Port of TBAData.Event's `Comparable` ordering:
     //   Preseason, Week 1, Week 2, …, Week 7, CMP divisions, CMP finals, FoC, Offseason, Unlabeled


### PR DESCRIPTION
## Summary

Silences the three Swift 5/6 retroactive-conformance warnings in the app target:

- `Messaging: FCMTokenProvider` — Firebase type, MyTBAKit protocol
- `TBAAPI: TBAAPIProtocol` — both live in the TBAAPI package, but the method implementations (`TBAAPI+Teams.swift`, `+Events.swift`, `+Districts.swift`, `+Status.swift`, `+Search.swift`) currently live in the app target
- `Event: Comparable` — TBAAPI type, stdlib protocol; the ordering logic relies on app-side `APIEvent+Helpers` (`isChampionshipDivision`, `eventTypeEnum`, `startDateParsed`, etc.)

The "move conformance into the owning module" fix would require relocating those extensions too — a substantially larger refactor than a warning cleanup. `@retroactive` is the pragmatic spelling here; a follow-up could move the extensions into the TBAAPI package if we want the conformance to live where the type does.

## Test plan

- [ ] `xcodebuild -project the-blue-alliance-ios.xcodeproj -scheme "The Blue Alliance" -destination "platform=iOS Simulator,name=iPhone 17 Pro" -configuration Debug -skipPackagePluginValidation build` succeeds with no new warnings
- [ ] The three retroactive-conformance warnings no longer appear in the build log
- [ ] Event list screens still render in the expected week/CMP/offseason order (exercises `Event: Comparable`)
- [ ] FCM token still wires through to myTBA push registration at launch (exercises `Messaging: FCMTokenProvider`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)