### PR TITLE
Consolidate UTC date handling and fix endOfMonth TZ leak

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPI.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPI.swift
@@ -23,6 +23,7 @@ public final class TBAAPI {
     public static let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         return dateFormatter
     }()
 

--- a/Packages/TBAUtils/Sources/TBAUtils/Calendar/Calendar+TBA.swift
+++ b/Packages/TBAUtils/Sources/TBAUtils/Calendar/Calendar+TBA.swift
@@ -16,7 +16,7 @@ extension Calendar {
     /// math like `endOfDay` doesn't clip against the user's local offset.
     public static let utc: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        calendar.timeZone = .utc
         return calendar
     }()
 

--- a/Packages/TBAUtils/Sources/TBAUtils/Date/Date+TBA.swift
+++ b/Packages/TBAUtils/Sources/TBAUtils/Date/Date+TBA.swift
@@ -18,7 +18,7 @@ extension Date {
     }
 
     public func endOfMonth(calendar: Calendar = Calendar.current) -> Date {
-        return calendar.date(byAdding: DateComponents(month: 1, day: -1), to: self.startOfMonth())!
+        return calendar.date(byAdding: DateComponents(month: 1, day: -1), to: self.startOfMonth(calendar: calendar))!
     }
 
     /**

--- a/Packages/TBAUtils/Sources/TBAUtils/TimeZone/TimeZone+TBA.swift
+++ b/Packages/TBAUtils/Sources/TBAUtils/TimeZone/TimeZone+TBA.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension TimeZone {
+    /// UTC, for pinning `DateFormatter.timeZone` when parsing or rendering
+    /// TBA's `yyyy-MM-dd` event dates. Companion to `Calendar.utc`.
+    public static let utc: TimeZone = TimeZone(abbreviation: "UTC") ?? .current
+}

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
@@ -76,7 +76,7 @@ extension Event {
         guard let date = startDateParsed else { return nil }
         let formatter = DateFormatter()
         formatter.dateFormat = "MMMM"
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.timeZone = .utc
         return formatter.string(from: date)
     }
 
@@ -112,8 +112,7 @@ extension Event {
         return now >= start && now <= end
     }
 
-    // Ported from TBAData.Event.isHappeningThisWeek: the event is going on
-    // now or starts within the next week.
+    // Event is going on now or starts within the next week.
     var isHappeningThisWeek: Bool {
         guard let start = startDateParsed, let end = endOfEventDay else { return false }
         guard let startOfWeek = Calendar.utc.date(byAdding: .day, value: -7, to: start) else {
@@ -128,11 +127,11 @@ extension Event {
 extension Event {
 
     // Parsed Date form of the API's string date fields. The generated struct
-    // stores `startDate` and `endDate` as ISO-ish `yyyy-MM-dd` strings; these
-    // use a matching formatter in UTC so our in-memory Date comparisons are
-    // consistent regardless of the user's locale.
-    var startDateParsed: Date? { APIEventDateFormatter.shared.date(from: startDate) }
-    var endDateParsed: Date? { APIEventDateFormatter.shared.date(from: endDate) }
+    // stores `startDate` and `endDate` as ISO-ish `yyyy-MM-dd` strings;
+    // `TBAAPI.dateFormatter` parses them in UTC so in-memory Date comparisons
+    // are consistent regardless of the user's locale.
+    var startDateParsed: Date? { TBAAPI.dateFormatter.date(from: startDate) }
+    var endDateParsed: Date? { TBAAPI.dateFormatter.date(from: endDate) }
 
     var locationString: String? {
         let parts = [city, stateProv, country].compactMap { $0 }.filter { !$0.isEmpty }
@@ -145,11 +144,11 @@ extension Event {
         // users west of UTC don't see the range shifted back a day.
         let shortFormatter = DateFormatter()
         shortFormatter.dateFormat = "MMM dd"
-        shortFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        shortFormatter.timeZone = .utc
 
         let longFormatter = DateFormatter()
         longFormatter.dateFormat = "MMM dd, y"
-        longFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        longFormatter.timeZone = .utc
 
         if start == end {
             return shortFormatter.string(from: end)
@@ -159,13 +158,4 @@ extension Event {
         }
         return "\(shortFormatter.string(from: start)) to \(longFormatter.string(from: end))"
     }
-}
-
-private enum APIEventDateFormatter {
-    static let shared: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        return formatter
-    }()
 }

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIWebcast+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIWebcast+Helpers.swift
@@ -3,7 +3,6 @@ import TBAAPI
 
 extension Webcast {
 
-    // Matches the string enum in TBAData's `Webcast.type`.
     var typeString: String { _type.rawValue }
 
     var displayName: String {
@@ -39,9 +38,6 @@ extension Webcast {
 
     var dateParsed: Date? {
         guard let date else { return nil }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        return formatter.date(from: date)
+        return TBAAPI.dateFormatter.date(from: date)
     }
 }


### PR DESCRIPTION
## Summary
- Add `TimeZone.utc` in TBAUtils as a companion to the existing `Calendar.utc`, and switch the main-app `yyyy-MM-dd` / `MMM dd` / `MMMM` formatters from open-coded `TimeZone(abbreviation: "UTC")` to `.utc`.
- Consolidate the three duplicate UTC `yyyy-MM-dd` parsers onto the public `TBAAPI.dateFormatter` (now pinned to UTC). `APIEvent.startDateParsed` / `endDateParsed` and `APIWebcast.dateParsed` route through it; the private `APIEventDateFormatter` enum and the inline webcast formatter are deleted.
- Fix a latent bug in `Date.endOfMonth(calendar:)` where `self.startOfMonth()` dropped the `calendar` argument and fell back to `Calendar.current`. Callers passing `.utc` (e.g. the offseason month filter in `WeekEventsViewController`) were silently mixing user-local and UTC month anchors, which could drop events on the last few days of the month for users east of UTC.

No behavior change for the main-path event rendering — these are consolidations plus one correctness fix in a utility function.

## Test plan
- [ ] Build `The Blue Alliance` scheme in Xcode — confirm clean compile. (Verified locally with `xcodebuild -skipPackagePluginValidation build`.)
- [ ] Run `TBAUtilsTests` — existing `Calendar.utc` / `Date+TBA` tests pass unchanged.
- [ ] Smoke-run Events tab: event date ranges ("Mar 23 to Apr 04"), week headers ("Week 3"), offseason month labels ("March Offseason") render identically to pre-change.
- [ ] Smoke-run Event Info with a live webcast event — webcast section appears when expected (`isHappeningThisWeek` still correct).
- [ ] `grep -rn 'TimeZone(abbreviation: "UTC")' the-blue-alliance-ios Packages` → only hits are `TBAAPI.swift` (package isolation from TBAUtils) and the `TimeZone.utc` definition itself.
- [ ] `grep -rn 'APIEventDateFormatter' the-blue-alliance-ios` → zero matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)