### PR TITLE
Add Firebase Analytics/Crashlytics opt-out toggles in Settings

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		92A5E5DD21A22D550025CC85 /* Int16+Suffix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5D221A22D550025CC85 /* Int16+Suffix.swift */; };
 		92AABBCC000000000000DD01 /* CachePolicyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AABBCC000000000000DD02 /* CachePolicyStore.swift */; };
 		92AABBCC000000000000DD11 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AABBCC000000000000DD12 /* AppSettings.swift */; };
+		92AABBCC000000000000DD21 /* FirebaseCollectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AABBCC000000000000DD22 /* FirebaseCollectionStore.swift */; };
 		92AF4D0C1E330790007E967D /* SelectTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AF4D0B1E330790007E967D /* SelectTableViewController.swift */; };
 		92AF73D821EB9E1E006A338D /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AF73D721EB9E1E006A338D /* SearchViewController.swift */; };
 		92B3873E21CAF6740041A049 /* IconTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B3873D21CAF6740041A049 /* IconTableViewCell.swift */; };
@@ -300,6 +301,7 @@
 		92A7B62F26D01BB900EECCC9 /* TBAUtils */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TBAUtils; sourceTree = "<group>"; };
 		92AABBCC000000000000DD02 /* CachePolicyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachePolicyStore.swift; sourceTree = "<group>"; };
 		92AABBCC000000000000DD12 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		92AABBCC000000000000DD22 /* FirebaseCollectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseCollectionStore.swift; sourceTree = "<group>"; };
 		92AF4D0B1E330790007E967D /* SelectTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectTableViewController.swift; sourceTree = "<group>"; };
 		92AF73D721EB9E1E006A338D /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		92B3873D21CAF6740041A049 /* IconTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconTableViewCell.swift; sourceTree = "<group>"; };
@@ -745,6 +747,7 @@
 			children = (
 				92AABBCC000000000000DD12 /* AppSettings.swift */,
 				92AABBCC000000000000DD02 /* CachePolicyStore.swift */,
+				92AABBCC000000000000DD22 /* FirebaseCollectionStore.swift */,
 			);
 			path = LocalStore;
 			sourceTree = "<group>";
@@ -1240,6 +1243,7 @@
 				92598CC724A92AFE007E08CB /* Dependencies.swift in Sources */,
 				92AABBCC000000000000DD01 /* CachePolicyStore.swift in Sources */,
 				92AABBCC000000000000DD11 /* AppSettings.swift in Sources */,
+				92AABBCC000000000000DD21 /* FirebaseCollectionStore.swift in Sources */,
 				92FF10F721A61AC2003BC5C4 /* MatchInfoViewController.swift in Sources */,
 				9279737D23CFF3A700FF9B86 /* EventInsightsConfigurator2018.swift in Sources */,
 				92564C6B21644AA30047917F /* Secrets.swift in Sources */,

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -125,8 +125,10 @@ private extension AppDelegate {
             Analytics.setAnalyticsCollectionEnabled(false)
             Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
         #else
-            Analytics.setAnalyticsCollectionEnabled(true)
-            Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
+            Analytics.setAnalyticsCollectionEnabled(appSettings.firebaseCollection.analyticsEnabled)
+            Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(
+                appSettings.firebaseCollection.crashlyticsEnabled
+            )
         #endif
     }
 

--- a/the-blue-alliance-ios/LocalStore/AppSettings.swift
+++ b/the-blue-alliance-ios/LocalStore/AppSettings.swift
@@ -3,8 +3,10 @@ import Foundation
 struct AppSettings {
 
     let cachePolicy: CachePolicyStore
+    let firebaseCollection: FirebaseCollectionStore
 
     init(defaults: UserDefaults = .standard) {
         self.cachePolicy = CachePolicyStore(defaults: defaults)
+        self.firebaseCollection = FirebaseCollectionStore(defaults: defaults)
     }
 }

--- a/the-blue-alliance-ios/LocalStore/FirebaseCollectionStore.swift
+++ b/the-blue-alliance-ios/LocalStore/FirebaseCollectionStore.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+private let kAnalyticsCollectionEnabled = "kAnalyticsCollectionEnabled"
+private let kCrashlyticsCollectionEnabled = "kCrashlyticsCollectionEnabled"
+
+struct FirebaseCollectionStore {
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var analyticsEnabled: Bool {
+        get { enabled(forKey: kAnalyticsCollectionEnabled) }
+        nonmutating set { defaults.set(newValue, forKey: kAnalyticsCollectionEnabled) }
+    }
+
+    var crashlyticsEnabled: Bool {
+        get { enabled(forKey: kCrashlyticsCollectionEnabled) }
+        nonmutating set { defaults.set(newValue, forKey: kCrashlyticsCollectionEnabled) }
+    }
+
+    private func enabled(forKey key: String) -> Bool {
+        defaults.object(forKey: key) as? Bool ?? true
+    }
+}

--- a/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
@@ -1,3 +1,5 @@
+import FirebaseAnalytics
+import FirebaseCrashlytics
 import MyTBAKit
 import TBAAPI
 import UIKit
@@ -5,6 +7,7 @@ import UIKit
 private enum SettingsSection: Int, CaseIterable {
     case info
     case networking
+    case privacy
     case debug
 }
 
