### PR TITLE
Refresh Firebase ID token per-request instead of caching it on MyTBA

### DIFF
--- a/Packages/MyTBAKit/Sources/MyTBAKit/Classes/MyTBA.swift
+++ b/Packages/MyTBAKit/Sources/MyTBAKit/Classes/MyTBA.swift
@@ -36,38 +36,38 @@ extension URLSession: MyTBAURLSession {}
 
 open class MyTBA {
 
-    // This is public, which is terrible, because it shouldn't be. But we need it so in TBA
-    // when Firebase Auth changes, we can remove the token
-    public var authToken: String? {
-        didSet {
-            // Only disaptch on changed state
-            if oldValue == authToken {
-                return
-            }
-
-            authenticationProvider.post { (observer) in
-                if authToken == nil {
-                    observer.unauthenticated()
-                } else {
-                    observer.authenticated()
-                }
-            }
-        }
+    public var isAuthenticated: Bool {
+        return idTokenProvider.isSignedIn
     }
 
-    public var isAuthenticated: Bool {
-        return authToken != nil
+    // Called by the host app when the underlying auth identity changes
+    // (sign-in / sign-out). Token refreshes in between do not flow through
+    // here — they're picked up per-request via `idTokenProvider.idToken()`.
+    public func notifyAuthStateChanged(isAuthenticated: Bool) {
+        if lastPostedAuthState == isAuthenticated {
+            return
+        }
+        lastPostedAuthState = isAuthenticated
+        authenticationProvider.post { observer in
+            if isAuthenticated {
+                observer.authenticated()
+            } else {
+                observer.unauthenticated()
+            }
+        }
     }
 
     public init(
         uuid: String,
         deviceName: String,
         fcmTokenProvider: FCMTokenProvider,
+        idTokenProvider: IDTokenProvider,
         urlSession: MyTBAURLSession? = nil
     ) {
         self.uuid = uuid
         self.deviceName = deviceName
         self.fcmTokenProvider = fcmTokenProvider
+        self.idTokenProvider = idTokenProvider
         self.urlSession = urlSession ?? URLSession(configuration: .default)
     }
 
@@ -81,6 +81,8 @@ open class MyTBA {
     internal var uuid: String
     internal var deviceName: String
     private var fcmTokenProvider: FCMTokenProvider
+    private var idTokenProvider: IDTokenProvider
+    private var lastPostedAuthState: Bool?
 
     static var jsonEncoder: JSONEncoder {
         let jsonEncoder = JSONEncoder()
@@ -94,13 +96,14 @@ open class MyTBA {
         return jsonDecoder
     }
 
-    func createRequest(_ method: String, _ bodyData: Data? = nil) -> URLRequest {
+    func createRequest(_ method: String, _ bodyData: Data? = nil) async throws -> URLRequest {
         let apiURL = URL(string: method, relativeTo: Constants.APIConstants.baseURL)!
         var request = URLRequest(url: apiURL)
         request.httpMethod = "POST"
 
-        if let authToken = authToken {
-            request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        if idTokenProvider.isSignedIn {
+            let token = try await idTokenProvider.idToken()
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
         #if DEBUG
@@ -117,7 +120,7 @@ open class MyTBA {
     }
 
     func callApi<T: MyTBAResponse>(method: String, bodyData: Data? = nil) async throws -> T {
-        let request = createRequest(method, bodyData)
+        let request = try await createRequest(method, bodyData)
         let (data, response) = try await urlSession.data(for: request)
 
         if let http = response as? HTTPURLResponse, http.statusCode == 500 {

--- a/Packages/MyTBAKit/Sources/MyTBAKit/Protocols/IDTokenProvider.swift
+++ b/Packages/MyTBAKit/Sources/MyTBAKit/Protocols/IDTokenProvider.swift
@@ -1,0 +1,8 @@
+public protocol IDTokenProvider: AnyObject {
+    // True when a user is signed in, independent of token freshness.
+    var isSignedIn: Bool { get }
+
+    // Returns a fresh ID token. Implementations are expected to silently
+    // refresh expired tokens (Firebase's `getIDToken(completion:)` does this).
+    func idToken() async throws -> String
+}

--- a/Packages/MyTBAKit/Sources/MyTBAKit/Protocols/MyTBAProtocol.swift
+++ b/Packages/MyTBAKit/Sources/MyTBAKit/Protocols/MyTBAProtocol.swift
@@ -2,9 +2,10 @@ import Foundation
 import TBAUtils
 
 public protocol MyTBAProtocol: AnyObject {
-    var authToken: String? { get set }
     var isAuthenticated: Bool { get }
     var authenticationProvider: Provider<MyTBAAuthenticationObservable> { get }
+
+    func notifyAuthStateChanged(isAuthenticated: Bool)
 
     func ping() async throws -> MyTBABaseResponse
     func register() async throws -> MyTBABaseResponse

--- a/Packages/MyTBAKit/Tests/MyTBAKitTests/Classes/MyTBATests.swift
+++ b/Packages/MyTBAKit/Tests/MyTBAKitTests/Classes/MyTBATests.swift
@@ -27,7 +27,13 @@ class MyTBATests: MyTBATestCase {
         let fcmToken = "abc"
 
         let mfcm = MockFCMTokenProvider(fcmToken: fcmToken)
-        let zz = MyTBA(uuid: uuid, deviceName: deviceName, fcmTokenProvider: mfcm)
+        let midTokenProvider = MockIDTokenProvider()
+        let zz = MyTBA(
+            uuid: uuid,
+            deviceName: deviceName,
+            fcmTokenProvider: mfcm,
+            idTokenProvider: midTokenProvider
+        )
         XCTAssertEqual(zz.uuid, uuid)
         XCTAssertEqual(zz.deviceName, deviceName)
         XCTAssertEqual(zz.fcmToken, fcmToken)
@@ -37,11 +43,12 @@ class MyTBATests: MyTBATestCase {
         let authObserver = MockAuthObserver()
         myTBA.authenticationProvider.add(observer: authObserver)
 
-        XCTAssertNil(myTBA.authToken)
+        XCTAssertFalse(myTBA.isAuthenticated)
 
         let authenticatedExpectation = expectation(description: "myTBA Authenticated")
         authObserver.authenticatedExpectation = authenticatedExpectation
-        myTBA.authToken = "abcd123"
+        myTBA.idTokenProvider.isSignedIn = true
+        myTBA.notifyAuthStateChanged(isAuthenticated: true)
         wait(for: [authenticatedExpectation], timeout: 1.0)
     }
 
@@ -49,27 +56,13 @@ class MyTBATests: MyTBATestCase {
         let authObserver = MockAuthObserver()
         myTBA.authenticationProvider.add(observer: authObserver)
 
-        XCTAssertNil(myTBA.authToken)
-        myTBA.authToken = "abcd123"
+        myTBA.idTokenProvider.isSignedIn = true
+        myTBA.notifyAuthStateChanged(isAuthenticated: true)
 
         let authenticatedExpectation = expectation(description: "myTBA Authenticated")
         authenticatedExpectation.isInverted = true
         authObserver.authenticatedExpectation = authenticatedExpectation
-        myTBA.authToken = "abcd123"
-
-        wait(for: [authenticatedExpectation], timeout: 1.0)
-    }
-
-    func test_authenticationProvider_changed() {
-        let authObserver = MockAuthObserver()
-        myTBA.authenticationProvider.add(observer: authObserver)
-
-        XCTAssertNil(myTBA.authToken)
-        myTBA.authToken = "abcd123"
-
-        let authenticatedExpectation = expectation(description: "myTBA Authenticated")
-        authObserver.authenticatedExpectation = authenticatedExpectation
-        myTBA.authToken = "321dcba"
+        myTBA.notifyAuthStateChanged(isAuthenticated: true)
 
         wait(for: [authenticatedExpectation], timeout: 1.0)
     }
@@ -78,21 +71,22 @@ class MyTBATests: MyTBATestCase {
         let authObserver = MockAuthObserver()
         myTBA.authenticationProvider.add(observer: authObserver)
 
-        XCTAssertNil(myTBA.authToken)
-        myTBA.authToken = "abcd123"
+        myTBA.idTokenProvider.isSignedIn = true
+        myTBA.notifyAuthStateChanged(isAuthenticated: true)
 
         let unauthenticatedExpectation = expectation(description: "myTBA Unauthenticated")
         authObserver.unauthenticatedExpectation = unauthenticatedExpectation
-        myTBA.authToken = nil
+        myTBA.idTokenProvider.isSignedIn = false
+        myTBA.notifyAuthStateChanged(isAuthenticated: false)
 
         wait(for: [unauthenticatedExpectation], timeout: 1.0)
     }
 
     func test_isAuthenticated() {
         XCTAssertFalse(myTBA.isAuthenticated)
-        myTBA.authToken = "abcd123"
+        myTBA.idTokenProvider.isSignedIn = true
         XCTAssert(myTBA.isAuthenticated)
-        myTBA.authToken = nil
+        myTBA.idTokenProvider.isSignedIn = false
         XCTAssertFalse(myTBA.isAuthenticated)
     }
 
@@ -107,7 +101,8 @@ class MyTBATests: MyTBATestCase {
     }
 
     func test_callApi_hasBearer() async throws {
-        myTBA.authToken = "abcd123"
+        myTBA.idTokenProvider.isSignedIn = true
+        myTBA.idTokenProvider.stubbedToken = "abcd123"
         myTBA.stub(for: "favorites/list")
         _ = try await myTBA.fetchFavorites()
 
@@ -123,7 +118,7 @@ class MyTBATests: MyTBATestCase {
             XCTFail()
             return
         }
-        XCTAssert(authorizationHeader.contains("Bearer"))
+        XCTAssertEqual(authorizationHeader, "Bearer abcd123")
     }
 
 }

--- a/Packages/MyTBAKit/Tests/MyTBAKitTests/MockMyTBA.swift
+++ b/Packages/MyTBAKit/Tests/MyTBAKitTests/MockMyTBA.swift
@@ -12,17 +12,41 @@ public class MockFCMTokenProvider: FCMTokenProvider {
     }
 }
 
+public class MockIDTokenProvider: IDTokenProvider {
+    public var isSignedIn: Bool
+    public var stubbedToken: String
+    public var stubbedError: Error?
+
+    public init(isSignedIn: Bool = false, stubbedToken: String = "mock-id-token") {
+        self.isSignedIn = isSignedIn
+        self.stubbedToken = stubbedToken
+    }
+
+    public func idToken() async throws -> String {
+        if let stubbedError {
+            throw stubbedError
+        }
+        return stubbedToken
+    }
+}
+
 public class MockMyTBA: MyTBA {
 
     public let session: MockURLSession
+    public let idTokenProvider: MockIDTokenProvider
 
-    public init(fcmTokenProvider: FCMTokenProvider) {
+    public init(
+        fcmTokenProvider: FCMTokenProvider,
+        idTokenProvider: MockIDTokenProvider = MockIDTokenProvider()
+    ) {
         self.session = MockURLSession()
+        self.idTokenProvider = idTokenProvider
 
         super.init(
             uuid: "abcd123",
             deviceName: "MyTBATesting",
             fcmTokenProvider: fcmTokenProvider,
+            idTokenProvider: idTokenProvider,
             urlSession: session
         )
     }

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -19,6 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let favoritesStore = FavoritesStore()
     let subscriptionsStore = SubscriptionsStore()
     let urlOpener: URLOpener = UIApplication.shared
+    let idTokenProvider = FirebaseIDTokenProvider()
 
     let appSettings = AppSettings()
 
@@ -33,7 +34,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy var myTBA: any MyTBAProtocol = MyTBA(
         uuid: UIDevice.current.identifierForVendor!.uuidString,
         deviceName: UIDevice.current.name,
-        fcmTokenProvider: messaging
+        fcmTokenProvider: messaging,
+        idTokenProvider: idTokenProvider
     )
     lazy var pushService: PushService = PushService(
         errorRecorder: errorRecorder,
@@ -144,15 +146,11 @@ private extension AppDelegate {
     }
 
     func configureAuth() {
-        _ = Auth.auth().addIDTokenDidChangeListener { [weak self] _, user in
-            guard let self else { return }
-            if let user = user {
-                user.getIDToken { token, _ in
-                    self.myTBA.authToken = token
-                }
-            } else {
-                self.myTBA.authToken = nil
-            }
+        // Coarse-grained auth state — fires on sign-in / sign-out only.
+        // The actual ID token is fetched per-request via `FirebaseIDTokenProvider`,
+        // so we no longer listen for (or care about) token refreshes here.
+        _ = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            self?.myTBA.notifyAuthStateChanged(isAuthenticated: user != nil)
         }
         restorePreviousSignIn()
     }
@@ -261,6 +259,37 @@ extension AppDelegate: RemoteNotificationRegistering {
 // MARK: - FCMTokenProvider conformance for Firebase Messaging
 
 extension Messaging: @retroactive FCMTokenProvider {}
+
+// MARK: - IDTokenProvider
+
+// Wraps Firebase Auth's `currentUser.getIDToken(completion:)`, which returns
+// a cached token if it's still fresh and silently refreshes if it's expired.
+// Called on every myTBA request, so stale tokens never pile up.
+final class FirebaseIDTokenProvider: IDTokenProvider {
+
+    var isSignedIn: Bool {
+        Auth.auth().currentUser != nil
+    }
+
+    func idToken() async throws -> String {
+        guard let user = Auth.auth().currentUser else {
+            throw MyTBAError.error(401, "Not signed in")
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            user.getIDToken { token, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let token {
+                    continuation.resume(returning: token)
+                } else {
+                    continuation.resume(
+                        throwing: MyTBAError.error(401, "Firebase returned no ID token")
+                    )
+                }
+            }
+        }
+    }
+}
 
 // MARK: - Appearance
 


### PR DESCRIPTION
## Summary

Fixes a class of bug where myTBA requests randomly start failing with `{code: 401, message: \"Unauthorized...\"}` until the user kills and relaunches the app.

**Root cause:** Firebase ID tokens expire after 1 hour. The old wiring cached whatever token the first `addIDTokenDidChangeListener` callback gave us into `MyTBA.authToken` and reused that string on every subsequent request. Firebase is *supposed* to auto-refresh and fire the listener again, but in practice that listener doesn't always fire in time — the cached string goes stale, the server rejects requests with a body-encoded 401, and users have to relaunch to clear it. Relaunch \"fixes\" it because `restorePreviousSignIn` explicitly fetches a fresh token.

**Fix:** stop caching. Replace `MyTBA.authToken` with an injected async `IDTokenProvider` that gets consulted on every request. Firebase's own `currentUser.getIDToken(completion:)` returns a cached-if-fresh / silently-refreshed-if-expired token — exactly the behavior we want. The stale-cache class of bug disappears.

- New `IDTokenProvider` protocol (mirrors the existing `FCMTokenProvider` shape; async + throwing since `getIDToken` is async).
- `MyTBA` takes it at init; `createRequest` is now `async throws` and awaits `idTokenProvider.idToken()` on each call. `isAuthenticated` delegates to the provider.
- Auth-state observers (`authenticated()` / `unauthenticated()`) fire through an explicit `notifyAuthStateChanged(isAuthenticated:)` call rather than a `didSet` on the token string — token rotations no longer post spurious observer events.
- `AppDelegate` implements `FirebaseIDTokenProvider` (wraps `Auth.auth().currentUser.getIDToken` in `withCheckedThrowingContinuation`) and swaps `addIDTokenDidChangeListener` for the coarser-grained `addStateDidChangeListener`, which only fires on sign-in / sign-out. Token refreshes aren't something we need to observe anymore.

**What's NOT fixed here (intentional):** a separate bug where a 401 response body (`{code: 401, favorites: []}`) silently decodes as an empty list and wipes the local store via `replaceAll(with: [])`. Once the token stays fresh the 401 condition stops happening, so that bug stops firing — but the underlying decode gap is real and deserves its own PR.

## Test plan

- [ ] `swift test --package-path Packages/MyTBAKit` — all eight `MyTBATests` pass (authenticated / noChange / unauthenticated / callApi_hasBearer / isAuthenticated / jsonEncoder / jsonDecoder / init) against the new mock-provider setup.
- [ ] `xcodebuild -project the-blue-alliance-ios.xcodeproj -scheme \"The Blue Alliance\" -destination \"generic/platform=iOS Simulator\" build` — ✅ BUILD SUCCEEDED locally.
- [ ] Sign in. Hit myTBA endpoints immediately — should succeed.
- [ ] Leave the app idle for 70+ minutes (past the 1-hour token expiry), come back, open the Preferences sheet for a favorited team. Previously this was the stale-token repro: toggles would be all-off and the console showed `code: 401`. Expect now: toggles load with real state, no 401.
- [ ] Fresh sign-in: `PushService.authenticated()` fires (push token registers), favorite star appears, myTBA tab refreshes.
- [ ] Sign out: observers fire `unauthenticated()` and UI collapses to the sign-in screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)