### PR TITLE
Modernize deprecated iOS APIs

### DIFF
--- a/the-blue-alliance-ios/Services/PushService.swift
+++ b/the-blue-alliance-ios/Services/PushService.swift
@@ -99,7 +99,7 @@ extension PushService: UNUserNotificationCenterDelegate {
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         // Show all notifications in the foreground.
-        completionHandler([.alert, .badge, .sound])
+        completionHandler([.banner, .list, .badge, .sound])
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAPreferenceViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAPreferenceViewController.swift
@@ -49,7 +49,7 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
         let item = UIBarButtonItem(title: "Save", primaryAction: UIAction { [weak self] _ in
             self?.save()
         })
-        item.style = .done
+        item.style = .prominent
         return item
     }()
     internal var saveActivityIndicatorBarButtonItem = UIBarButtonItem.activityIndicatorBarButtonItem()

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBASignInViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBASignInViewController.swift
@@ -41,6 +41,10 @@ class MyTBASignInViewController: UIViewController, ASAuthorizationControllerPres
         super.viewDidLoad()
 
         styleInterface()
+
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: MyTBASignInViewController, previousTraitCollection) in
+            self.updateInterface(previousTraitCollection: previousTraitCollection)
+        }
     }
 
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -56,12 +60,6 @@ class MyTBASignInViewController: UIViewController, ASAuthorizationControllerPres
                 $0.isHidden = shouldHideImages
             }
         })
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        updateInterface(previousTraitCollection: previousTraitCollection)
     }
 
     // MARK: - Interface Methods


### PR DESCRIPTION
## Summary

Three independent iOS deprecation fixes, no availability guards needed (deployment target is iOS 26.0):

- **`PushService`** — `UNNotificationPresentationOptions.alert` was split into `.banner` + `.list` in iOS 14. Use both so foreground notifications still render in the banner drawer and the notification list.
- **`MyTBAPreferenceViewController`** — `UIBarButtonItem.Style.done` was renamed to `.prominent` in iOS 26.
- **`MyTBASignInViewController`** — `traitCollectionDidChange` was deprecated in iOS 17 in favor of `registerForTraitChanges`. Register on `UITraitUserInterfaceStyle` (what `updateInterface` actually reacts to) and invoke the same handler from the new closure-based API.

## Test plan

- [ ] Build succeeds with no new warnings
- [ ] Foreground a push notification — banner still appears and the message lands in the notification list
- [ ] Open a myTBA team/event/match preference sheet — Save button renders with prominent styling and is tappable
- [ ] On the myTBA sign-in screen, toggle system Light ↔ Dark mode — Google sign-in button's background images refresh correctly
- [ ] Rotate the sign-in screen between portrait and landscape on iPhone — star/favorite/subscription icons still fade in and out with size-class changes (this path is still handled by `willTransition`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)