### PR TITLE
Switch remaining async let workarounds to Task handles

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -56,15 +56,16 @@ class MatchViewController: MyTBAContainerViewController {
 
     private func loadMatchAndEvent() {
         Task { @MainActor in
-            async let matchTask = dependencies.api.match(key: matchKey)
-            async let eventTask = dependencies.api.event(key: MatchKey.eventKey(from: matchKey))
-
-            // Await in reverse declaration order so async let child tasks are torn
-            // down LIFO; otherwise swift_task_dealloc traps. Workaround for a Swift
-            // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
+            // Unstructured Task handles instead of `async let`: Swift 6.1's
+            // async-let stack allocator trips swift_task_dealloc's LIFO check
+            // here even with reverse-order awaits (#995 didn't fully fix it).
+            // Task handles heap-allocate and sidestep the allocator entirely.
             // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
-            let event = try? await eventTask
-            let match = try? await matchTask
+            let matchHandle = Task { try? await self.dependencies.api.match(key: self.matchKey) }
+            let eventHandle = Task { try? await self.dependencies.api.event(key: MatchKey.eventKey(from: self.matchKey)) }
+
+            let match = await matchHandle.value
+            let event = await eventHandle.value
 
 
             if let match {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -104,15 +104,16 @@ class TeamViewController: HeaderContainerViewController {
 
     private func loadTeamData() {
         Task { @MainActor in
-            async let teamTask = dependencies.api.team(key: teamKey)
-            async let yearsTask = dependencies.api.teamYearsParticipated(key: teamKey)
-
-            // Await in reverse declaration order so async let child tasks are torn
-            // down LIFO; otherwise swift_task_dealloc traps. Workaround for a Swift
-            // 6.1 codegen bug — remove once Swift 6.3 is our minimum.
+            // Unstructured Task handles instead of `async let`: Swift 6.1's
+            // async-let stack allocator trips swift_task_dealloc's LIFO check
+            // here even with reverse-order awaits (#995 didn't fully fix it).
+            // Task handles heap-allocate and sidestep the allocator entirely.
             // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
-            let years = try? await yearsTask
-            let team = try? await teamTask
+            let teamHandle = Task { try? await self.dependencies.api.team(key: self.teamKey) }
+            let yearsHandle = Task { try? await self.dependencies.api.teamYearsParticipated(key: self.teamKey) }
+
+            let team = await teamHandle.value
+            let years = await yearsHandle.value
 
 
             if let team {


### PR DESCRIPTION
## Summary
- `TeamViewController.loadTeamData` and `MatchViewController.loadMatchAndEvent` were still using the reverse-order `async let` workaround for the Swift 6.1 async-let stack allocator LIFO crash (#996).
- `TeamAtEventViewController` and `TeamSummaryViewController` already moved to unstructured `Task` handles, which heap-allocate and sidestep the allocator entirely.
- Brings these two remaining spots onto the same pattern so the whole codebase shares one approach to the workaround.

## Test plan
- [ ] Open a Team page (any season) and confirm the team name/number and years-participated list populate without crashing.
- [ ] Open a Match page from an event and confirm the match title and event subtitle populate without crashing.
- [ ] Background the app mid-load for both screens and re-enter to confirm no `swift_task_dealloc` trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)