### PR TITLE
Fix myTBA Preferences subscription loading, header, and match cell overlap

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAPreferenceViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAPreferenceViewController.swift
@@ -11,14 +11,14 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
         return subscribableModelClass.notificationTypes
     }()
 
-    let isFavoriteInitially: Bool
+    private(set) var isFavoriteInitially: Bool
     var isFavorite: Bool {
         didSet {
             updateInterface()
         }
     }
 
-    let notificationsInitial: [NotificationType]
+    private(set) var notificationsInitial: [NotificationType]
     var notifications: [NotificationType] {
         didSet {
             updateInterface()
@@ -29,6 +29,19 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
     private var subscriptionsStore: SubscriptionsStore { myTBAStores.subscriptions }
 
     private var preferencesTask: Task<Void, Never>?
+    private var loadTask: Task<Void, Never>?
+
+    // Set while fetching current state from the server on sheet open. If the
+    // fetch fails we keep Save disabled so a stale empty toggle set can't
+    // silently wipe the user's real server-side subscriptions.
+    private var isLoading: Bool = false {
+        didSet {
+            DispatchQueue.main.async {
+                self.updateInterface()
+            }
+        }
+    }
+    private var loadFailed: Bool = false
 
     var hasChanges: Bool {
         return (notifications != notificationsInitial) || (isFavorite != isFavoriteInitially)
@@ -80,12 +93,14 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
         super.viewDidLoad()
 
         styleInterface()
+        refresh()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
         preferencesTask?.cancel()
+        loadTask?.cancel()
     }
 
     // MARK: - Interface Methods
@@ -96,13 +111,60 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
     }
 
     func updateInterface() {
-        saveBarButtonItem.isEnabled = hasChanges
+        saveBarButtonItem.isEnabled = hasChanges && !isLoading && !loadFailed
         isModalInPresentation = hasChanges
 
-        if isSaving {
+        if isSaving || isLoading {
             navigationItem.rightBarButtonItem = saveActivityIndicatorBarButtonItem
         } else {
             navigationItem.rightBarButtonItem = saveBarButtonItem
+        }
+    }
+
+    // The local myTBA stores are only populated when the user visits the
+    // corresponding tab in myTBA. Since this sheet can be opened directly from
+    // a team/event/match screen, pull the authoritative state from the server
+    // before letting the user edit — otherwise empty toggles could overwrite
+    // real subscriptions on Save.
+    private func refresh() {
+        guard myTBA.isAuthenticated else { return }
+
+        isLoading = true
+        loadFailed = false
+        loadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                async let favorites = self.myTBA.fetchFavorites()
+                async let subscriptions = self.myTBA.fetchSubscriptions()
+                let (fetchedFavorites, fetchedSubscriptions) = try await (favorites, subscriptions)
+
+                self.favoritesStore.replaceAll(with: fetchedFavorites)
+                self.subscriptionsStore.replaceAll(with: fetchedSubscriptions)
+
+                let existingFavorite = fetchedFavorites.first {
+                    $0.modelKey == self.subscribableModel.modelKey && $0.modelType == self.subscribableModel.modelType
+                }
+                self.isFavorite = (existingFavorite != nil)
+                self.isFavoriteInitially = self.isFavorite
+
+                let existingSubscription = fetchedSubscriptions.first {
+                    $0.modelKey == self.subscribableModel.modelKey && $0.modelType == self.subscribableModel.modelType
+                }
+                self.notifications = existingSubscription?.notifications ?? []
+                self.notificationsInitial = self.notifications
+
+                self.loadTask = nil
+                self.isLoading = false
+                self.tableView.reloadData()
+            } catch is CancellationError {
+                self.loadTask = nil
+                self.isLoading = false
+            } catch {
+                self.loadTask = nil
+                self.loadFailed = true
+                self.isLoading = false
+                self.showErrorAlert(with: "Unable to load myTBA preferences - \(error.localizedDescription)")
+            }
         }
     }
 
@@ -211,7 +273,7 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
 
         }()
 
