### PR TITLE
Fix MyTBA sign-in build error and compile main iOS app in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,5 +25,7 @@ jobs:
           bundle exec fastlane setup_secrets
         env:
           TBA_API_KEY: ${{ secrets.TBA_API_KEY }}
+      - name: fastlane build_ci
+        run: bundle exec fastlane build_ci
       - name: fastlane test
         run: bundle exec fastlane test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,6 +28,9 @@ jobs:
           bundle exec fastlane setup_secrets
         env:
           TBA_API_KEY: ${{ secrets.TBA_API_KEY }}
+      - name: fastlane build_ci
+        if: ${{ !contains(github.event.head_commit.message, '[clowntown]') }}
+        run: bundle exec fastlane build_ci
       - name: fastlane test
         if: ${{ !contains(github.event.head_commit.message, '[clowntown]') }}
         run: bundle exec fastlane test

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,6 +23,19 @@ platform :ios do
     test_tbautils
   end
 
+  desc "Compile the main iOS app for CI (no code signing)"
+  lane :build_ci do
+    build_app(
+      project: "the-blue-alliance-ios.xcodeproj",
+      scheme: "The Blue Alliance",
+      destination: "generic/platform=iOS Simulator",
+      skip_archive: true,
+      skip_codesigning: true,
+      skip_package_ipa: true,
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
+    )
+  end
+
   desc "Capture App Store screenshots"
   lane :screenshots do
     capture_screenshots

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,6 +28,7 @@ platform :ios do
     build_app(
       project: "the-blue-alliance-ios.xcodeproj",
       scheme: "The Blue Alliance",
+      configuration: "Debug",
       destination: "generic/platform=iOS Simulator",
       skip_archive: true,
       skip_codesigning: true,

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,6 +47,22 @@ Run TBAUtils unit tests
 
 Run all of our tests
 
+### ios build_ci
+
+```sh
+[bundle exec] fastlane ios build_ci
+```
+
+Compile the main iOS app for CI (no code signing)
+
+### ios screenshots
+
+```sh
+[bundle exec] fastlane ios screenshots
+```
+
+Capture App Store screenshots
+
 ### ios setup_secrets
 
 ```sh
@@ -54,6 +70,14 @@ Run all of our tests
 ```
 
 Setup Secrets.plist file (used by CI)
+
+### ios dsyms
+
+```sh
+[bundle exec] fastlane ios dsyms
+```
+
+Download dSYMs for a specific build. Usage: fastlane dsyms version:3.2.3 build:2
 
 ### ios beta_ci
 

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBASignInViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBASignInViewController.swift
@@ -41,10 +41,6 @@ class MyTBASignInViewController: UIViewController, ASAuthorizationControllerPres
         super.viewDidLoad()
 
         styleInterface()
-
-        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: MyTBASignInViewController, previousTraitCollection) in
-            self.updateInterface(previousTraitCollection: previousTraitCollection)
-        }
     }
 
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
## Summary

- Remove a dangling `registerForTraitChanges` call in `MyTBASignInViewController` that invoked a method deleted in #990 — the Google sign-in button's `configurationUpdateHandler` already refreshes on trait/state changes, so no replacement is needed.
- Add a fastlane `build_ci` lane (xcodebuild against iOS Simulator, no codesigning) and wire it into `pull_request.yml` + `push.yml` ahead of `fastlane test`, so the main iOS app target is actually compiled on every PR/push. Previously CI only ran SPM tests on `MyTBAKit`/`TBAUtils`, which is how #1017 merged with a broken app build.

## Root cause

`#990 — Migrate Google sign-in button to UIButton.Configuration` deliberately removed `traitCollectionDidChange` and `updateInterface(previousTraitCollection:)` since `configurationUpdateHandler` is invoked automatically on state/trait changes. `#1017 — Modernize deprecated iOS APIs` landed three weeks later on a branch forked before #990 and re-added a `registerForTraitChanges` block that referenced `self.updateInterface(previousTraitCollection:)` — but the target method was gone.

## Test plan

- [ ] `bundle exec fastlane build_ci` runs locally and produces `** BUILD SUCCEEDED **`
- [ ] CI (`fastlane build_ci` + `fastlane test`) goes green on this PR
- [ ] Open MyTBA → sign-in screen on a fresh install (light mode)
- [ ] Swap device to dark mode; confirm the Google sign-in button's background image swaps to the dark variant
- [ ] Rotate to landscape on compact-height; confirm the star/favorite/subscription images still hide via the existing `willTransition` handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)