### PR TITLE
Fix miscellaneous code-quality warnings

### DIFF
--- a/Packages/TBAUtils/Sources/TBAUtils/Provider.swift
+++ b/Packages/TBAUtils/Sources/TBAUtils/Provider.swift
@@ -1,16 +1,20 @@
 import Foundation
 
 private class Weak: Hashable {
-    let hashValue: Int
+    let identifier: ObjectIdentifier
     weak var value: AnyObject?
 
     init(value: AnyObject) {
         self.value = value
-        self.hashValue = ObjectIdentifier(value).hashValue
+        self.identifier = ObjectIdentifier(value)
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
     }
 
     static func ==(lhs: Weak, rhs: Weak) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.identifier == rhs.identifier
     }
 }
 

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -125,7 +125,7 @@ private extension AppDelegate {
     }
 
     func configureAuth() {
-        Auth.auth().addIDTokenDidChangeListener { [weak self] _, user in
+        _ = Auth.auth().addIDTokenDidChangeListener { [weak self] _, user in
             guard let self else { return }
             if let user = user {
                 user.getIDToken { token, _ in

--- a/the-blue-alliance-ios/Services/RetryService.swift
+++ b/the-blue-alliance-ios/Services/RetryService.swift
@@ -34,7 +34,7 @@ class RetryService {
     }
 
     fileprivate func unregister() {
-        weak var retryTimer = self.retryTimer
+        let retryTimer = self.retryTimer
         retryRunLoop?.perform {
             retryTimer?.invalidate()
         }

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -122,7 +122,7 @@ class SearchViewController: TBATableViewController {
         }
 
         if scope.shouldShowTeams {
-            let teams = (index.teams ?? [])
+            let teams = index.teams
                 .filter { matches(team: $0, query: query) }
                 .sorted { lhs, rhs in
                     let l = Int(TeamKey.trimFRCPrefix(lhs.key)) ?? .max
@@ -137,7 +137,7 @@ class SearchViewController: TBATableViewController {
         }
 
         if scope.shouldShowEvents {
-            let events = (index.events ?? [])
+            let events = index.events
                 .filter { matches(event: $0, query: query) }
                 .sorted { lhs, rhs in
                     let lYear = Int(lhs.key.prefix(4)) ?? 0


### PR DESCRIPTION
## Summary

Five small, independent compiler warnings, grouped into one PR to keep the churn low:

- **`AppDelegate.configureAuth`** — silence unused-result on `addIDTokenDidChangeListener`. We never need the listener handle; the listener lives for the process.
- **`RetryService.unregister`** — the local `weak var retryTimer` shadow existed only to avoid capturing `self` inside the runloop block, but was never mutated. Switch to `let`. The timer is retained by the run loop anyway, so strong capture is safe.
- **`SearchViewController`** — drop `?? []` on `index.teams` / `index.events`. Both are non-optional arrays per the generated OpenAPI types.
- **`TBAUtils/Provider`** — `Weak` class stored its Hashable identity via the deprecated `let hashValue: Int` pattern. Store the identity once as an `ObjectIdentifier` and implement `hash(into:)` — equivalent behavior, modern shape.

## Test plan

- [ ] `xcodebuild … build` succeeds with no new warnings
- [ ] `swift test --package-path Packages/TBAUtils` passes (existing 17 tests)
- [ ] Status service retry still fires: put device in airplane mode, wait for status refresh failures, disable airplane mode — status should refresh without crashing in `unregister()`
- [ ] Search for a team key (e.g. \"1114\") and event (e.g. \"2019onosh\") — both lists still populate and sort correctly
- [ ] Sign in / out of myTBA — observer notifications still fire once per observer (Provider dedup invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)