@@ -17,6 +20,11 @@ private enum InfoRow: String, CaseIterable {
 private enum NetworkingRow: Int, CaseIterable {
     case cachePolicy
     case deleteNetworkCache
+}
+
+private enum PrivacyRow: Int, CaseIterable {
+    case analytics
+    case crashlytics
 }
 
 private enum DebugRow: Int, CaseIterable {
@@ -83,6 +91,8 @@ class SettingsViewController: TBATableViewController {
             return InfoRow.allCases.count
         case .networking:
             return NetworkingRow.allCases.count
+        case .privacy:
+            return PrivacyRow.allCases.count
         case .debug:
             return DebugRow.allCases.count
         }
@@ -100,6 +110,8 @@ class SettingsViewController: TBATableViewController {
             return "Info"
         case .networking:
             return "Networking"
+        case .privacy:
+            return "Privacy"
         case .debug:
             return "Debug"
         }
@@ -108,10 +120,15 @@ class SettingsViewController: TBATableViewController {
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int)
         -> String?
     {
-        guard SettingsSection(rawValue: section) == .debug else {
+        switch SettingsSection(rawValue: section) {
+        case .privacy:
+            return
+                "Analytics helps us understand how the app is used. Crash reports help us find and fix bugs. Both are sent to Firebase."
+        case .debug:
+            return "The Blue Alliance for iOS - \(Bundle.main.displayVersionString)"
+        default:
             return nil
         }
-        return "The Blue Alliance for iOS - \(Bundle.main.displayVersionString)"
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
@@ -156,6 +173,31 @@ class SettingsViewController: TBATableViewController {
                 cell.accessoryType = .disclosureIndicator
                 return cell
             }
+        case .privacy:
+            let privacyRow = PrivacyRow.allCases[indexPath.row]
+            let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+            let toggle = UISwitch()
+            switch privacyRow {
+            case .analytics:
+                cell.textLabel?.text = "Share Analytics"
+                toggle.isOn = dependencies.appSettings.firebaseCollection.analyticsEnabled
+                toggle.addTarget(
+                    self,
+                    action: #selector(analyticsToggleChanged(_:)),
+                    for: .valueChanged
+                )
+            case .crashlytics:
+                cell.textLabel?.text = "Share Crash Reports"
+                toggle.isOn = dependencies.appSettings.firebaseCollection.crashlyticsEnabled
+                toggle.addTarget(
+                    self,
+                    action: #selector(crashlyticsToggleChanged(_:)),
+                    for: .valueChanged
+                )
+            }
+            cell.accessoryView = toggle
+            cell.selectionStyle = .none
+            return cell
         case .debug:
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
 
@@ -204,6 +246,8 @@ class SettingsViewController: TBATableViewController {
             case .deleteNetworkCache:
                 showDeleteNetworkCache()
             }
+        case .privacy:
+            break
         case .debug:
             let debugRow = DebugRow.allCases[indexPath.row]
             switch debugRow {
@@ -358,6 +402,44 @@ class SettingsViewController: TBATableViewController {
         alertController.addAction(cancelAction)
 
         self.present(alertController, animated: true, completion: nil)
+    }
+
+    // MARK: - Privacy Methods
+
+    @objc private func analyticsToggleChanged(_ sender: UISwitch) {
+        dependencies.appSettings.firebaseCollection.analyticsEnabled = sender.isOn
+        Analytics.setAnalyticsCollectionEnabled(sender.isOn)
+    }
+
+    @objc private func crashlyticsToggleChanged(_ sender: UISwitch) {
+        if sender.isOn {
+            applyCrashlyticsEnabled(true)
+            return
+        }
+
+        let alert = UIAlertController(
+            title: "Turn off crash reports?",
+            message:
+                "If the app crashes, we won't receive a crash log to help us investigate and fix the issue.",
+            preferredStyle: .alert
+        )
+        alert.addAction(
+            UIAlertAction(title: "Cancel", style: .cancel) { _ in
+                sender.setOn(true, animated: true)
+                self.applyCrashlyticsEnabled(true)
+            }
+        )
+        alert.addAction(
+            UIAlertAction(title: "Turn Off", style: .destructive) { _ in
+                self.applyCrashlyticsEnabled(false)
+            }
+        )
+        present(alert, animated: true)
+    }
+
+    private func applyCrashlyticsEnabled(_ enabled: Bool) {
+        dependencies.appSettings.firebaseCollection.crashlyticsEnabled = enabled
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(enabled)
     }
 
     // MARK: - Debug Methods


### PR DESCRIPTION
## Summary
- New **Privacy** section in Settings with two switches: *Share Analytics* and *Share Crash Reports*.
- Preferences persist in `UserDefaults` via a new `FirebaseCollectionStore` (both default ON) and are applied at launch in `configureFirebase()` for non-DEBUG builds. Toggles also take effect at runtime.
- Turning off crash reports presents a confirmation alert explaining that disabling will prevent crash logs from reaching us. Cancel reverts the switch; Turn Off persists + calls Firebase.
- DEBUG builds still force both collectors off at launch (unchanged).

## Test plan
- [ ] Launch on a Release/TestFlight build → open Settings → confirm Privacy section appears after Networking.
- [ ] Both switches default to ON on first launch.
- [ ] Toggle *Share Analytics* off/on → preference persists across relaunches.
- [ ] Toggle *Share Crash Reports* off → confirmation alert appears.
  - [ ] Cancel → switch reverts; preference stays ON.
  - [ ] Turn Off → switch stays off; preference persists; Firebase stops collecting crashes.
- [ ] Toggle *Share Crash Reports* back on → no alert; takes effect immediately.
- [ ] Restart app after disabling each → verify `configureFirebase()` applies the stored values (Firebase console / Analytics debug view).
- [ ] Existing Settings rows (Cache Policy, Delete network cache, Troubleshoot notifications) continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)