### PR TITLE
Show all event webcasts, not just today's

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -135,11 +135,6 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
             let webcasts = event.webcasts
                 .sorted { $0.channel > $1.channel }
                 .filter { $0.urlString != nil }
-                .filter { webcast in
-                    guard let date = webcast.dateParsed else { return true }
-                    // dateParsed is UTC-midnight; check "today" in UTC to match.
-                    return Calendar.utc.isDateInToday(date)
-                }
                 .map { EventInfoItem.webcast($0) }
             if !webcasts.isEmpty, event.isHappeningThisWeek {
                 snapshot.appendSections([.webcast])


### PR DESCRIPTION
## Summary

- The Event Info webcasts section filtered each webcast by `date == today (UTC)`, so for multi-day events with one webcast per day (e.g. `2026mimtp`'s three YouTube entries for 3/6–3/8) at most one ever rendered — and zero whenever the device's local "today" drifted out of the current UTC day. The filter was effectively ported from the Core Data build, but the old version parsed `yyyy-MM-dd` in local time and compared with `Calendar.current`, so it covered the whole local day; the OpenAPI migration switched both ends to UTC and shrank the visible window.
- Drop the per-day filter. The existing `event.isHappeningThisWeek` guard already prevents stale webcasts from leaking onto finished events, which was the only job the date comparison was usefully doing.
- One file touched, five-line deletion, no behavior change outside the webcast section.

## Test plan

- [ ] Build and run `the-blue-alliance-ios` in the simulator.
- [ ] Open an event within `isHappeningThisWeek` that has multiple dated webcasts — every webcast should appear in Info, regardless of weekday.
- [ ] Reproduce the original regression: toggle the simulator between UTC, America/New_York, and America/Los_Angeles on that same event — webcast count must not change across timezones.
- [ ] Open a finished event (e.g. `2026mimtp` today) and confirm the webcast section is still hidden — `isHappeningThisWeek` is doing that work, unchanged.
- [ ] Open an event with no webcasts and confirm the section is still absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)