### PR TITLE
Fetch full git history and tags in release CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,9 @@ jobs:
           xcode-version: latest-stable
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/cache@v4
         with:
           path: vendor/bundle


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` defaults to a shallow clone with no tags, so `changelog_from_git_commits` in the `commit_changelog` fastlane lane had no last-tag anchor and resolved to an empty string.
- That empty changelog flowed into the TestFlight notes handed to beta testers, the `#app-releases` Slack post, and the GitHub release body — every release since v3.2.0 has shipped with blank notes.
- Set `fetch-depth: 0` and `fetch-tags: true` on the checkout step so the release lanes can see the full tag history.

## Test plan
- [ ] On the next `[beta]` push, confirm the TestFlight "What to Test" field is populated with the commit list since the previous tag.
- [ ] On the next `[app_store]` push, confirm the GitHub release body, `#app-releases` Slack message, and TestFlight notes are all non-empty.
- [ ] Verify CI wall-clock time on `main` pushes is not meaningfully worse from the deeper fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)