### PR TITLE
Restore LaunchScreen.storyboard with a modern silhouette

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		928EF686222E026E00A75DDF /* MatchQueryOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928EF685222E026E00A75DDF /* MatchQueryOptionsViewController.swift */; };
 		92942D961E2154DA008E79CA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92942D951E2154DA008E79CA /* AppDelegate.swift */; };
 		92942D9F1E2154DA008E79CA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 92942D9E1E2154DA008E79CA /* Assets.xcassets */; };
+		92942DA21E2154DA008E79CA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 92942DA01E2154DA008E79CA /* LaunchScreen.storyboard */; };
 		92942DAF1E2158EC008E79CA /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 92942DAE1E2158EC008E79CA /* Settings.bundle */; };
 		92942DBB1E215B8D008E79CA /* MyTBAViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92942DBA1E215B8D008E79CA /* MyTBAViewController.swift */; };
 		92943B08222E1DF700EA35B2 /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92943B07222E1DF700EA35B2 /* SwitchTableViewCell.swift */; };
@@ -272,6 +273,7 @@
 		92942D921E2154DA008E79CA /* The Blue Alliance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "The Blue Alliance.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		92942D951E2154DA008E79CA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92942D9E1E2154DA008E79CA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		92942DA11E2154DA008E79CA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		92942DA31E2154DA008E79CA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		92942DAE1E2158EC008E79CA /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		92942DBA1E215B8D008E79CA /* MyTBAViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyTBAViewController.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 		923A0D7620D21D3800BF5E31 /* LaunchViews */ = {
 			isa = PBXGroup;
 			children = (
+				92942DA01E2154DA008E79CA /* LaunchScreen.storyboard */,
 				92E9F0AA216C439700C1F916 /* NoDataViewController.swift */,
 				924AFD782171AB1A00D7BE7E /* NoDataView.xib */,
 			);
@@ -1053,6 +1056,7 @@
 				92942DAF1E2158EC008E79CA /* Settings.bundle in Resources */,
 				9274E14921B1AAD300F5D5D0 /* NotificationStatusTableViewCell.xib in Resources */,
 				304ED0411EF1D2D300E31791 /* RankingTableViewCell.xib in Resources */,
+				92942DA21E2154DA008E79CA /* LaunchScreen.storyboard in Resources */,
 				929BBB081EC55A22006D3854 /* InfoTableViewCell.xib in Resources */,
 				924AFD792171AB1A00D7BE7E /* NoDataView.xib in Resources */,
 				92942D9F1E2154DA008E79CA /* Assets.xcassets in Resources */,
@@ -1252,6 +1256,18 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		92942DA01E2154DA008E79CA /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				92942DA11E2154DA008E79CA /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			path = .;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		92942DA41E2154DA008E79CA /* Debug */ = {

--- a/the-blue-alliance-ios/Info.plist
+++ b/the-blue-alliance-ios/Info.plist
@@ -81,11 +81,8 @@
 			</array>
 		</dict>
 	</dict>
-	<key>UILaunchScreen</key>
-	<dict>
-		<key>UIColorName</key>
-		<string>navigationBarTintColor</string>
-	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/the-blue-alliance-ios/LaunchViews/Base.lproj/LaunchScreen.storyboard
+++ b/the-blue-alliance-ios/LaunchViews/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22690"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TBr-la-un1" userLabel="TopBar">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="169"/>
+                                <color key="backgroundColor" name="navigationBarTintColor"/>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MID-la-un1" userLabel="Middle">
+                                <rect key="frame" x="0.0" y="103" width="393" height="715"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BBr-la-un1" userLabel="BottomBar">
+                                <rect key="frame" x="0.0" y="818" width="393" height="34"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SEP-la-un1" userLabel="Separator">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="0.5"/>
+                                        <color key="backgroundColor" systemColor="separatorColor"/>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="SEP-la-un1" firstAttribute="top" secondItem="BBr-la-un1" secondAttribute="top" id="sp1"/>
+                                    <constraint firstItem="SEP-la-un1" firstAttribute="leading" secondItem="BBr-la-un1" secondAttribute="leading" id="sp2"/>
+                                    <constraint firstItem="BBr-la-un1" firstAttribute="trailing" secondItem="SEP-la-un1" secondAttribute="trailing" id="sp3"/>
+                                    <constraint firstAttribute="height" constant="0.5" id="sp4" firstItem="SEP-la-un1"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="saF-e1-aRa"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="TBr-la-un1" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="c01"/>
+                            <constraint firstItem="TBr-la-un1" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="c02"/>
+                            <constraint firstItem="Ze5-6b-2t3" firstAttribute="trailing" secondItem="TBr-la-un1" secondAttribute="trailing" id="c03"/>
+                            <constraint firstItem="TBr-la-un1" firstAttribute="bottom" secondItem="saF-e1-aRa" secondAttribute="top" constant="44" id="c04"/>
+                            <constraint firstItem="MID-la-un1" firstAttribute="top" secondItem="TBr-la-un1" secondAttribute="bottom" id="c05"/>
+                            <constraint firstItem="MID-la-un1" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="c06"/>
+                            <constraint firstItem="Ze5-6b-2t3" firstAttribute="trailing" secondItem="MID-la-un1" secondAttribute="trailing" id="c07"/>
+                            <constraint firstItem="BBr-la-un1" firstAttribute="top" secondItem="MID-la-un1" secondAttribute="bottom" id="c08"/>
+                            <constraint firstItem="BBr-la-un1" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="c09"/>
+                            <constraint firstItem="Ze5-6b-2t3" firstAttribute="trailing" secondItem="BBr-la-un1" secondAttribute="trailing" id="c10"/>
+                            <constraint firstItem="Ze5-6b-2t3" firstAttribute="bottom" secondItem="BBr-la-un1" secondAttribute="bottom" id="c11"/>
+                            <constraint firstItem="saF-e1-aRa" firstAttribute="bottom" secondItem="BBr-la-un1" secondAttribute="top" constant="50" id="c12"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <namedColor name="navigationBarTintColor">
+            <color red="0.247" green="0.318" blue="0.71" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="separatorColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
## Summary

- Replace the minimal `UILaunchScreen` color-only `Info.plist` dict (added in f51d9dd1) with a storyboard that paints the app's nav bar + content + tab bar silhouette, so the hand-off from launch → first frame doesn't visibly jump.
- Storyboard is a plain `UIViewController` with three Auto-Layout views pinned to `safeAreaLayoutGuide` — no custom classes, runtime attributes, `UITabBarController`, or `UINavigationController` (launch storyboards can't instantiate custom classes anyway, and the old storyboard was malformed for that reason).
- Top bar uses `navigationBarTintColor`; middle + bottom bar use `systemBackground`; a 0.5pt separator hints at the tab bar top edge. All colors via asset/system refs — no baked RGB values.
- Anchors: top-bar bottom at `safeArea.top + 44`, bottom-bar top at `safeArea.bottom − 50`, so the silhouette adapts automatically across Dynamic Island / notched / home-button devices.
- `Info.plist` flips `UILaunchScreen` → `UILaunchStoryboardName`; `.pbxproj` restores the pre-f51d9dd1 object IDs for the storyboard (PBXBuildFile, PBXFileReference, PBXVariantGroup, LaunchViews group child, Resources phase entry) so git blame stays clean.

## Test plan

- [ ] Build `The Blue Alliance` scheme for an iPhone 17 Pro simulator and cold-launch — confirm no visual jump from launch screen to first frame.
- [ ] Repeat in dark mode — top bar becomes `systemGray6`, middle/bottom become black, separator renders.
- [ ] Launch on an iPhone SE / non-Dynamic-Island simulator if available — confirm the silhouette still lines up (anchors are safe-area-relative).
- [ ] `grep UILaunchScreen the-blue-alliance-ios/Info.plist` → no hits; `grep UILaunchStoryboardName` → one hit pointing at `LaunchScreen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)