-        cell.switchView.isEnabled = !isSaving
+        cell.switchView.isEnabled = !isSaving && !isLoading
         cell.selectionStyle = .none
 
         return cell
@@ -236,6 +298,12 @@ class MyTBAPreferenceViewController: TBATableViewController, UIAdaptivePresentat
             return "Notification Settings"
         }
         return nil
+    }
+
+    // Modal grouped sheet — fall back to the iOS default header rendering
+    // instead of TBATableViewController's navy-on-white tab chrome.
+    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        // Intentionally not calling super.
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -126,8 +126,6 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
                 let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
                 if let match = self.matchesCache[key] {
                     cell.viewModel = MatchViewModel(apiMatch: match)
-                } else {
-                    cell.textLabel?.text = key
                 }
                 return cell
             }

--- a/the-blue-alliance-ios/ViewElements/Match/MatchTableViewCell.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchTableViewCell.swift
@@ -25,6 +25,7 @@ class MatchTableViewCell: UITableViewCell, Reusable {
         super.prepareForReuse()
 
         matchSummaryView?.resetView()
+        textLabel?.text = nil
     }
 
 }


### PR DESCRIPTION
## Summary

Three regressions in the myTBA flow, most critically a data-loss risk where saving preferences could silently wipe server-side subscriptions.

- **Subscriptions couldn't be edited.** Opening the Preferences sheet for a team the user subscribes to (e.g. team 1684 with Alliance Selection + Awards Posted on the web) showed every notification toggle OFF. `MyTBAPreferenceViewController.init` was reading `subscriptionsStore` synchronously, but that store is only populated when the user visits the myTBA Subscriptions tab — if they hit the star icon from a team/event/match screen first, it's empty. Save would then send `notifications: []` and wipe the user's real server-side subscriptions. Fixed by refreshing favorites + subscriptions from the server in `viewDidLoad`, with Save disabled while loading and after a failed fetch so stale state can't overwrite the server.

- **Preferences sheet header looked wrong.** #984 re-parented `MyTBAPreferenceViewController` from `UITableViewController` to `TBATableViewController`, which unconditionally paints section headers white-on-navy for the main myTBA tab. On a modal grouped sheet that styling is out of place — "Notification Settings" should be default iOS grouped-style grey. Overrode `willDisplayHeaderView` as a no-op on this sheet only; the four other `.grouped` subclasses (Settings, Notifications, TeamInfo, EventInfo) keep the navy chrome.

- **myTBA Favorites match cell had overlapping text.** The raw match key (e.g. `2002cmp_f1m3`) was visibly drawn under the MatchSummaryView's score/team grid. `MyTBATableViewController` fell back to `cell.textLabel?.text = key` when the match cache was cold, and `MatchTableViewCell.prepareForReuse` never cleared it, so the text persisted after the viewModel landed. Dropped the fallback and clear `textLabel` in `prepareForReuse` as belt-and-suspenders.

## Test plan

- [ ] Sign into the app. Go straight to the myTBA tab (default = Favorites), then navigate to a team with existing server-side subscriptions and tap the star. Confirm: activity indicator on Save briefly → toggles settle with the real subscriptions ON, Favorite toggle reflects real state, Save disabled until you actually change something.
- [ ] Toggle one subscription off and Save. Verify on the TBA web UI that only that subscription was removed — no silent wipe of others.
- [ ] Airplane mode → open Preferences. Error alert surfaces, Save stays disabled, Close still works.
- [ ] Visual: "Notification Settings" header renders in default iOS grouped-style grey, not navy-on-white.
- [ ] Sanity: Settings / Notifications / TeamInfo / EventInfo headers still wear the navy chrome (unchanged).
- [ ] Favorite a recently-played match. Pull-to-refresh on myTBA → Favorites. During fetch the match row is empty (no overlapping raw key); once loaded, MatchSummaryView renders cleanly with no leftover text under the score grid.
- [ ] `xcodebuild -scheme MyTBAKit test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)