### PR TITLE
Fix DCMP grouping regression and match Android section sort

### DIFF
--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
@@ -123,21 +123,18 @@ extension Event {
         return now >= startOfWeek && now <= end
     }
 
-    // Sort key used in place of the Core Data `hybridType` attribute — groups
-    // events by their "conceptual bucket" within a season so the weekly
-    // section headers stack in a sensible order.
-    // Sort key used in place of the Core Data `hybridType` attribute — groups
-    // events by their "conceptual bucket" within a season so the weekly
-    // section headers stack in a sensible order.
+    // Section key used to group events in the Week view. Events sharing this
+    // key land in the same table section, and the lexicographic ordering of
+    // the key (Regional < District < DCMP, and within each type by district
+    // display name) drives the section order the user sees. We key off
+    // displayName rather than abbreviation so section order matches what the
+    // user reads on screen (and matches the Android app).
     var hybridTypeSortKey: String {
-        if isDistrictChampionshipEvent {
-            if eventTypeEnum == .districtChampionshipDivision, let abbrev = district?.abbreviation {
-                return "\(APIEventType.districtChampionship.rawValue)..\(abbrev).dcmpd"
-            }
-            return "\(eventType)"
+        if isDistrictChampionshipEvent, let district {
+            return "\(APIEventType.districtChampionship.rawValue)..\(district.displayName.lowercased()).dcmp"
         }
-        if let district, !isDistrictChampionshipEvent {
-            return "\(eventType).\(district.abbreviation)"
+        if let district {
+            return "\(eventType).\(district.displayName.lowercased())"
         }
         if eventTypeEnum == .offseason, let date = startDateParsed {
             let formatter = DateFormatter()

--- a/the-blue-alliance-ios/Extensions/TBAAPI/WeekEventsGrouping.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/WeekEventsGrouping.swift
@@ -123,17 +123,34 @@ extension Event: @retroactive Comparable {
             }
             return lhsType.rawValue < rhsType.rawValue
         }
-        // Everything else — districts, regionals, DCMPs, DCMP divisions — sorted by week.
-        // Within a week: Regional < District < DCMP Division < DCMP (DCMP div is a higher raw value,
-        // so flip when both sides are district-CMP).
+        // Everything else — districts, regionals, DCMPs, DCMP divisions — has a
+        // week number. Order first by week, then by section within a week, then
+        // by event within a section.
         if let lWeek = lhs.week, let rWeek = rhs.week {
+            // Different weeks: earlier week comes first.
             if lWeek == rWeek {
-                if lhs.isDistrictChampionshipEvent && rhs.isDistrictChampionshipEvent {
-                    if let l = lhs.startDateParsed, let r = rhs.startDateParsed { return l < r }
-                    return lhsType.rawValue > rhsType.rawValue
+                // Same week. Group events into sections using hybridTypeSortKey so
+                // the Week view lays out as Regional → District(name) →
+                // DCMP/Divisions(name). Lexicographic ordering of the key drives
+                // the section order.
+                let lKey = lhs.hybridTypeSortKey
+                let rKey = rhs.hybridTypeSortKey
+                if lKey == rKey {
+                    // Same section. DCMP parents (type 2) and DCMP divisions
+                    // (type 5) share a section per district — within it, the
+                    // parent sorts first so it renders at the top of the
+                    // "{District} District Championship Divisions" list.
+                    if lhs.eventType == rhs.eventType {
+                        // Same section, same type. Break the tie by start date,
+                        // then by key, so the sort is deterministic across reloads.
+                        if let l = lhs.startDateParsed, let r = rhs.startDateParsed, l != r {
+                            return l < r
+                        }
+                        return lhs.key < rhs.key
+                    }
+                    return lhs.eventType < rhs.eventType
                 }
-                if let l = lhs.startDateParsed, let r = rhs.startDateParsed { return l < r }
-                return lhsType.rawValue < rhsType.rawValue
+                return lKey < rKey
             }
             return lWeek < rWeek
         }

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
@@ -101,10 +101,10 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
         let districtName = event.district?.displayName
 
         if event.isDistrictChampionshipEvent {
-            guard let districtName, !event.eventTypeString.isEmpty else { return nil }
-            return event.isDistrictChampionshipDivision
-                ? "\(districtName) \(event.eventTypeString)s"
-                : "\(event.eventTypeString)s"
+            guard let districtName else {
+                return event.eventTypeString.isEmpty ? nil : "\(event.eventTypeString)s"
+            }
+            return districtName
         } else if event.isChampionshipEvent {
             guard !event.eventTypeString.isEmpty else { return nil }
             // CMP Finals is already plural.


### PR DESCRIPTION
## Summary

- DCMP parents and divisions of the same district now live in one section (parent first, divisions below), fixing the regression where every DCMP parent collapsed into a single "District Championships" section above the per-district division sections.
- Section order follows `district.displayName` case-insensitively, matching the Android app. Example Week 7 2026 order:
  `Regional Events → FIRST Canada - Ontario → FIRST in Michigan → FIRST In Texas → FIRST Indiana Robotics → FIRST Mid-Atlantic → FIRST Wisconsin → New England`
- DCMP section title renders the district display name alone (e.g., `FIRST in Michigan`) since the section now contains the parent in addition to its divisions.

## Root cause

Post-Core-Data migration, `hybridTypeSortKey` keyed DCMP divisions by district but returned just `"\(eventType)"` for DCMP parents, so every parent collapsed to one bucket. Combined with the new first-appearance section ordering in `EventsListViewController`, an early-starting parent (Mid-Atlantic, Apr 14) opened the "District Championships" section before any per-district division section — producing the user-reported screenshot.

## Changes

- `Extensions/TBAAPI/APIEvent+Helpers.swift` — `hybridTypeSortKey` uses `district.displayName.lowercased()` for both DCMP and regular district events; DCMP parent + divisions of a district share the key `"2..{displayname}.dcmp"`.
- `Extensions/TBAAPI/WeekEventsGrouping.swift` — within-week `Comparable` now orders by `hybridTypeSortKey`, then by `eventType` (so parent type 2 sorts before division type 5), then by `startDate`, then by `key` for a deterministic tie-break.
- `ViewControllers/Events/EventsListViewController.swift` — DCMP section title is just the district display name.

## Test plan

- [ ] Week 7 2026 renders: Regional Events → FIRST Canada - Ontario → FIRST in Michigan → FIRST In Texas → FIRST Indiana Robotics → FIRST Mid-Atlantic → FIRST Wisconsin → New England
- [ ] Michigan section lists "FIRST in Michigan State Championship" first, then the MSC division events
- [ ] Week 6 (no DCMPs yet) still shows Regional Events + per-district District Events only
- [ ] Championship week (CMP divisions + finals) renders unchanged
- [ ] 2017+ multi-city CMP rows still say "Championship - Houston", "Championship - St. Louis"
- [ ] District detail screen and Team events screen still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)