### PR TITLE
Refresh OpenAPI spec from prod + add update script

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
@@ -5,6 +5,7 @@ import Foundation
 // main app target picks them up through `import TBAAPI`.
 public typealias APIStatus = Components.Schemas.APIStatus
 public typealias Award = Components.Schemas.Award
+public typealias CompLevel = Components.Schemas.CompLevel
 public typealias District = Components.Schemas.District
 public typealias DistrictRanking = Components.Schemas.DistrictRanking
 public typealias EliminationAlliance = Components.Schemas.EliminationAlliance

--- a/Packages/TBAAPI/Sources/TBAAPI/openapi.json
+++ b/Packages/TBAAPI/Sources/TBAAPI/openapi.json
@@ -1,9884 +1,10564 @@
 {
-    "openapi": "3.1.1",
-    "info": {
-        "title": "The Blue Alliance API v3",
-        "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-        "version": "3.10.0",
-        "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-        "x-changes": "3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+  "openapi": "3.1.1",
+  "info": {
+    "title": "The Blue Alliance API v3",
+    "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
+    "version": "3.12.2",
+    "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
+    "x-changes": "3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+  },
+  "servers": [
+    {
+      "url": "https://www.thebluealliance.com/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "name": "TBA",
+      "description": "Calls that expose TBA internals or status."
     },
-    "servers": [
-        {
-            "url": "https://www.thebluealliance.com/api/v3"
-        }
-    ],
-    "tags": [
-        {
-            "name": "TBA",
-            "description": "Calls that expose TBA internals or status."
-        },
-        {
-            "name": "list",
-            "description": "Calls that return a list of records."
-        },
-        {
-            "name": "team",
-            "description": "Calls that return team or team-specific information."
-        },
-        {
-            "name": "event",
-            "description": "Calls that return event, or event-specific information."
-        },
-        {
-            "name": "match",
-            "description": "Calls that return match, or match-specific information."
-        },
-        {
-            "name": "district",
-            "description": "Calls that return district, or district-related information."
-        },
-        {
-            "name": "regional_advancement",
-            "description": "Calls that return information about regional teams advancing to CMP, starting in 2025"
-        },
-        {
-            "name": "insight",
-            "description": "Calls that return insights, or insight-related information."
-        }
-    ],
-    "paths": {
-        "/status": {
-            "get": {
-                "tags": [
-                    "TBA"
-                ],
-                "description": "Returns API status, and TBA status information.",
-                "operationId": "getStatus",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/API_Status"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/teams/{page_num}": {
-            "get": {
-                "tags": [
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of `Team` objects, paginated in groups of 500.",
-                "operationId": "getTeams",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/page_num"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/teams/{page_num}/simple": {
-            "get": {
-                "tags": [
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of short form `Team_Simple` objects, paginated in groups of 500.",
-                "operationId": "getTeamsSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/page_num"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/teams/{page_num}/keys": {
-            "get": {
-                "tags": [
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of Team keys, paginated in groups of 500. (Note, each page will not have 500 teams, but will include the teams within that range of 500.)",
-                "operationId": "getTeamsKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/page_num"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/teams/{year}/{page_num}": {
-            "get": {
-                "tags": [
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of `Team` objects that competed in the given year, paginated in groups of 500.",
-                "operationId": "getTeamsByYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    },
-                    {
-                        "$ref": "#/components/parameters/page_num"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/teams/{year}/{page_num}/simple": {
-            "get": {
-                "tags": [
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of short form `Team_Simple` objects that competed in the given year, paginated in groups of 500.",
-                "operationId": "getTeamsByYearSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    },
-                    {
-                        "$ref": "#/components/parameters/page_num"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/teams/{year}/{page_num}/keys": {
-            "get": {
-                "tags": [
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list Team Keys that competed in the given year, paginated in groups of 500.",
-                "operationId": "getTeamsByYearKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    },
-                    {
-                        "$ref": "#/components/parameters/page_num"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Team Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a `Team` object for the team referenced by the given key.",
-                "operationId": "getTeam",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Team"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/simple": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a `Team_Simple` object for the team referenced by the given key.",
-                "operationId": "getTeamSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Team_Simple"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/history": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets the history for the team referenced by the given key, including their events and awards.",
-                "operationId": "getTeamHistory",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response with team's history including events and awards.",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/History"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/years_participated": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a list of years in which the team participated in at least one competition.",
-                "operationId": "getTeamYearsParticipated",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "integer"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/districts": {
-            "get": {
-                "tags": [
-                    "team",
-                    "district"
-                ],
-                "description": "Gets an array of districts representing each year the team was in a district. Will return an empty array if the team was never in a district.",
-                "operationId": "getTeamDistricts",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/District"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/robots": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a list of year and robot name pairs for each year that a robot name was provided. Will return an empty array if the team has never named a robot.",
-                "operationId": "getTeamRobots",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team_Robot"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/events": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event"
-                ],
-                "description": "Gets a list of all events this team has competed at.",
-                "operationId": "getTeamEvents",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/events/simple": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event"
-                ],
-                "description": "Gets a short-form list of all events this team has competed at.",
-                "operationId": "getTeamEventsSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/events/keys": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event"
-                ],
-                "description": "Gets a list of the event keys for all events this team has competed at.",
-                "operationId": "getTeamEventsKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Event Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/events/{year}": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event"
-                ],
-                "description": "Gets a list of events this team has competed at in the given year.",
-                "operationId": "getTeamEventsByYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/events/{year}/simple": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event"
-                ],
-                "description": "Gets a short-form list of events this team has competed at in the given year.",
-                "operationId": "getTeamEventsByYearSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/events/{year}/keys": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event"
-                ],
-                "description": "Gets a list of the event keys for events this team has competed at in the given year.",
-                "operationId": "getTeamEventsByYearKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Event Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/events/{year}/statuses": {
-            "get": {
-                "tags": [
-                    "list",
-                    "team",
-                    "event"
-                ],
-                "description": "Gets a key-value list of the event statuses for events this team has competed at in the given year.",
-                "operationId": "getTeamEventsStatusesByYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": [
-                                            "null",
-                                            "object"
-                                        ],
-                                        "$ref": "#/components/schemas/Team_Event_Status"
-                                    },
-                                    "description": "A key-value pair of `Team_Event_Status` objects with the event key as the key."
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/event/{event_key}/matches": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event",
-                    "match"
-                ],
-                "description": "Gets a list of matches for the given team and event.",
-                "operationId": "getTeamEventMatches",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Match"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/event/{event_key}/matches/simple": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event",
-                    "match"
-                ],
-                "description": "Gets a short-form list of matches for the given team and event.",
-                "operationId": "getTeamEventMatchesSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Match"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/event/{event_key}/matches/keys": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event",
-                    "match"
-                ],
-                "description": "Gets a list of match keys for matches for the given team and event.",
-                "operationId": "getTeamEventMatchesKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Match Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/event/{event_key}/awards": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event"
-                ],
-                "description": "Gets a list of awards the given team won at the given event.",
-                "operationId": "getTeamEventAwards",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Award"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/event/{event_key}/status": {
-            "get": {
-                "tags": [
-                    "team",
-                    "event"
-                ],
-                "description": "Gets the competition rank and status of the team at the given event.",
-                "operationId": "getTeamEventStatus",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ],
-                                    "$ref": "#/components/schemas/Team_Event_Status"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/awards": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a list of awards the given team has won.",
-                "operationId": "getTeamAwards",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Award"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/awards/{year}": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a list of awards the given team has won in a given year.",
-                "operationId": "getTeamAwardsByYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Award"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/matches/{year}": {
-            "get": {
-                "tags": [
-                    "team",
-                    "match"
-                ],
-                "description": "Gets a list of matches for the given team and year.",
-                "operationId": "getTeamMatchesByYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Match"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/matches/{year}/simple": {
-            "get": {
-                "tags": [
-                    "team",
-                    "match"
-                ],
-                "description": "Gets a short-form list of matches for the given team and year.",
-                "operationId": "getTeamMatchesByYearSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Match_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/matches/{year}/keys": {
-            "get": {
-                "tags": [
-                    "team",
-                    "match"
-                ],
-                "description": "Gets a list of match keys for matches for the given team and year.",
-                "operationId": "getTeamMatchesByYearKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Match Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/media/{year}": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a list of Media (videos / pictures) for the given team and year.",
-                "operationId": "getTeamMediaByYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Media"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/media/tag/{media_tag}": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a list of Media (videos / pictures) for the given team and tag.",
-                "operationId": "getTeamMediaByTag",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/media_tag"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Media"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/media/tag/{media_tag}/{year}": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a list of Media (videos / pictures) for the given team, tag and year.",
-                "operationId": "getTeamMediaByTagYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    },
-                    {
-                        "$ref": "#/components/parameters/media_tag"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Media"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/team/{team_key}/social_media": {
-            "get": {
-                "tags": [
-                    "team"
-                ],
-                "description": "Gets a list of Media (social media) for the given team.",
-                "operationId": "getTeamSocialMedia",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/team_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Media"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/events/{year}": {
-            "get": {
-                "tags": [
-                    "event",
-                    "list"
-                ],
-                "description": "Gets a list of events in the given year.",
-                "operationId": "getEventsByYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/events/{year}/simple": {
-            "get": {
-                "tags": [
-                    "event",
-                    "list"
-                ],
-                "description": "Gets a short-form list of events in the given year.",
-                "operationId": "getEventsByYearSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/events/{year}/keys": {
-            "get": {
-                "tags": [
-                    "event",
-                    "list"
-                ],
-                "description": "Gets a list of event keys in the given year.",
-                "operationId": "getEventsByYearKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Event Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets an Event.",
-                "operationId": "getEvent",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/simple": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets a short-form Event.",
-                "operationId": "getEventSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event_Simple"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/alliances": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets a list of Elimination Alliances for the given Event.",
-                "operationId": "getEventAlliances",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "array"
-                                    ],
-                                    "items": {
-                                        "$ref": "#/components/schemas/Elimination_Alliance"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/insights": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets a set of Event-specific insights for the given Event.",
-                "operationId": "getEventInsights",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event_Insights",
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/oprs": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets a set of Event OPRs (including OPR, DPR, and CCWM) for the given Event.",
-                "operationId": "getEventOPRs",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ],
-                                    "$ref": "#/components/schemas/Event_OPRs"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/coprs": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets a set of Event Component OPRs for the given Event.",
-                "operationId": "getEventCOPRs",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ],
-                                    "$ref": "#/components/schemas/Event_COPRs"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/predictions": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets information on TBA-generated predictions for the given Event. Contains year-specific information. *WARNING* This endpoint is currently under development and may change at any time.",
-                "operationId": "getEventPredictions",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event_Predictions",
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/rankings": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets a list of team rankings for the Event.",
-                "operationId": "getEventRankings",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event_Ranking",
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/district_points": {
-            "get": {
-                "tags": [
-                    "event",
-                    "district"
-                ],
-                "description": "Gets a list of district points for the Event. These are always calculated, regardless of event type, and may/may not be actually useful.",
-                "operationId": "getEventDistrictPoints",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event_District_Points",
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/regional_champs_pool_points": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "For 2025+ Regional events, this will return points towards the Championship qualification pool.",
-                "operationId": "getRegionalChampsPoolPoints",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ],
-                                    "$ref": "#/components/schemas/Event_District_Points"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/advancement_points": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Depending on the type of event (district/regional), this will return either district points or regional CMP points",
-                "operationId": "getEventAdvancementPoints",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event_District_Points",
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/teams": {
-            "get": {
-                "tags": [
-                    "event",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of `Team` objects that competed in the given event.",
-                "operationId": "getEventTeams",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/teams/simple": {
-            "get": {
-                "tags": [
-                    "event",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a short-form list of `Team` objects that competed in the given event.",
-                "operationId": "getEventTeamsSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/teams/keys": {
-            "get": {
-                "tags": [
-                    "event",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of `Team` keys that competed in the given event.",
-                "operationId": "getEventTeamsKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Team Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/teams/statuses": {
-            "get": {
-                "tags": [
-                    "event",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a key-value list of the event statuses for teams competing at the given event.",
-                "operationId": "getEventTeamsStatuses",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "$ref": "#/components/schemas/Team_Event_Status",
-                                        "type": [
-                                            "null",
-                                            "object"
-                                        ]
-                                    },
-                                    "description": "A key-value pair of `Team_Event_Status` objects with the event key as the key."
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/matches": {
-            "get": {
-                "tags": [
-                    "event",
-                    "match"
-                ],
-                "description": "Gets a list of matches for the given event.",
-                "operationId": "getEventMatches",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Match"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/matches/simple": {
-            "get": {
-                "tags": [
-                    "event",
-                    "match"
-                ],
-                "description": "Gets a short-form list of matches for the given event.",
-                "operationId": "getEventMatchesSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Match_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/matches/keys": {
-            "get": {
-                "tags": [
-                    "event",
-                    "match"
-                ],
-                "description": "Gets a list of match keys for the given event.",
-                "operationId": "getEventMatchesKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Match Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/matches/timeseries": {
-            "get": {
-                "tags": [
-                    "event",
-                    "match"
-                ],
-                "description": "Gets an array of Match Keys for the given event key that have timeseries data. Returns an empty array if no matches have timeseries data.\n*WARNING:* This is *not* official data, and is subject to a significant possibility of error, or missing data. Do not rely on this data for any purpose. In fact, pretend we made it up.\n*WARNING:* This endpoint and corresponding data models are under *active development* and may change at any time, including in breaking ways.",
-                "operationId": "getEventMatchTimeseries",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "description": "Match Key"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/awards": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets a list of awards from the given event.",
-                "operationId": "getEventAwards",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Award"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/event/{event_key}/team_media": {
-            "get": {
-                "tags": [
-                    "event"
-                ],
-                "description": "Gets a list of media objects that correspond to teams at this event.",
-                "operationId": "getEventTeamMedia",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/event_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Media"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/match/{match_key}": {
-            "get": {
-                "tags": [
-                    "match"
-                ],
-                "description": "Gets a `Match` object for the given match key.",
-                "operationId": "getMatch",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/match_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Match"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/match/{match_key}/simple": {
-            "get": {
-                "tags": [
-                    "match"
-                ],
-                "description": "Gets a short-form `Match` object for the given match key.",
-                "operationId": "getMatchSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/match_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Match_Simple"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/match/{match_key}/timeseries": {
-            "get": {
-                "tags": [
-                    "match"
-                ],
-                "description": "Gets an array of game-specific Match Timeseries objects for the given match key or an empty array if not available.\n*WARNING:* This is *not* official data, and is subject to a significant possibility of error, or missing data. Do not rely on this data for any purpose. In fact, pretend we made it up.\n*WARNING:* This endpoint and corresponding data models are under *active development* and may change at any time, including in breaking ways.",
-                "operationId": "getMatchTimeseries",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/match_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {}
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/match/{match_key}/zebra_motionworks": {
-            "get": {
-                "tags": [
-                    "match"
-                ],
-                "description": "Gets Zebra MotionWorks data for a Match for the given match key.",
-                "operationId": "getMatchZebra",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/match_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Zebra"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/districts/{year}": {
-            "get": {
-                "tags": [
-                    "district"
-                ],
-                "description": "Gets a list of districts and their corresponding district key, for the given year.",
-                "operationId": "getDistrictsByYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/District"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_abbreviation}/history": {
-            "get": {
-                "tags": [
-                    "district"
-                ],
-                "description": "Gets a list of District objects with the given district abbreviation. This accounts for district abbreviation changes, such as MAR to FMA.",
-                "operationId": "getDistrictHistory",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_abbreviation"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/District"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/events": {
-            "get": {
-                "tags": [
-                    "district",
-                    "event",
-                    "list"
-                ],
-                "description": "Gets a list of events in the given district.",
-                "operationId": "getDistrictEvents",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/awards": {
-            "get": {
-                "tags": [
-                    "district",
-                    "event",
-                    "list"
-                ],
-                "description": "Gets a list of awards in the given district.",
-                "operationId": "getDistrictAwards",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Award"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/events/simple": {
-            "get": {
-                "tags": [
-                    "district",
-                    "event",
-                    "list"
-                ],
-                "description": "Gets a short-form list of events in the given district.",
-                "operationId": "getDistrictEventsSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "name": "district_key",
-                        "in": "path",
-                        "description": "TBA District Key, eg `2016fim`",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/events/keys": {
-            "get": {
-                "tags": [
-                    "district",
-                    "event",
-                    "list"
-                ],
-                "description": "Gets a list of event keys for events in the given district.",
-                "operationId": "getDistrictEventsKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Event Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/teams": {
-            "get": {
-                "tags": [
-                    "district",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of `Team` objects that competed in events in the given district.",
-                "operationId": "getDistrictTeams",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/teams/simple": {
-            "get": {
-                "tags": [
-                    "district",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a short-form list of `Team` objects that competed in events in the given district.",
-                "operationId": "getDistrictTeamsSimple",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Team_Simple"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/teams/keys": {
-            "get": {
-                "tags": [
-                    "district",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of `Team` objects that competed in events in the given district.",
-                "operationId": "getDistrictTeamsKeys",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "description": "Array of Team Keys",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/rankings": {
-            "get": {
-                "tags": [
-                    "district",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of team district rankings for the given district.",
-                "operationId": "getDistrictRankings",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "array"
-                                    ],
-                                    "items": {
-                                        "$ref": "#/components/schemas/District_Ranking"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/district/{district_key}/advancement": {
-            "get": {
-                "tags": [
-                    "district",
-                    "team",
-                    "list"
-                ],
-                "description": "Gets a list of advancement information per team in a district.",
-                "operationId": "getDistrictAdvancement",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/district_key"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ],
-                                    "description": "A mapping of team key to District_Advancement",
-                                    "additionalProperties": {
-                                        "$ref": "#/components/schemas/District_Advancement"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/regional_advancement/{year}": {
-            "get": {
-                "tags": [
-                    "regional_advancement",
-                    "list"
-                ],
-                "description": "Gets information about per-team advancement to the FIRST Championship.",
-                "operationId": "getRegionalAdvancement",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "object"
-                                    ],
-                                    "additionalProperties": {
-                                        "$ref": "#/components/schemas/Regional_Advancement"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/regional_advancement/{year}/rankings": {
-            "get": {
-                "tags": [
-                    "regional_advancement",
-                    "list"
-                ],
-                "description": "Gets the team rankings in the regional pool for a specific year.",
-                "operationId": "getRegionalRankings",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "null",
-                                        "array"
-                                    ],
-                                    "items": {
-                                        "$ref": "#/components/schemas/Regional_Ranking"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/insights/leaderboards/{year}": {
-            "get": {
-                "tags": [
-                    "insight",
-                    "list"
-                ],
-                "description": "Gets a list of `LeaderboardInsight` objects from a specific year. Use year=0 for overall.",
-                "operationId": "getInsightsLeaderboardsYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/LeaderboardInsight"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/insights/notables/{year}": {
-            "get": {
-                "tags": [
-                    "insight",
-                    "list"
-                ],
-                "description": "Gets a list of `NotablesInsight` objects from a specific year. Use year=0 for overall.",
-                "operationId": "getInsightsNotablesYear",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/components/parameters/year"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/NotablesInsight"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        },
-        "/search_index": {
-            "get": {
-                "tags": [],
-                "description": "Gets a large blob of data that is used on the frontend for searching. May change without notice.",
-                "operationId": "getSearchIndex",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/If-None-Match"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "headers": {
-                            "Cache-Control": {
-                                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "ETag": {
-                                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SearchIndex"
-                                }
-                            }
-                        }
-                    },
-                    "304": {
-                        "$ref": "#/components/responses/NotModified"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/NotFound"
-                    }
-                },
-                "security": [
-                    {
-                        "apiKey": []
-                    }
-                ]
-            }
-        }
+    {
+      "name": "district",
+      "description": "Calls that return district, or district-related information."
     },
-    "components": {
-        "schemas": {
-            "API_Status": {
-                "required": [
-                    "android",
-                    "current_season",
-                    "down_events",
-                    "ios",
-                    "is_datafeed_down",
-                    "max_season",
-                    "max_team_page"
-                ],
-                "type": "object",
-                "properties": {
-                    "current_season": {
-                        "type": "integer",
-                        "description": "Year of the current FRC season."
-                    },
-                    "max_season": {
-                        "type": "integer",
-                        "description": "Maximum FRC season year for valid queries."
-                    },
-                    "is_datafeed_down": {
-                        "type": "boolean",
-                        "description": "True if the entire FMS API provided by FIRST is down."
-                    },
-                    "down_events": {
-                        "type": "array",
-                        "description": "An array of strings containing event keys of any active events that are no longer updating.",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "ios": {
-                        "$ref": "#/components/schemas/API_Status_App_Version"
-                    },
-                    "android": {
-                        "$ref": "#/components/schemas/API_Status_App_Version"
-                    },
-                    "max_team_page": {
-                        "type": "integer",
-                        "description": "Maximum team page number for valid queries."
-                    }
+    {
+      "name": "event",
+      "description": "Calls that return event, or event-specific information."
+    },
+    {
+      "name": "insight",
+      "description": "Calls that return insights, or insight-related information."
+    },
+    {
+      "name": "match",
+      "description": "Calls that return match, or match-specific information."
+    },
+    {
+      "name": "regional_advancement",
+      "description": "Calls that return information about regional teams advancing to CMP, starting in 2025"
+    },
+    {
+      "name": "team",
+      "description": "Calls that return team or team-specific information."
+    }
+  ],
+  "paths": {
+    "/district/{district_abbreviation}/dcmp_history": {
+      "get": {
+        "tags": [
+          "district"
+        ],
+        "description": "Gets a list of DCMP events and awards for the given district abbreviation.",
+        "operationId": "getDistrictDCMPHistory",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_abbreviation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
                 }
-            },
-            "API_Status_App_Version": {
-                "required": [
-                    "latest_app_version",
-                    "min_app_version"
-                ],
-                "type": "object",
-                "properties": {
-                    "min_app_version": {
-                        "type": "integer",
-                        "description": "Internal use - Minimum application version required to correctly connect and process data."
-                    },
-                    "latest_app_version": {
-                        "type": "integer",
-                        "description": "Internal use - Latest application version available."
-                    }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
                 }
+              }
             },
-            "Team_Simple": {
-                "required": [
-                    "key",
-                    "name",
-                    "team_number",
-                    "nickname",
-                    "city",
-                    "state_prov",
-                    "country"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "TBA team key with the format `frcXXXX` with `XXXX` representing the team number."
-                    },
-                    "team_number": {
-                        "type": "integer",
-                        "description": "Official team number issued by FIRST."
-                    },
-                    "nickname": {
-                        "type": "string",
-                        "description": "Team nickname provided by FIRST."
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Official long name registered with FIRST."
-                    },
-                    "city": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "City of team derived from parsing the address registered with FIRST."
-                    },
-                    "state_prov": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "State of team derived from parsing the address registered with FIRST."
-                    },
-                    "country": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Country of team derived from parsing the address registered with FIRST."
-                    }
-                }
-            },
-            "Team": {
-                "required": [
-                    "key",
-                    "name",
-                    "team_number",
-                    "nickname",
-                    "school_name",
-                    "city",
-                    "state_prov",
-                    "country",
-                    "address",
-                    "postal_code",
-                    "gmaps_place_id",
-                    "gmaps_url",
-                    "lat",
-                    "lng",
-                    "location_name",
-                    "rookie_year"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "TBA team key with the format `frcXXXX` with `XXXX` representing the team number."
-                    },
-                    "team_number": {
-                        "type": "integer",
-                        "description": "Official team number issued by FIRST."
-                    },
-                    "nickname": {
-                        "type": "string",
-                        "description": "Team nickname provided by FIRST."
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Official long name registered with FIRST."
-                    },
-                    "school_name": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Name of team school or affilited group registered with FIRST."
-                    },
-                    "city": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "City of team derived from parsing the address registered with FIRST."
-                    },
-                    "state_prov": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "State of team derived from parsing the address registered with FIRST."
-                    },
-                    "country": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Country of team derived from parsing the address registered with FIRST."
-                    },
-                    "address": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Will be NULL, for future development."
-                    },
-                    "postal_code": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Postal code from the team address."
-                    },
-                    "gmaps_place_id": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Will be NULL, for future development."
-                    },
-                    "gmaps_url": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Will be NULL, for future development.",
-                        "format": "url"
-                    },
-                    "lat": {
-                        "type": [
-                            "number",
-                            "null"
-                        ],
-                        "description": "Will be NULL, for future development.",
-                        "format": "double"
-                    },
-                    "lng": {
-                        "type": [
-                            "number",
-                            "null"
-                        ],
-                        "description": "Will be NULL, for future development.",
-                        "format": "double"
-                    },
-                    "location_name": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Will be NULL, for future development."
-                    },
-                    "website": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Official website associated with the team.",
-                        "format": "url"
-                    },
-                    "rookie_year": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "First year the team officially competed."
-                    }
-                }
-            },
-            "Team_Robot": {
-                "required": [
-                    "key",
-                    "robot_name",
-                    "team_key",
-                    "year"
-                ],
-                "type": "object",
-                "properties": {
-                    "year": {
-                        "type": "integer",
-                        "description": "Year this robot competed in."
-                    },
-                    "robot_name": {
-                        "type": "string",
-                        "description": "Name of the robot as provided by the team."
-                    },
-                    "key": {
-                        "type": "string",
-                        "description": "Internal TBA identifier for this robot."
-                    },
-                    "team_key": {
-                        "type": "string",
-                        "description": "TBA team key for this robot."
-                    }
-                }
-            },
-            "Event_Simple": {
-                "required": [
-                    "key",
-                    "name",
-                    "event_code",
-                    "event_type",
-                    "district",
-                    "city",
-                    "state_prov",
-                    "country",
-                    "start_date",
-                    "end_date",
-                    "year"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "TBA event key with the format yyyy[EVENT_CODE], where yyyy is the year, and EVENT_CODE is the event code of the event."
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Official name of event on record either provided by FIRST or organizers of offseason event."
-                    },
-                    "event_code": {
-                        "type": "string",
-                        "description": "Event short code, as provided by FIRST."
-                    },
-                    "event_type": {
-                        "type": "integer",
-                        "description": "Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/event_type.py#L2"
-                    },
-                    "district": {
-                        "$ref": "#/components/schemas/District",
-                        "type": [
-                            "null",
-                            "object"
-                        ]
-                    },
-                    "city": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "City, town, village, etc. the event is located in."
-                    },
-                    "state_prov": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "State or Province the event is located in."
-                    },
-                    "country": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Country the event is located in."
-                    },
-                    "start_date": {
-                        "type": "string",
-                        "description": "Event start date in `yyyy-mm-dd` format.",
-                        "format": "date"
-                    },
-                    "end_date": {
-                        "type": "string",
-                        "description": "Event end date in `yyyy-mm-dd` format.",
-                        "format": "date"
-                    },
-                    "year": {
-                        "type": "integer",
-                        "description": "Year the event data is for."
-                    }
-                }
-            },
-            "Event": {
-                "required": [
-                    "key",
-                    "name",
-                    "event_code",
-                    "event_type",
-                    "district",
-                    "city",
-                    "state_prov",
-                    "country",
-                    "start_date",
-                    "end_date",
-                    "year",
-                    "short_name",
-                    "event_type_string",
-                    "week",
-                    "address",
-                    "postal_code",
-                    "gmaps_place_id",
-                    "gmaps_url",
-                    "lat",
-                    "lng",
-                    "location_name",
-                    "timezone",
-                    "website",
-                    "first_event_id",
-                    "first_event_code",
-                    "webcasts",
-                    "division_keys",
-                    "parent_event_key",
-                    "playoff_type",
-                    "playoff_type_string"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "TBA event key with the format yyyy[EVENT_CODE], where yyyy is the year, and EVENT_CODE is the event code of the event."
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Official name of event on record either provided by FIRST or organizers of offseason event."
-                    },
-                    "event_code": {
-                        "type": "string",
-                        "description": "Event short code, as provided by FIRST."
-                    },
-                    "event_type": {
-                        "type": "integer",
-                        "description": "Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/event_type.py#L2"
-                    },
-                    "district": {
-                        "$ref": "#/components/schemas/District",
-                        "type": [
-                            "null",
-                            "object"
-                        ]
-                    },
-                    "city": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "City, town, village, etc. the event is located in."
-                    },
-                    "state_prov": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "State or Province the event is located in."
-                    },
-                    "country": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Country the event is located in."
-                    },
-                    "start_date": {
-                        "type": "string",
-                        "description": "Event start date in `yyyy-mm-dd` format.",
-                        "format": "date"
-                    },
-                    "end_date": {
-                        "type": "string",
-                        "description": "Event end date in `yyyy-mm-dd` format.",
-                        "format": "date"
-                    },
-                    "year": {
-                        "type": "integer",
-                        "description": "Year the event data is for."
-                    },
-                    "short_name": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Same as `name` but doesn't include event specifiers, such as 'Regional' or 'District'. May be null."
-                    },
-                    "event_type_string": {
-                        "type": "string",
-                        "description": "Event Type, eg Regional, District, or Offseason."
-                    },
-                    "week": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "Week of the event relative to the first official season event, zero-indexed. Only valid for Regionals, Districts, and District Championships. Null otherwise. (Eg. A season with a week 0 'preseason' event does not count, and week 1 events will show 0 here. Seasons with a week 0.5 regional event will show week 0 for those event(s) and week 1 for week 1 events and so on.)"
-                    },
-                    "address": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Address of the event's venue, if available."
-                    },
-                    "postal_code": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Postal code from the event address."
-                    },
-                    "gmaps_place_id": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Google Maps Place ID for the event address."
-                    },
-                    "gmaps_url": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Link to address location on Google Maps.",
-                        "format": "url"
-                    },
-                    "lat": {
-                        "type": [
-                            "number",
-                            "null"
-                        ],
-                        "description": "Latitude for the event address.",
-                        "format": "double"
-                    },
-                    "lng": {
-                        "type": [
-                            "number",
-                            "null"
-                        ],
-                        "description": "Longitude for the event address.",
-                        "format": "double"
-                    },
-                    "location_name": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Name of the location at the address for the event, eg. Blue Alliance High School."
-                    },
-                    "timezone": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Timezone name."
-                    },
-                    "website": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "The event's website, if any."
-                    },
-                    "first_event_id": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "The FIRST internal Event ID, used to link to the event on the FRC webpage."
-                    },
-                    "first_event_code": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Public facing event code used by FIRST (on frc-events.firstinspires.org, for example)"
-                    },
-                    "webcasts": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "awards": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/Webcast"
+                          "$ref": "#/components/schemas/Award"
                         }
-                    },
-                    "division_keys": {
-                        "type": "array",
-                        "description": "An array of event keys for the divisions at this event.",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "parent_event_key": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "The TBA Event key that represents the event's parent. Used to link back to the event from a division event. It is also the inverse relation of `divison_keys`."
-                    },
-                    "playoff_type": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "Playoff Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/playoff_type.py#L4, or null."
-                    },
-                    "playoff_type_string": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "String representation of the `playoff_type`, or null."
+                      },
+                      "event": {
+                        "$ref": "#/components/schemas/Event"
+                      }
                     }
+                  }
                 }
-            },
-            "Team_Event_Status": {
-                "type": "object",
-                "properties": {
-                    "qual": {
-                        "$ref": "#/components/schemas/Team_Event_Status_rank",
-                        "type": [
-                            "null",
-                            "object"
-                        ]
-                    },
-                    "alliance": {
-                        "$ref": "#/components/schemas/Team_Event_Status_alliance",
-                        "type": [
-                            "null",
-                            "object"
-                        ]
-                    },
-                    "playoff": {
-                        "$ref": "#/components/schemas/Team_Event_Status_playoff",
-                        "type": [
-                            "null",
-                            "object"
-                        ]
-                    },
-                    "alliance_status_str": {
-                        "type": "string",
-                        "description": "An HTML formatted string suitable for display to the user containing the team's alliance pick status."
-                    },
-                    "playoff_status_str": {
-                        "type": "string",
-                        "description": "An HTML formatter string suitable for display to the user containing the team's playoff status."
-                    },
-                    "overall_status_str": {
-                        "type": "string",
-                        "description": "An HTML formatted string suitable for display to the user containing the team's overall status summary of the event."
-                    },
-                    "next_match_key": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "TBA match key for the next match the team is scheduled to play in at this event, or null."
-                    },
-                    "last_match_key": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "TBA match key for the last match the team played in at this event, or null."
-                    }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_abbreviation}/history": {
+      "get": {
+        "tags": [
+          "district"
+        ],
+        "description": "Gets a list of District objects with the given district abbreviation. This accounts for district abbreviation changes, such as MAR to FMA.",
+        "operationId": "getDistrictHistory",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_abbreviation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
                 }
-            },
-            "Team_Event_Status_rank": {
-                "type": "object",
-                "properties": {
-                    "num_teams": {
-                        "type": "integer",
-                        "description": "Number of teams ranked."
-                    },
-                    "ranking": {
-                        "type": "object",
-                        "properties": {
-                            "matches_played": {
-                                "type": "integer",
-                                "description": "Number of matches played."
-                            },
-                            "qual_average": {
-                                "type": "number",
-                                "description": "For some years, average qualification score. Can be null.",
-                                "format": "double"
-                            },
-                            "sort_orders": {
-                                "type": "array",
-                                "description": "Ordered list of values used to determine the rank. See the `sort_order_info` property for the name of each value.",
-                                "items": {
-                                    "type": "number",
-                                    "format": "double"
-                                }
-                            },
-                            "record": {
-                                "$ref": "#/components/schemas/WLT_Record",
-                                "type": [
-                                    "null",
-                                    "object"
-                                ]
-                            },
-                            "rank": {
-                                "type": "integer",
-                                "description": "Relative rank of this team."
-                            },
-                            "dq": {
-                                "type": "integer",
-                                "description": "Number of matches the team was disqualified for."
-                            },
-                            "team_key": {
-                                "type": "string",
-                                "description": "TBA team key for this rank."
-                            }
-                        }
-                    },
-                    "sort_order_info": {
-                        "type": "array",
-                        "description": "Ordered list of names corresponding to the elements of the `sort_orders` array.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "precision": {
-                                    "type": "integer",
-                                    "description": "The number of digits of precision used for this value, eg `2` would correspond to a value of `101.11` while `0` would correspond to `101`."
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "The descriptive name of the value used to sort the ranking."
-                                }
-                            }
-                        }
-                    },
-                    "status": {
-                        "type": "string"
-                    }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
                 }
+              }
             },
-            "Team_Event_Status_alliance": {
-                "required": [
-                    "number",
-                    "pick"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Alliance name, may be null."
-                    },
-                    "number": {
-                        "type": "integer",
-                        "description": "Alliance number."
-                    },
-                    "backup": {
-                        "$ref": "#/components/schemas/Team_Event_Status_alliance_backup"
-                    },
-                    "pick": {
-                        "type": "integer",
-                        "description": "Order the team was picked in the alliance from 0-2, with 0 being alliance captain."
-                    }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/District"
+                  }
                 }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_abbreviation}/insights": {
+      "get": {
+        "tags": [
+          "district"
+        ],
+        "description": "Gets insights for a given district.",
+        "operationId": "getDistrictInsights",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_abbreviation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             },
-            "Team_Event_Status_alliance_backup": {
-                "type": [
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/District_Insight"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/advancement": {
+      "get": {
+        "tags": [
+          "district",
+          "team"
+        ],
+        "description": "Gets a list of advancement information per team in a district.",
+        "operationId": "getDistrictAdvancement",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
                     "null",
                     "object"
-                ],
-                "properties": {
-                    "out": {
-                        "type": "string",
-                        "description": "TBA key for the team replaced by the backup."
-                    },
-                    "in": {
-                        "type": "string",
-                        "description": "TBA key for the backup team called in."
-                    }
-                },
-                "description": "Backup status, may be null."
+                  ],
+                  "description": "A mapping of team key to District_Advancement",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/District_Advancement"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/awards": {
+      "get": {
+        "tags": [
+          "district",
+          "event"
+        ],
+        "description": "Gets a list of awards in the given district.",
+        "operationId": "getDistrictAwards",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             },
-            "Team_Event_Status_playoff": {
-                "type": [
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Award"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/events": {
+      "get": {
+        "tags": [
+          "district",
+          "event"
+        ],
+        "description": "Gets a list of events in the given district.",
+        "operationId": "getDistrictEvents",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/events/keys": {
+      "get": {
+        "tags": [
+          "district",
+          "event"
+        ],
+        "description": "Gets a list of event keys for events in the given district.",
+        "operationId": "getDistrictEventsKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Event Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/events/simple": {
+      "get": {
+        "tags": [
+          "district",
+          "event"
+        ],
+        "description": "Gets a short-form list of events in the given district.",
+        "operationId": "getDistrictEventsSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "name": "district_key",
+            "in": "path",
+            "description": "TBA District Key, eg `2016fim`",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/rankings": {
+      "get": {
+        "tags": [
+          "district",
+          "team"
+        ],
+        "description": "Gets a list of team district rankings for the given district.",
+        "operationId": "getDistrictRankings",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "$ref": "#/components/schemas/District_Ranking"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/teams": {
+      "get": {
+        "tags": [
+          "district",
+          "team"
+        ],
+        "description": "Gets a list of `Team` objects that competed in events in the given district.",
+        "operationId": "getDistrictTeams",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/teams/keys": {
+      "get": {
+        "tags": [
+          "district",
+          "team"
+        ],
+        "description": "Gets a list of `Team` objects that competed in events in the given district.",
+        "operationId": "getDistrictTeamsKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Team Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/district/{district_key}/teams/simple": {
+      "get": {
+        "tags": [
+          "district",
+          "team"
+        ],
+        "description": "Gets a short-form list of `Team` objects that competed in events in the given district.",
+        "operationId": "getDistrictTeamsSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/district_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/districts/{year}": {
+      "get": {
+        "tags": [
+          "district"
+        ],
+        "description": "Gets a list of districts and their corresponding district key, for the given year.",
+        "operationId": "getDistrictsByYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/District"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets an Event.",
+        "operationId": "getEvent",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/advancement_points": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Depending on the type of event (district/regional), this will return either district points or regional CMP points",
+        "operationId": "getEventAdvancementPoints",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_District_Points"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/alliances": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a list of Elimination Alliances for the given Event.",
+        "operationId": "getEventAlliances",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "$ref": "#/components/schemas/Elimination_Alliance"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/awards": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a list of awards from the given event.",
+        "operationId": "getEventAwards",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Award"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/coprs": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a set of Event Component OPRs for the given Event.",
+        "operationId": "getEventCOPRs",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_COPRs"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/district_points": {
+      "get": {
+        "tags": [
+          "event",
+          "district"
+        ],
+        "description": "Gets a list of district points for the Event. These are always calculated, regardless of event type, and may/may not be actually useful.",
+        "operationId": "getEventDistrictPoints",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_District_Points"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/insights": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a set of Event-specific insights for the given Event.",
+        "operationId": "getEventInsights",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_Insights"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/matches": {
+      "get": {
+        "tags": [
+          "event",
+          "match"
+        ],
+        "description": "Gets a list of matches for the given event.",
+        "operationId": "getEventMatches",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Match"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/matches/keys": {
+      "get": {
+        "tags": [
+          "event",
+          "match"
+        ],
+        "description": "Gets a list of match keys for the given event.",
+        "operationId": "getEventMatchesKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Match Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/matches/simple": {
+      "get": {
+        "tags": [
+          "event",
+          "match"
+        ],
+        "description": "Gets a short-form list of matches for the given event.",
+        "operationId": "getEventMatchesSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Match_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/matches/timeseries": {
+      "get": {
+        "tags": [
+          "event",
+          "match"
+        ],
+        "description": "Gets an array of Match Keys for the given event key that have timeseries data. Returns an empty array if no matches have timeseries data.\n*WARNING:* This is *not* official data, and is subject to a significant possibility of error, or missing data. Do not rely on this data for any purpose. In fact, pretend we made it up.\n*WARNING:* This endpoint and corresponding data models are under *active development* and may change at any time, including in breaking ways.",
+        "operationId": "getEventMatchTimeseries",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "Match Key"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/oprs": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a set of Event OPRs (including OPR, DPR, and CCWM) for the given Event.",
+        "operationId": "getEventOPRs",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_OPRs"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/predictions": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets information on TBA-generated predictions for the given Event. Contains year-specific information. *WARNING* This endpoint is currently under development and may change at any time.",
+        "operationId": "getEventPredictions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_Predictions"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/rankings": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a list of team rankings for the Event.",
+        "operationId": "getEventRankings",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_Ranking"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/regional_champs_pool_points": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "For 2025+ Regional events, this will return points towards the Championship qualification pool.",
+        "operationId": "getRegionalChampsPoolPoints",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_District_Points"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/simple": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a short-form Event.",
+        "operationId": "getEventSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event_Simple"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/team_media": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a list of media objects that correspond to teams at this event.",
+        "operationId": "getEventTeamMedia",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Media"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/teams": {
+      "get": {
+        "tags": [
+          "event",
+          "team"
+        ],
+        "description": "Gets a list of `Team` objects that competed in the given event.",
+        "operationId": "getEventTeams",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/teams/keys": {
+      "get": {
+        "tags": [
+          "event",
+          "team"
+        ],
+        "description": "Gets a list of `Team` keys that competed in the given event.",
+        "operationId": "getEventTeamsKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Team Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/teams/simple": {
+      "get": {
+        "tags": [
+          "event",
+          "team"
+        ],
+        "description": "Gets a short-form list of `Team` objects that competed in the given event.",
+        "operationId": "getEventTeamsSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/teams/statuses": {
+      "get": {
+        "tags": [
+          "event",
+          "team"
+        ],
+        "description": "Gets a key-value list of the event statuses for teams competing at the given event.",
+        "operationId": "getEventTeamsStatuses",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/Team_Event_Status"
+                  },
+                  "description": "A key-value pair of `Team_Event_Status` objects with the event key as the key."
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/events/{year}": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a list of events in the given year.",
+        "operationId": "getEventsByYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/events/{year}/keys": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a list of event keys in the given year.",
+        "operationId": "getEventsByYearKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Event Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/events/{year}/simple": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a short-form list of events in the given year.",
+        "operationId": "getEventsByYearSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/insights/leaderboards/{year}": {
+      "get": {
+        "tags": [
+          "insight"
+        ],
+        "description": "Gets a list of `LeaderboardInsight` objects from a specific year. Use year=0 for overall.",
+        "operationId": "getInsightsLeaderboardsYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LeaderboardInsight"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/insights/notables/{year}": {
+      "get": {
+        "tags": [
+          "insight"
+        ],
+        "description": "Gets a list of `NotablesInsight` objects from a specific year. Use year=0 for overall.",
+        "operationId": "getInsightsNotablesYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotablesInsight"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/match/{match_key}": {
+      "get": {
+        "tags": [
+          "match"
+        ],
+        "description": "Gets a `Match` object for the given match key.",
+        "operationId": "getMatch",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/match_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Match"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/match/{match_key}/simple": {
+      "get": {
+        "tags": [
+          "match"
+        ],
+        "description": "Gets a short-form `Match` object for the given match key.",
+        "operationId": "getMatchSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/match_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Match_Simple"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/match/{match_key}/timeseries": {
+      "get": {
+        "tags": [
+          "match"
+        ],
+        "description": "Gets an array of game-specific Match Timeseries objects for the given match key or an empty array if not available.\n*WARNING:* This is *not* official data, and is subject to a significant possibility of error, or missing data. Do not rely on this data for any purpose. In fact, pretend we made it up.\n*WARNING:* This endpoint and corresponding data models are under *active development* and may change at any time, including in breaking ways.",
+        "operationId": "getMatchTimeseries",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/match_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {}
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/match/{match_key}/zebra_motionworks": {
+      "get": {
+        "tags": [
+          "match"
+        ],
+        "description": "Gets Zebra MotionWorks data for a Match for the given match key.",
+        "operationId": "getMatchZebra",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/match_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Zebra"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/regional_advancement/{year}": {
+      "get": {
+        "tags": [
+          "regional_advancement"
+        ],
+        "description": "Gets information about per-team advancement to the FIRST Championship.",
+        "operationId": "getRegionalAdvancement",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
                     "null",
                     "object"
-                ],
-                "properties": {
-                    "level": {
-                        "type": "string",
-                        "description": "The highest playoff level the team reached.",
-                        "enum": [
-                            "qm",
-                            "ef",
-                            "qf",
-                            "sf",
-                            "f"
-                        ]
-                    },
-                    "current_level_record": {
-                        "type": [
-                            "null",
-                            "object"
-                        ],
-                        "$ref": "#/components/schemas/WLT_Record"
-                    },
-                    "record": {
-                        "type": [
-                            "null",
-                            "object"
-                        ],
-                        "$ref": "#/components/schemas/WLT_Record"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Current competition status for the playoffs.",
-                        "enum": [
-                            "won",
-                            "eliminated",
-                            "playing"
-                        ]
-                    },
-                    "playoff_average": {
-                        "type": [
-                            "null",
-                            "number"
-                        ],
-                        "format": "double",
-                        "description": "The average match score during playoffs. Year specific. May be null if not relevant for a given year."
-                    }
-                },
-                "description": "Playoff status for this team, may be null if the team did not make playoffs, or playoffs have not begun."
-            },
-            "Event_Ranking": {
-                "required": [
-                    "rankings",
-                    "sort_order_info",
-                    "extra_stats_info"
-                ],
-                "type": "object",
-                "properties": {
-                    "rankings": {
-                        "type": "array",
-                        "description": "List of rankings at the event.",
-                        "items": {
-                            "required": [
-                                "dq",
-                                "matches_played",
-                                "rank",
-                                "record",
-                                "team_key",
-                                "extra_stats",
-                                "qual_average",
-                                "sort_orders"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "matches_played": {
-                                    "type": "integer",
-                                    "description": "Number of matches played by this team."
-                                },
-                                "qual_average": {
-                                    "type": [
-                                        "integer",
-                                        "null"
-                                    ],
-                                    "description": "The average match score during qualifications. Year specific. May be null if not relevant for a given year."
-                                },
-                                "extra_stats": {
-                                    "type": "array",
-                                    "description": "Additional special data on the team's performance calculated by TBA.",
-                                    "items": {
-                                        "type": "number"
-                                    }
-                                },
-                                "sort_orders": {
-                                    "type": [
-                                        "array",
-                                        "null"
-                                    ],
-                                    "items": {
-                                        "type": "number",
-                                        "format": "double"
-                                    },
-                                    "description": "Additional year-specific information, may be null. See parent `sort_order_info` for details."
-                                },
-                                "record": {
-                                    "type": [
-                                        "object",
-                                        "null"
-                                    ],
-                                    "$ref": "#/components/schemas/WLT_Record"
-                                },
-                                "rank": {
-                                    "type": "integer",
-                                    "description": "The team's rank at the event as provided by FIRST."
-                                },
-                                "dq": {
-                                    "type": "integer",
-                                    "description": "Number of times disqualified."
-                                },
-                                "team_key": {
-                                    "type": "string",
-                                    "description": "The team with this rank."
-                                }
-                            }
-                        }
-                    },
-                    "extra_stats_info": {
-                        "type": "array",
-                        "description": "List of special TBA-generated values provided in the `extra_stats` array for each item.",
-                        "items": {
-                            "required": [
-                                "name",
-                                "precision"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "precision": {
-                                    "type": "number",
-                                    "description": "Integer expressing the number of digits of precision in the number provided in `sort_orders`."
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "Name of the field used in the `extra_stats` array."
-                                }
-                            }
-                        }
-                    },
-                    "sort_order_info": {
-                        "type": "array",
-                        "description": "List of year-specific values provided in the `sort_orders` array for each team.",
-                        "items": {
-                            "required": [
-                                "name",
-                                "precision"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "precision": {
-                                    "type": "integer",
-                                    "description": "Integer expressing the number of digits of precision in the number provided in `sort_orders`."
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "Name of the field used in the `sort_order` array."
-                                }
-                            }
-                        }
-                    }
+                  ],
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/Regional_Advancement"
+                  }
                 }
-            },
-            "Event_District_Points": {
-                "required": [
-                    "points"
-                ],
-                "type": "object",
-                "properties": {
-                    "points": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "required": [
-                                "alliance_points",
-                                "award_points",
-                                "elim_points",
-                                "qual_points",
-                                "total"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "total": {
-                                    "type": "integer",
-                                    "description": "Total points awarded at this event."
-                                },
-                                "alliance_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for alliance selection"
-                                },
-                                "elim_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for elimination match performance."
-                                },
-                                "award_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for event awards."
-                                },
-                                "qual_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for qualification match performance."
-                                }
-                            }
-                        },
-                        "description": "Points gained for each team at the event. Stored as a key-value pair with the team key as the key, and an object describing the points as its value."
-                    },
-                    "tiebreakers": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "object",
-                            "properties": {
-                                "highest_qual_scores": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "integer"
-                                    }
-                                },
-                                "qual_wins": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "description": "Tiebreaker values for each team at the event. Stored as a key-value pair with the team key as the key, and an object describing the tiebreaker elements as its value."
-                    }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/regional_advancement/{year}/rankings": {
+      "get": {
+        "tags": [
+          "regional_advancement"
+        ],
+        "description": "Gets the team rankings in the regional pool for a specific year.",
+        "operationId": "getRegionalRankings",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
                 }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             },
-            "Event_Insights": {
-                "type": "object",
-                "properties": {
-                    "qual": {
-                        "type": "object",
-                        "properties": {},
-                        "description": "Inights for the qualification round of an event"
-                    },
-                    "playoff": {
-                        "type": "object",
-                        "properties": {},
-                        "description": "Insights for the playoff round of an event"
-                    }
-                },
-                "description": "A year-specific event insight object expressed as a JSON string, separated in to `qual` and `playoff` fields. See also Event_Insights_2016, Event_Insights_2017, etc."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "$ref": "#/components/schemas/Regional_Ranking"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/search_index": {
+      "get": {
+        "tags": [],
+        "description": "Gets a large blob of data that is used on the frontend for searching. May change without notice.",
+        "operationId": "getSearchIndex",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             },
-            "Event_Insights_2016": {
-                "required": [
-                    "A_ChevalDeFrise",
-                    "A_Portcullis",
-                    "B_Moat",
-                    "B_Ramparts",
-                    "C_Drawbridge",
-                    "C_SallyPort",
-                    "D_RockWall",
-                    "D_RoughTerrain",
-                    "LowBar",
-                    "average_auto_score",
-                    "average_boulder_score",
-                    "average_crossing_score",
-                    "average_foul_score",
-                    "average_high_goals",
-                    "average_low_goals",
-                    "average_score",
-                    "average_tower_score",
-                    "average_win_margin",
-                    "average_win_score",
-                    "breaches",
-                    "captures",
-                    "challenges",
-                    "high_score",
-                    "scales"
-                ],
-                "type": "object",
-                "properties": {
-                    "LowBar": {
-                        "type": "array",
-                        "description": "For the Low Bar - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "A_ChevalDeFrise": {
-                        "type": "array",
-                        "description": "For the Cheval De Frise - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "A_Portcullis": {
-                        "type": "array",
-                        "description": "For the Portcullis - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "B_Ramparts": {
-                        "type": "array",
-                        "description": "For the Ramparts - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "B_Moat": {
-                        "type": "array",
-                        "description": "For the Moat - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "C_SallyPort": {
-                        "type": "array",
-                        "description": "For the Sally Port - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "C_Drawbridge": {
-                        "type": "array",
-                        "description": "For the Drawbridge - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "D_RoughTerrain": {
-                        "type": "array",
-                        "description": "For the Rough Terrain - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "D_RockWall": {
-                        "type": "array",
-                        "description": "For the Rock Wall - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "average_high_goals": {
-                        "type": "number",
-                        "description": "Average number of high goals scored.",
-                        "format": "float"
-                    },
-                    "average_low_goals": {
-                        "type": "number",
-                        "description": "Average number of low goals scored.",
-                        "format": "float"
-                    },
-                    "breaches": {
-                        "type": "array",
-                        "description": "An array with three values, number of times breached, number of opportunities to breach, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "scales": {
-                        "type": "array",
-                        "description": "An array with three values, number of times scaled, number of opportunities to scale, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "challenges": {
-                        "type": "array",
-                        "description": "An array with three values, number of times challenged, number of opportunities to challenge, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "captures": {
-                        "type": "array",
-                        "description": "An array with three values, number of times captured, number of opportunities to capture, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "average_win_score": {
-                        "type": "number",
-                        "description": "Average winning score.",
-                        "format": "float"
-                    },
-                    "average_win_margin": {
-                        "type": "number",
-                        "description": "Average margin of victory.",
-                        "format": "float"
-                    },
-                    "average_score": {
-                        "type": "number",
-                        "description": "Average total score.",
-                        "format": "float"
-                    },
-                    "average_auto_score": {
-                        "type": "number",
-                        "description": "Average autonomous score.",
-                        "format": "float"
-                    },
-                    "average_crossing_score": {
-                        "type": "number",
-                        "description": "Average crossing score.",
-                        "format": "float"
-                    },
-                    "average_boulder_score": {
-                        "type": "number",
-                        "description": "Average boulder score.",
-                        "format": "float"
-                    },
-                    "average_tower_score": {
-                        "type": "number",
-                        "description": "Average tower score.",
-                        "format": "float"
-                    },
-                    "average_foul_score": {
-                        "type": "number",
-                        "description": "Average foul score.",
-                        "format": "float"
-                    },
-                    "high_score": {
-                        "type": "array",
-                        "description": "An array with three values, high score, match key from the match with the high score, and the name of the match.",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "description": "Insights for FIRST Stronghold qualification and elimination matches."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchIndex"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/status": {
+      "get": {
+        "tags": [
+          "TBA"
+        ],
+        "description": "Returns API status, and TBA status information.",
+        "operationId": "getStatus",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             },
-            "Event_Insights_2017": {
-                "required": [
-                    "average_foul_score",
-                    "average_fuel_points",
-                    "average_fuel_points_auto",
-                    "average_fuel_points_teleop",
-                    "average_high_goals",
-                    "average_high_goals_auto",
-                    "average_high_goals_teleop",
-                    "average_low_goals",
-                    "average_low_goals_auto",
-                    "average_low_goals_teleop",
-                    "average_mobility_points_auto",
-                    "average_points_auto",
-                    "average_points_teleop",
-                    "average_rotor_points",
-                    "average_rotor_points_auto",
-                    "average_rotor_points_teleop",
-                    "average_score",
-                    "average_takeoff_points_teleop",
-                    "average_win_margin",
-                    "average_win_score",
-                    "high_kpa",
-                    "high_score",
-                    "kpa_achieved",
-                    "mobility_counts",
-                    "rotor_1_engaged",
-                    "rotor_1_engaged_auto",
-                    "rotor_2_engaged",
-                    "rotor_2_engaged_auto",
-                    "rotor_3_engaged",
-                    "rotor_4_engaged",
-                    "takeoff_counts",
-                    "unicorn_matches"
-                ],
-                "type": "object",
-                "properties": {
-                    "average_foul_score": {
-                        "type": "number",
-                        "description": "Average foul score.",
-                        "format": "float"
-                    },
-                    "average_fuel_points": {
-                        "type": "number",
-                        "description": "Average fuel points scored.",
-                        "format": "float"
-                    },
-                    "average_fuel_points_auto": {
-                        "type": "number",
-                        "description": "Average fuel points scored during auto.",
-                        "format": "float"
-                    },
-                    "average_fuel_points_teleop": {
-                        "type": "number",
-                        "description": "Average fuel points scored during teleop.",
-                        "format": "float"
-                    },
-                    "average_high_goals": {
-                        "type": "number",
-                        "description": "Average points scored in the high goal.",
-                        "format": "float"
-                    },
-                    "average_high_goals_auto": {
-                        "type": "number",
-                        "description": "Average points scored in the high goal during auto.",
-                        "format": "float"
-                    },
-                    "average_high_goals_teleop": {
-                        "type": "number",
-                        "description": "Average points scored in the high goal during teleop.",
-                        "format": "float"
-                    },
-                    "average_low_goals": {
-                        "type": "number",
-                        "description": "Average points scored in the low goal.",
-                        "format": "float"
-                    },
-                    "average_low_goals_auto": {
-                        "type": "number",
-                        "description": "Average points scored in the low goal during auto.",
-                        "format": "float"
-                    },
-                    "average_low_goals_teleop": {
-                        "type": "number",
-                        "description": "Average points scored in the low goal during teleop.",
-                        "format": "float"
-                    },
-                    "average_mobility_points_auto": {
-                        "type": "number",
-                        "description": "Average mobility points scored during auto.",
-                        "format": "float"
-                    },
-                    "average_points_auto": {
-                        "type": "number",
-                        "description": "Average points scored during auto.",
-                        "format": "float"
-                    },
-                    "average_points_teleop": {
-                        "type": "number",
-                        "description": "Average points scored during teleop.",
-                        "format": "float"
-                    },
-                    "average_rotor_points": {
-                        "type": "number",
-                        "description": "Average rotor points scored.",
-                        "format": "float"
-                    },
-                    "average_rotor_points_auto": {
-                        "type": "number",
-                        "description": "Average rotor points scored during auto.",
-                        "format": "float"
-                    },
-                    "average_rotor_points_teleop": {
-                        "type": "number",
-                        "description": "Average rotor points scored during teleop.",
-                        "format": "float"
-                    },
-                    "average_score": {
-                        "type": "number",
-                        "description": "Average score.",
-                        "format": "float"
-                    },
-                    "average_takeoff_points_teleop": {
-                        "type": "number",
-                        "description": "Average takeoff points scored during teleop.",
-                        "format": "float"
-                    },
-                    "average_win_margin": {
-                        "type": "number",
-                        "description": "Average margin of victory.",
-                        "format": "float"
-                    },
-                    "average_win_score": {
-                        "type": "number",
-                        "description": "Average winning score.",
-                        "format": "float"
-                    },
-                    "high_kpa": {
-                        "type": "array",
-                        "description": "An array with three values, kPa scored, match key from the match with the high kPa, and the name of the match",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "high_score": {
-                        "type": "array",
-                        "description": "An array with three values, high score, match key from the match with the high score, and the name of the match",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "kpa_achieved": {
-                        "type": "array",
-                        "description": "An array with three values, number of times kPa bonus achieved, number of opportunities to bonus, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "mobility_counts": {
-                        "type": "array",
-                        "description": "An array with three values, number of times mobility bonus achieved, number of opportunities to bonus, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "rotor_1_engaged": {
-                        "type": "array",
-                        "description": "An array with three values, number of times rotor 1 engaged, number of opportunities to engage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "rotor_1_engaged_auto": {
-                        "type": "array",
-                        "description": "An array with three values, number of times rotor 1 engaged in auto, number of opportunities to engage in auto, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "rotor_2_engaged": {
-                        "type": "array",
-                        "description": "An array with three values, number of times rotor 2 engaged, number of opportunities to engage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "rotor_2_engaged_auto": {
-                        "type": "array",
-                        "description": "An array with three values, number of times rotor 2 engaged in auto, number of opportunities to engage in auto, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "rotor_3_engaged": {
-                        "type": "array",
-                        "description": "An array with three values, number of times rotor 3 engaged, number of opportunities to engage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "rotor_4_engaged": {
-                        "type": "array",
-                        "description": "An array with three values, number of times rotor 4 engaged, number of opportunities to engage, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "takeoff_counts": {
-                        "type": "array",
-                        "description": "An array with three values, number of times takeoff was counted, number of opportunities to takeoff, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "unicorn_matches": {
-                        "type": "array",
-                        "description": "An array with three values, number of times a unicorn match (Win + kPa & Rotor Bonuses) occured, number of opportunities to have a unicorn match, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    }
-                },
-                "description": "Insights for FIRST STEAMWORKS qualification and elimination matches."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/API_Status"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a `Team` object for the team referenced by the given key.",
+        "operationId": "getTeam",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             },
-            "Event_Insights_2018": {
-                "required": [
-                    "auto_quest_achieved",
-                    "average_boost_played",
-                    "average_endgame_points",
-                    "average_force_played",
-                    "average_foul_score",
-                    "average_points_auto",
-                    "average_points_teleop",
-                    "average_run_points_auto",
-                    "average_scale_ownership_points",
-                    "average_scale_ownership_points_auto",
-                    "average_scale_ownership_points_teleop",
-                    "average_score",
-                    "average_switch_ownership_points",
-                    "average_switch_ownership_points_auto",
-                    "average_switch_ownership_points_teleop",
-                    "average_vault_points",
-                    "average_win_margin",
-                    "average_win_score",
-                    "boost_played_counts",
-                    "climb_counts",
-                    "face_the_boss_achieved",
-                    "force_played_counts",
-                    "high_score",
-                    "levitate_played_counts",
-                    "run_counts_auto",
-                    "scale_neutral_percentage",
-                    "scale_neutral_percentage_auto",
-                    "scale_neutral_percentage_teleop",
-                    "switch_owned_counts_auto",
-                    "unicorn_matches",
-                    "winning_opp_switch_denial_percentage_teleop",
-                    "winning_own_switch_ownership_percentage",
-                    "winning_own_switch_ownership_percentage_auto",
-                    "winning_own_switch_ownership_percentage_teleop",
-                    "winning_scale_ownership_percentage",
-                    "winning_scale_ownership_percentage_auto",
-                    "winning_scale_ownership_percentage_teleop"
-                ],
-                "type": "object",
-                "properties": {
-                    "auto_quest_achieved": {
-                        "type": "array",
-                        "description": "An array with three values, number of times auto quest was completed, number of opportunities to complete the auto quest, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "average_boost_played": {
-                        "type": "number",
-                        "description": "Average number of boost power up scored (out of 3).",
-                        "format": "float"
-                    },
-                    "average_endgame_points": {
-                        "type": "number",
-                        "description": "Average endgame points.",
-                        "format": "float"
-                    },
-                    "average_force_played": {
-                        "type": "number",
-                        "description": "Average number of force power up scored (out of 3).",
-                        "format": "float"
-                    },
-                    "average_foul_score": {
-                        "type": "number",
-                        "description": "Average foul score.",
-                        "format": "float"
-                    },
-                    "average_points_auto": {
-                        "type": "number",
-                        "description": "Average points scored during auto.",
-                        "format": "float"
-                    },
-                    "average_points_teleop": {
-                        "type": "number",
-                        "description": "Average points scored during teleop.",
-                        "format": "float"
-                    },
-                    "average_run_points_auto": {
-                        "type": "number",
-                        "description": "Average mobility points scored during auto.",
-                        "format": "float"
-                    },
-                    "average_scale_ownership_points": {
-                        "type": "number",
-                        "description": "Average scale ownership points scored.",
-                        "format": "float"
-                    },
-                    "average_scale_ownership_points_auto": {
-                        "type": "number",
-                        "description": "Average scale ownership points scored during auto.",
-                        "format": "float"
-                    },
-                    "average_scale_ownership_points_teleop": {
-                        "type": "number",
-                        "description": "Average scale ownership points scored during teleop.",
-                        "format": "float"
-                    },
-                    "average_score": {
-                        "type": "number",
-                        "description": "Average score.",
-                        "format": "float"
-                    },
-                    "average_switch_ownership_points": {
-                        "type": "number",
-                        "description": "Average switch ownership points scored.",
-                        "format": "float"
-                    },
-                    "average_switch_ownership_points_auto": {
-                        "type": "number",
-                        "description": "Average switch ownership points scored during auto.",
-                        "format": "float"
-                    },
-                    "average_switch_ownership_points_teleop": {
-                        "type": "number",
-                        "description": "Average switch ownership points scored during teleop.",
-                        "format": "float"
-                    },
-                    "average_vault_points": {
-                        "type": "number",
-                        "description": "Average value points scored.",
-                        "format": "float"
-                    },
-                    "average_win_margin": {
-                        "type": "number",
-                        "description": "Average margin of victory.",
-                        "format": "float"
-                    },
-                    "average_win_score": {
-                        "type": "number",
-                        "description": "Average winning score.",
-                        "format": "float"
-                    },
-                    "boost_played_counts": {
-                        "type": "array",
-                        "description": "An array with three values, number of times a boost power up was played, number of opportunities to play a boost power up, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "climb_counts": {
-                        "type": "array",
-                        "description": "An array with three values, number of times a climb occurred, number of opportunities to climb, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "face_the_boss_achieved": {
-                        "type": "array",
-                        "description": "An array with three values, number of times an alliance faced the boss, number of opportunities to face the boss, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "force_played_counts": {
-                        "type": "array",
-                        "description": "An array with three values, number of times a force power up was played, number of opportunities to play a force power up, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "high_score": {
-                        "type": "array",
-                        "description": "An array with three values, high score, match key from the match with the high score, and the name of the match",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "levitate_played_counts": {
-                        "type": "array",
-                        "description": "An array with three values, number of times a levitate power up was played, number of opportunities to play a levitate power up, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "run_counts_auto": {
-                        "type": "array",
-                        "description": "An array with three values, number of times a team scored mobility points in auto, number of opportunities to score mobility points in auto, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "scale_neutral_percentage": {
-                        "type": "number",
-                        "description": "Average scale neutral percentage.",
-                        "format": "float"
-                    },
-                    "scale_neutral_percentage_auto": {
-                        "type": "number",
-                        "description": "Average scale neutral percentage during auto.",
-                        "format": "float"
-                    },
-                    "scale_neutral_percentage_teleop": {
-                        "type": "number",
-                        "description": "Average scale neutral percentage during teleop.",
-                        "format": "float"
-                    },
-                    "switch_owned_counts_auto": {
-                        "type": "array",
-                        "description": "An array with three values, number of times a switch was owned during auto, number of opportunities to own a switch during auto, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "unicorn_matches": {
-                        "type": "array",
-                        "description": "An array with three values, number of times a unicorn match (Win + Auto Quest + Face the Boss) occurred, number of opportunities to have a unicorn match, and percentage.",
-                        "items": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    "winning_opp_switch_denial_percentage_teleop": {
-                        "type": "number",
-                        "description": "Average opposing switch denail percentage for the winning alliance during teleop.",
-                        "format": "float"
-                    },
-                    "winning_own_switch_ownership_percentage": {
-                        "type": "number",
-                        "description": "Average own switch ownership percentage for the winning alliance.",
-                        "format": "float"
-                    },
-                    "winning_own_switch_ownership_percentage_auto": {
-                        "type": "number",
-                        "description": "Average own switch ownership percentage for the winning alliance during auto.",
-                        "format": "float"
-                    },
-                    "winning_own_switch_ownership_percentage_teleop": {
-                        "type": "number",
-                        "description": "Average own switch ownership percentage for the winning alliance during teleop.",
-                        "format": "float"
-                    },
-                    "winning_scale_ownership_percentage": {
-                        "type": "number",
-                        "description": "Average scale ownership percentage for the winning alliance.",
-                        "format": "float"
-                    },
-                    "winning_scale_ownership_percentage_auto": {
-                        "type": "number",
-                        "description": "Average scale ownership percentage for the winning alliance during auto.",
-                        "format": "float"
-                    },
-                    "winning_scale_ownership_percentage_teleop": {
-                        "type": "number",
-                        "description": "Average scale ownership percentage for the winning alliance during teleop.",
-                        "format": "float"
-                    }
-                },
-                "description": "Insights for FIRST Power Up qualification and elimination matches."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Team"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/awards": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of awards the given team has won.",
+        "operationId": "getTeamAwards",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             },
-            "Event_OPRs": {
-                "type": "object",
-                "properties": {
-                    "oprs": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "number",
-                            "description": "OPR for team.",
-                            "format": "float"
-                        },
-                        "description": "A key-value pair with team key (eg `frc254`) as key and OPR as value."
-                    },
-                    "dprs": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "number",
-                            "description": "DPR for team.",
-                            "format": "float"
-                        },
-                        "description": "A key-value pair with team key (eg `frc254`) as key and DPR as value."
-                    },
-                    "ccwms": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "number",
-                            "description": "CCWM for team.",
-                            "format": "float"
-                        },
-                        "description": "A key-value pair with team key (eg `frc254`) as key and CCWM as value."
-                    }
-                },
-                "description": "OPR, DPR, and CCWM for teams at the event."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Award"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/awards/{year}": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of awards the given team has won in a given year.",
+        "operationId": "getTeamAwardsByYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             },
-            "Event_COPRs": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Award"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/districts": {
+      "get": {
+        "tags": [
+          "team",
+          "district"
+        ],
+        "description": "Gets an array of districts representing each year the team was in a district. Will return an empty array if the team was never in a district.",
+        "operationId": "getTeamDistricts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/District"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/event/{event_key}/awards": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets a list of awards the given team won at the given event.",
+        "operationId": "getTeamEventAwards",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Award"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/event/{event_key}/matches": {
+      "get": {
+        "tags": [
+          "team",
+          "event",
+          "match"
+        ],
+        "description": "Gets a list of matches for the given team and event.",
+        "operationId": "getTeamEventMatches",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Match"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/event/{event_key}/matches/keys": {
+      "get": {
+        "tags": [
+          "team",
+          "event",
+          "match"
+        ],
+        "description": "Gets a list of match keys for matches for the given team and event.",
+        "operationId": "getTeamEventMatchesKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Match Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/event/{event_key}/matches/simple": {
+      "get": {
+        "tags": [
+          "team",
+          "event",
+          "match"
+        ],
+        "description": "Gets a short-form list of matches for the given team and event.",
+        "operationId": "getTeamEventMatchesSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Match"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/event/{event_key}/status": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets the competition rank and status of the team at the given event.",
+        "operationId": "getTeamEventStatus",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Team_Event_Status"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/events": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets a list of all events this team has competed at.",
+        "operationId": "getTeamEvents",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/events/keys": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets a list of the event keys for all events this team has competed at.",
+        "operationId": "getTeamEventsKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Event Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/events/simple": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets a short-form list of all events this team has competed at.",
+        "operationId": "getTeamEventsSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/events/{year}": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets a list of events this team has competed at in the given year.",
+        "operationId": "getTeamEventsByYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/events/{year}/keys": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets a list of the event keys for events this team has competed at in the given year.",
+        "operationId": "getTeamEventsByYearKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Event Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/events/{year}/simple": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets a short-form list of events this team has competed at in the given year.",
+        "operationId": "getTeamEventsByYearSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/events/{year}/statuses": {
+      "get": {
+        "tags": [
+          "team",
+          "event"
+        ],
+        "description": "Gets a key-value list of the event statuses for events this team has competed at in the given year.",
+        "operationId": "getTeamEventsStatusesByYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/Team_Event_Status"
+                  },
+                  "description": "A key-value pair of `Team_Event_Status` objects with the event key as the key."
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/history": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets the history for the team referenced by the given key, including their events and awards.",
+        "operationId": "getTeamHistory",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with team's history including events and awards.",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/History"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/matches/{year}": {
+      "get": {
+        "tags": [
+          "team",
+          "match"
+        ],
+        "description": "Gets a list of matches for the given team and year.",
+        "operationId": "getTeamMatchesByYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Match"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/matches/{year}/keys": {
+      "get": {
+        "tags": [
+          "team",
+          "match"
+        ],
+        "description": "Gets a list of match keys for matches for the given team and year.",
+        "operationId": "getTeamMatchesByYearKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Match Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/matches/{year}/simple": {
+      "get": {
+        "tags": [
+          "team",
+          "match"
+        ],
+        "description": "Gets a short-form list of matches for the given team and year.",
+        "operationId": "getTeamMatchesByYearSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Match_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/media/tag/{media_tag}": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of Media (videos / pictures) for the given team and tag.",
+        "operationId": "getTeamMediaByTag",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/media_tag"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Media"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/media/tag/{media_tag}/{year}": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of Media (videos / pictures) for the given team, tag and year.",
+        "operationId": "getTeamMediaByTagYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/media_tag"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Media"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/media/{year}": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of Media (videos / pictures) for the given team and year.",
+        "operationId": "getTeamMediaByYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Media"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/robots": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of year and robot name pairs for each year that a robot name was provided. Will return an empty array if the team has never named a robot.",
+        "operationId": "getTeamRobots",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team_Robot"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/simple": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a `Team_Simple` object for the team referenced by the given key.",
+        "operationId": "getTeamSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Team_Simple"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/social_media": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of Media (social media) for the given team.",
+        "operationId": "getTeamSocialMedia",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Media"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/team/{team_key}/years_participated": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of years in which the team participated in at least one competition.",
+        "operationId": "getTeamYearsParticipated",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/team_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/teams/{page_num}": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of `Team` objects, paginated in groups of 500.",
+        "operationId": "getTeams",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/page_num"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/teams/{page_num}/keys": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of Team keys, paginated in groups of 500. (Note, each page will not have 500 teams, but will include the teams within that range of 500.)",
+        "operationId": "getTeamsKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/page_num"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/teams/{page_num}/simple": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of short form `Team_Simple` objects, paginated in groups of 500.",
+        "operationId": "getTeamsSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/page_num"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/teams/{year}/{page_num}": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of `Team` objects that competed in the given year, paginated in groups of 500.",
+        "operationId": "getTeamsByYear",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          },
+          {
+            "$ref": "#/components/parameters/page_num"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/teams/{year}/{page_num}/keys": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list Team Keys that competed in the given year, paginated in groups of 500.",
+        "operationId": "getTeamsByYearKeys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          },
+          {
+            "$ref": "#/components/parameters/page_num"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "Array of Team Keys",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/teams/{year}/{page_num}/simple": {
+      "get": {
+        "tags": [
+          "team"
+        ],
+        "description": "Gets a list of short form `Team_Simple` objects that competed in the given year, paginated in groups of 500.",
+        "operationId": "getTeamsByYearSimple",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          },
+          {
+            "$ref": "#/components/parameters/page_num"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Team_Simple"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "API_Status": {
+        "required": [
+          "android",
+          "current_season",
+          "down_events",
+          "ios",
+          "is_datafeed_down",
+          "max_season",
+          "max_team_page"
+        ],
+        "type": "object",
+        "properties": {
+          "current_season": {
+            "type": "integer",
+            "description": "Year of the current FRC season."
+          },
+          "max_season": {
+            "type": "integer",
+            "description": "Maximum FRC season year for valid queries."
+          },
+          "is_datafeed_down": {
+            "type": "boolean",
+            "description": "True if the entire FMS API provided by FIRST is down."
+          },
+          "down_events": {
+            "type": "array",
+            "description": "An array of strings containing event keys of any active events that are no longer updating.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ios": {
+            "$ref": "#/components/schemas/API_Status_App_Version"
+          },
+          "android": {
+            "$ref": "#/components/schemas/API_Status_App_Version"
+          },
+          "max_team_page": {
+            "type": "integer",
+            "description": "Maximum team page number for valid queries."
+          }
+        }
+      },
+      "API_Status_App_Version": {
+        "required": [
+          "latest_app_version",
+          "min_app_version"
+        ],
+        "type": "object",
+        "properties": {
+          "min_app_version": {
+            "type": "integer",
+            "description": "Internal use - Minimum application version required to correctly connect and process data."
+          },
+          "latest_app_version": {
+            "type": "integer",
+            "description": "Internal use - Latest application version available."
+          }
+        }
+      },
+      "AutoChargeStationRobot_2023": {
+        "type": "string",
+        "enum": [
+          "Docked",
+          "None"
+        ]
+      },
+      "AutoLineRobot_2024": {
+        "type": "string",
+        "enum": [
+          "No",
+          "Yes"
+        ]
+      },
+      "AutoRobot_2018": {
+        "type": "string",
+        "enum": [
+          "None",
+          "AutoRun"
+        ]
+      },
+      "Award": {
+        "required": [
+          "award_type",
+          "event_key",
+          "name",
+          "recipient_list",
+          "year"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the award as provided by FIRST. May vary for the same award type."
+          },
+          "award_type": {
+            "type": "integer",
+            "description": "Type of award given. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/award_type.py#L8"
+          },
+          "event_key": {
+            "type": "string",
+            "description": "The event_key of the event the award was won at."
+          },
+          "recipient_list": {
+            "type": "array",
+            "description": "A list of recipients of the award at the event. May have either a team_key or an awardee, both, or neither (in the case the award wasn't awarded at the event).",
+            "items": {
+              "$ref": "#/components/schemas/Award_Recipient"
+            }
+          },
+          "year": {
+            "type": "integer",
+            "description": "The year this award was won."
+          }
+        }
+      },
+      "Award_Recipient": {
+        "type": "object",
+        "required": [
+          "team_key",
+          "awardee"
+        ],
+        "properties": {
+          "team_key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The TBA team key for the team that was given the award. May be null."
+          },
+          "awardee": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The name of the individual given the award. May be null."
+          }
+        },
+        "description": "An `Award_Recipient` object represents the team and/or person who received an award at an event."
+      },
+      "Bay_2019": {
+        "type": "string",
+        "enum": [
+          "None",
+          "Panel",
+          "PanelAndCargo"
+        ]
+      },
+      "BridgeState_2023": {
+        "type": "string",
+        "enum": [
+          "Level",
+          "NotLevel"
+        ]
+      },
+      "Comp_Level": {
+        "type": "string",
+        "enum": [
+          "qm",
+          "ef",
+          "qf",
+          "sf",
+          "f"
+        ],
+        "description": "The competition level the match was played at."
+      },
+      "District": {
+        "required": [
+          "abbreviation",
+          "display_name",
+          "key",
+          "year",
+          "official_advancement_counts"
+        ],
+        "type": "object",
+        "properties": {
+          "abbreviation": {
+            "type": "string",
+            "description": "The short identifier for the district."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "The long name for the district."
+          },
+          "key": {
+            "type": "string",
+            "description": "Key for this district, e.g. `2016ne`."
+          },
+          "year": {
+            "type": "integer",
+            "description": "Year this district participated."
+          },
+          "official_advancement_counts": {
+            "type": "object",
+            "description": "The number of teams advancing to DCMP and CMP from this district, as specified in the FIRST manual.",
+            "required": [
+              "dcmp",
+              "cmp"
+            ],
+            "properties": {
+              "dcmp": {
+                "type": "integer",
+                "description": "Number of teams advancing to the District Championship."
+              },
+              "cmp": {
+                "type": "integer",
+                "description": "Number of teams advancing to the Championship."
+              }
+            }
+          }
+        }
+      },
+      "DistrictInsightRegionData": {
+        "type": "object",
+        "properties": {
+          "yearly_active_team_count": {
+            "type": "object",
+            "description": "Map of year to number of active teams",
+            "additionalProperties": {
+              "type": "integer"
+            }
+          },
+          "yearly_event_count": {
+            "type": "object",
+            "description": "Map of year to number of events",
+            "additionalProperties": {
+              "type": "integer"
+            }
+          },
+          "yearly_gained_teams": {
+            "type": "object",
+            "description": "Map of year to list of team keys gained",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "yearly_lost_teams": {
+            "type": "object",
+            "description": "Map of year to list of team keys lost",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "yearly_active_team_count",
+          "yearly_event_count",
+          "yearly_gained_teams",
+          "yearly_lost_teams"
+        ]
+      },
+      "District_Advancement": {
+        "required": [
+          "cmp",
+          "dcmp"
+        ],
+        "type": "object",
+        "properties": {
+          "dcmp": {
+            "type": "boolean",
+            "description": "Whether or not the team qualified for their District Championship"
+          },
+          "cmp": {
+            "type": "boolean",
+            "description": "Whether or not the team qualified for the FIRST Championship"
+          }
+        },
+        "description": "Advancement status of a team in a district."
+      },
+      "District_Insight": {
+        "type": "object",
+        "properties": {
+          "district_data": {
+            "type": "object",
+            "properties": {
+              "region_data": {
                 "type": "object",
                 "additionalProperties": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "number"
-                    },
-                    "description": "A key-value pair with team key (eg `frc254`) as key and CCWM as value."
-                },
-                "description": "Component OPRs for teams at the event."
-            },
-            "Event_Predictions": {
-                "type": "object",
-                "description": "JSON Object containing prediction information for the event. Contains year-specific information and is subject to change."
-            },
-            "Match_Simple": {
-                "required": [
-                    "key",
-                    "comp_level",
-                    "set_number",
-                    "match_number",
-                    "alliances",
-                    "winning_alliance",
-                    "event_key",
-                    "time",
-                    "predicted_time",
-                    "actual_time"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may append the competition level if more than one match in required per set."
-                    },
-                    "comp_level": {
-                        "type": "string",
-                        "description": "The competition level the match was played at.",
-                        "enum": [
-                            "qm",
-                            "ef",
-                            "qf",
-                            "sf",
-                            "f"
-                        ]
-                    },
-                    "set_number": {
-                        "type": "integer",
-                        "description": "The set number in a series of matches where more than one match is required in the match series."
-                    },
-                    "match_number": {
-                        "type": "integer",
-                        "description": "The match number of the match in the competition level."
-                    },
-                    "alliances": {
-                        "type": "object",
-                        "required": [
-                            "red",
-                            "blue"
-                        ],
-                        "properties": {
-                            "red": {
-                                "$ref": "#/components/schemas/Match_alliance"
-                            },
-                            "blue": {
-                                "$ref": "#/components/schemas/Match_alliance"
-                            }
-                        },
-                        "description": "A list of alliances, the teams on the alliances, and their score."
-                    },
-                    "winning_alliance": {
-                        "type": "string",
-                        "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.",
-                        "enum": [
-                            "red",
-                            "blue",
-                            ""
-                        ]
-                    },
-                    "event_key": {
-                        "type": "string",
-                        "description": "Event key of the event the match was played at."
-                    },
-                    "time": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the scheduled match time, as taken from the published schedule.",
-                        "format": "int64"
-                    },
-                    "predicted_time": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the TBA predicted match start time.",
-                        "format": "int64"
-                    },
-                    "actual_time": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of actual match start time.",
-                        "format": "int64"
-                    }
+                  "$ref": "#/components/schemas/DistrictInsightRegionData"
                 }
+              },
+              "district_wide_data": {
+                "$ref": "#/components/schemas/DistrictInsightRegionData"
+              }
             },
-            "Match": {
-                "required": [
-                    "comp_level",
-                    "event_key",
-                    "key",
-                    "match_number",
-                    "set_number",
-                    "alliances",
-                    "winning_alliance",
-                    "time",
-                    "actual_time",
-                    "predicted_time",
-                    "post_result_time",
-                    "score_breakdown",
-                    "videos"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may be appended to the competition level if more than one match in required per set."
-                    },
-                    "comp_level": {
-                        "type": "string",
-                        "description": "The competition level the match was played at.",
-                        "enum": [
-                            "qm",
-                            "ef",
-                            "qf",
-                            "sf",
-                            "f"
-                        ]
-                    },
-                    "set_number": {
-                        "type": "integer",
-                        "description": "The set number in a series of matches where more than one match is required in the match series."
-                    },
-                    "match_number": {
-                        "type": "integer",
-                        "description": "The match number of the match in the competition level."
-                    },
-                    "alliances": {
-                        "type": "object",
-                        "required": [
-                            "red",
-                            "blue"
-                        ],
-                        "properties": {
-                            "red": {
-                                "$ref": "#/components/schemas/Match_alliance"
-                            },
-                            "blue": {
-                                "$ref": "#/components/schemas/Match_alliance"
-                            }
-                        },
-                        "description": "A list of alliances, the teams on the alliances, and their score."
-                    },
-                    "winning_alliance": {
-                        "type": "string",
-                        "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.",
-                        "enum": [
-                            "red",
-                            "blue",
-                            ""
-                        ]
-                    },
-                    "event_key": {
-                        "type": "string",
-                        "description": "Event key of the event the match was played at."
-                    },
-                    "time": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the scheduled match time, as taken from the published schedule.",
-                        "format": "int64"
-                    },
-                    "actual_time": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of actual match start time.",
-                        "format": "int64"
-                    },
-                    "predicted_time": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the TBA predicted match start time.",
-                        "format": "int64"
-                    },
-                    "post_result_time": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) when the match result was posted.",
-                        "format": "int64"
-                    },
-                    "score_breakdown": {
-                        "type": [
-                            "object",
-                            "null"
-                        ],
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2015"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2016"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2017"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2018"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2019"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2020"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2022"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2023"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2024"
-                            },
-                            {
-                                "$ref": "#/components/schemas/Match_Score_Breakdown_2025"
-                            }
-                        ],
-                        "description": "Score breakdown for auto, teleop, etc. points. Varies from year to year. May be null."
-                    },
-                    "videos": {
-                        "type": "array",
-                        "description": "Array of video objects associated with this match.",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "type",
-                                "key"
-                            ],
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "description": "Can be one of 'youtube' or 'tba'"
-                                },
-                                "key": {
-                                    "type": "string",
-                                    "description": "Unique key representing this video"
-                                }
-                            }
-                        }
-                    }
+            "required": []
+          },
+          "team_data": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "district_seasons": {
+                  "type": "integer"
+                },
+                "total_district_points": {
+                  "type": "integer"
+                },
+                "total_pre_dcmp_district_points": {
+                  "type": "integer"
+                },
+                "district_event_wins": {
+                  "type": "integer"
+                },
+                "dcmp_wins": {
+                  "type": "integer"
+                },
+                "team_awards": {
+                  "type": "integer"
+                },
+                "individual_awards": {
+                  "type": "integer"
+                },
+                "quals_record": {
+                  "$ref": "#/components/schemas/WLT_Record"
+                },
+                "elims_record": {
+                  "$ref": "#/components/schemas/WLT_Record"
+                },
+                "in_district_extra_play_count": {
+                  "type": "integer"
+                },
+                "total_matches_played": {
+                  "type": "integer"
+                },
+                "dcmp_appearances": {
+                  "type": "integer"
+                },
+                "cmp_appearances": {
+                  "type": "integer"
                 }
-            },
-            "Match_alliance": {
-                "required": [
-                    "score",
-                    "team_keys",
-                    "surrogate_team_keys",
-                    "dq_team_keys"
-                ],
-                "type": "object",
-                "properties": {
-                    "score": {
-                        "type": "integer",
-                        "description": "Score for this alliance. Will be null or -1 for an unplayed match."
-                    },
-                    "team_keys": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "description": "TBA Team keys (eg `frc254`) for teams on this alliance."
-                        }
-                    },
-                    "surrogate_team_keys": {
-                        "type": "array",
-                        "description": "TBA team keys (eg `frc254`) of any teams playing as a surrogate.",
-                        "items": {
-                            "type": "string",
-                            "description": "Team key of a surrogate team."
-                        }
-                    },
-                    "dq_team_keys": {
-                        "type": "array",
-                        "description": "TBA team keys (eg `frc254`) of any disqualified teams.",
-                        "items": {
-                            "type": "string",
-                            "description": "Team key of a disqualified team."
-                        }
-                    }
-                }
-            },
-            "Zebra": {
-                "required": [
-                    "key",
-                    "times",
-                    "alliances"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may be appended to the competition level if more than one match in required per set."
-                    },
-                    "times": {
-                        "type": "array",
-                        "description": "A list of relative timestamps for each data point. Each timestamp will correspond to the X and Y value at the same index in a team xs and ys arrays. `times`, all teams `xs` and all teams `ys` are guarenteed to be the same length.",
-                        "items": {
-                            "type": "number",
-                            "format": "double",
-                            "examples": [
-                                0,
-                                0.1,
-                                0.2
-                            ]
-                        }
-                    },
-                    "alliances": {
-                        "type": "object",
-                        "properties": {
-                            "red": {
-                                "type": "array",
-                                "description": "Zebra MotionWorks data for teams on the red alliance",
-                                "items": {
-                                    "$ref": "#/components/schemas/Zebra_team"
-                                }
-                            },
-                            "blue": {
-                                "type": "array",
-                                "description": "Zebra data for teams on the blue alliance",
-                                "items": {
-                                    "$ref": "#/components/schemas/Zebra_team"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "Zebra_team": {
-                "required": [
-                    "team_key",
-                    "xs",
-                    "ys"
-                ],
-                "type": "object",
-                "properties": {
-                    "team_key": {
-                        "type": "string",
-                        "description": "The TBA team key for the Zebra MotionWorks data.",
-                        "examples": [
-                            "frc7332"
-                        ]
-                    },
-                    "xs": {
-                        "type": "array",
-                        "description": "A list containing doubles and nulls representing a teams X position in feet at the corresponding timestamp. A null value represents no tracking data for a given timestamp.",
-                        "items": {
-                            "type": "number",
-                            "format": "double",
-                            "examples": [
-                                2.73,
-                                2.7,
-                                null
-                            ]
-                        }
-                    },
-                    "ys": {
-                        "type": "array",
-                        "description": "A list containing doubles and nulls representing a teams Y position in feet at the corresponding timestamp. A null value represents no tracking data for a given timestamp.",
-                        "items": {
-                            "type": "number",
-                            "format": "double",
-                            "examples": [
-                                2.73,
-                                2.7,
-                                null
-                            ]
-                        }
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2015": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red",
-                    "coopertition",
-                    "coopertition_points"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2015_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2015_Alliance"
-                    },
-                    "coopertition": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Unknown",
-                            "Stack"
-                        ]
-                    },
-                    "coopertition_points": {
-                        "type": "integer"
-                    }
-                },
-                "description": "See the 2015 FMS API documentation for a description of each value"
-            },
-            "Match_Score_Breakdown_2015_Alliance": {
-                "type": "object",
-                "properties": {
-                    "auto_points": {
-                        "type": "integer"
-                    },
-                    "teleop_points": {
-                        "type": "integer"
-                    },
-                    "container_points": {
-                        "type": "integer"
-                    },
-                    "tote_points": {
-                        "type": "integer"
-                    },
-                    "litter_points": {
-                        "type": "integer"
-                    },
-                    "foul_points": {
-                        "type": "integer"
-                    },
-                    "adjust_points": {
-                        "type": "integer"
-                    },
-                    "total_points": {
-                        "type": "integer"
-                    },
-                    "foul_count": {
-                        "type": "integer"
-                    },
-                    "tote_count_far": {
-                        "type": "integer"
-                    },
-                    "tote_count_near": {
-                        "type": "integer"
-                    },
-                    "tote_set": {
-                        "type": "boolean"
-                    },
-                    "tote_stack": {
-                        "type": "boolean"
-                    },
-                    "container_count_level1": {
-                        "type": "integer"
-                    },
-                    "container_count_level2": {
-                        "type": "integer"
-                    },
-                    "container_count_level3": {
-                        "type": "integer"
-                    },
-                    "container_count_level4": {
-                        "type": "integer"
-                    },
-                    "container_count_level5": {
-                        "type": "integer"
-                    },
-                    "container_count_level6": {
-                        "type": "integer"
-                    },
-                    "container_set": {
-                        "type": "boolean"
-                    },
-                    "litter_count_container": {
-                        "type": "integer"
-                    },
-                    "litter_count_landfill": {
-                        "type": "integer"
-                    },
-                    "litter_count_unprocessed": {
-                        "type": "integer"
-                    },
-                    "robot_set": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2016": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2016_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2016_Alliance"
-                    }
-                },
-                "description": "See the 2016 FMS API documentation for a description of each value."
-            },
-            "Match_Score_Breakdown_2016_Alliance": {
-                "type": "object",
-                "properties": {
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "breachPoints": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "capturePoints": {
-                        "type": "integer"
-                    },
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    },
-                    "robot1Auto": {
-                        "type": "string",
-                        "enum": [
-                            "Crossed",
-                            "Reached",
-                            "None"
-                        ]
-                    },
-                    "robot2Auto": {
-                        "type": "string",
-                        "enum": [
-                            "Crossed",
-                            "Reached",
-                            "None"
-                        ]
-                    },
-                    "robot3Auto": {
-                        "type": "string",
-                        "enum": [
-                            "Crossed",
-                            "Reached",
-                            "None"
-                        ]
-                    },
-                    "autoReachPoints": {
-                        "type": "integer"
-                    },
-                    "autoCrossingPoints": {
-                        "type": "integer"
-                    },
-                    "autoBouldersLow": {
-                        "type": "integer"
-                    },
-                    "autoBouldersHigh": {
-                        "type": "integer"
-                    },
-                    "autoBoulderPoints": {
-                        "type": "integer"
-                    },
-                    "teleopCrossingPoints": {
-                        "type": "integer"
-                    },
-                    "teleopBouldersLow": {
-                        "type": "integer"
-                    },
-                    "teleopBouldersHigh": {
-                        "type": "integer"
-                    },
-                    "teleopBoulderPoints": {
-                        "type": "integer"
-                    },
-                    "teleopDefensesBreached": {
-                        "type": "boolean"
-                    },
-                    "teleopChallengePoints": {
-                        "type": "integer"
-                    },
-                    "teleopScalePoints": {
-                        "type": "integer"
-                    },
-                    "teleopTowerCaptured": {
-                        "type": "boolean"
-                    },
-                    "towerFaceA": {
-                        "type": "string"
-                    },
-                    "towerFaceB": {
-                        "type": "string"
-                    },
-                    "towerFaceC": {
-                        "type": "string"
-                    },
-                    "towerEndStrength": {
-                        "type": "integer"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "position2": {
-                        "type": "string"
-                    },
-                    "position3": {
-                        "type": "string"
-                    },
-                    "position4": {
-                        "type": "string"
-                    },
-                    "position5": {
-                        "type": "string"
-                    },
-                    "position1crossings": {
-                        "type": "integer"
-                    },
-                    "position2crossings": {
-                        "type": "integer"
-                    },
-                    "position3crossings": {
-                        "type": "integer"
-                    },
-                    "position4crossings": {
-                        "type": "integer"
-                    },
-                    "position5crossings": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2017": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2017_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2017_Alliance"
-                    }
-                },
-                "description": "See the 2017 FMS API documentation for a description of each value."
-            },
-            "Match_Score_Breakdown_2017_Alliance": {
-                "type": "object",
-                "properties": {
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    },
-                    "robot1Auto": {
-                        "type": "string",
-                        "enum": [
-                            "Unknown",
-                            "Mobility",
-                            "None"
-                        ]
-                    },
-                    "robot2Auto": {
-                        "type": "string",
-                        "enum": [
-                            "Unknown",
-                            "Mobility",
-                            "None"
-                        ]
-                    },
-                    "robot3Auto": {
-                        "type": "string",
-                        "enum": [
-                            "Unknown",
-                            "Mobility",
-                            "None"
-                        ]
-                    },
-                    "rotor1Auto": {
-                        "type": "boolean"
-                    },
-                    "rotor2Auto": {
-                        "type": "boolean"
-                    },
-                    "autoFuelLow": {
-                        "type": "integer"
-                    },
-                    "autoFuelHigh": {
-                        "type": "integer"
-                    },
-                    "autoMobilityPoints": {
-                        "type": "integer"
-                    },
-                    "autoRotorPoints": {
-                        "type": "integer"
-                    },
-                    "autoFuelPoints": {
-                        "type": "integer"
-                    },
-                    "teleopFuelPoints": {
-                        "type": "integer"
-                    },
-                    "teleopFuelLow": {
-                        "type": "integer"
-                    },
-                    "teleopFuelHigh": {
-                        "type": "integer"
-                    },
-                    "teleopRotorPoints": {
-                        "type": "integer"
-                    },
-                    "kPaRankingPointAchieved": {
-                        "type": "boolean"
-                    },
-                    "teleopTakeoffPoints": {
-                        "type": "integer"
-                    },
-                    "kPaBonusPoints": {
-                        "type": "integer"
-                    },
-                    "rotorBonusPoints": {
-                        "type": "integer"
-                    },
-                    "rotor1Engaged": {
-                        "type": "boolean"
-                    },
-                    "rotor2Engaged": {
-                        "type": "boolean"
-                    },
-                    "rotor3Engaged": {
-                        "type": "boolean"
-                    },
-                    "rotor4Engaged": {
-                        "type": "boolean"
-                    },
-                    "rotorRankingPointAchieved": {
-                        "type": "boolean"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "touchpadNear": {
-                        "type": "string"
-                    },
-                    "touchpadMiddle": {
-                        "type": "string"
-                    },
-                    "touchpadFar": {
-                        "type": "string"
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2018": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2018_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2018_Alliance"
-                    }
-                },
-                "description": "See the 2018 FMS API documentation for a description of each value. https://frcevents2.docs.apiary.io/#/reference/match-results/score-details"
-            },
-            "Match_Score_Breakdown_2018_Alliance": {
-                "type": "object",
-                "properties": {
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "autoOwnershipPoints": {
-                        "type": "integer"
-                    },
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "autoQuestRankingPoint": {
-                        "type": "boolean"
-                    },
-                    "autoRobot1": {
-                        "type": "string"
-                    },
-                    "autoRobot2": {
-                        "type": "string"
-                    },
-                    "autoRobot3": {
-                        "type": "string"
-                    },
-                    "autoRunPoints": {
-                        "type": "integer"
-                    },
-                    "autoScaleOwnershipSec": {
-                        "type": "integer"
-                    },
-                    "autoSwitchAtZero": {
-                        "type": "boolean"
-                    },
-                    "autoSwitchOwnershipSec": {
-                        "type": "integer"
-                    },
-                    "endgamePoints": {
-                        "type": "integer"
-                    },
-                    "endgameRobot1": {
-                        "type": "string"
-                    },
-                    "endgameRobot2": {
-                        "type": "string"
-                    },
-                    "endgameRobot3": {
-                        "type": "string"
-                    },
-                    "faceTheBossRankingPoint": {
-                        "type": "boolean"
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "rp": {
-                        "type": "integer"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "teleopOwnershipPoints": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "teleopScaleBoostSec": {
-                        "type": "integer"
-                    },
-                    "teleopScaleForceSec": {
-                        "type": "integer"
-                    },
-                    "teleopScaleOwnershipSec": {
-                        "type": "integer"
-                    },
-                    "teleopSwitchBoostSec": {
-                        "type": "integer"
-                    },
-                    "teleopSwitchForceSec": {
-                        "type": "integer"
-                    },
-                    "teleopSwitchOwnershipSec": {
-                        "type": "integer"
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    },
-                    "vaultBoostPlayed": {
-                        "type": "integer"
-                    },
-                    "vaultBoostTotal": {
-                        "type": "integer"
-                    },
-                    "vaultForcePlayed": {
-                        "type": "integer"
-                    },
-                    "vaultForceTotal": {
-                        "type": "integer"
-                    },
-                    "vaultLevitatePlayed": {
-                        "type": "integer"
-                    },
-                    "vaultLevitateTotal": {
-                        "type": "integer"
-                    },
-                    "vaultPoints": {
-                        "type": "integer"
-                    },
-                    "tba_gameData": {
-                        "type": "string",
-                        "description": "Unofficial TBA-computed value of the FMS provided GameData given to the alliance teams at the start of the match. 3 Character String containing `L` and `R` only. The first character represents the near switch, the 2nd the scale, and the 3rd the far, opposing, switch from the alliance's perspective. An `L` in a position indicates the platform on the left will be lit for the alliance while an `R` will indicate the right platform will be lit for the alliance. See also [WPI Screen Steps](https://wpilib.screenstepslive.com/s/currentCS/m/getting_started/l/826278-2018-game-data-details)."
-                    }
-                }
-            },
-            "Match_Timeseries_2018": {
-                "type": "object",
-                "properties": {
-                    "event_key": {
-                        "type": "string",
-                        "description": "TBA event key with the format yyyy[EVENT_CODE], where yyyy is the year, and EVENT_CODE is the event code of the event."
-                    },
-                    "match_id": {
-                        "type": "string",
-                        "description": "Match ID consisting of the level, match number, and set number, eg `qm45` or `f1m1`."
-                    },
-                    "mode": {
-                        "type": "string",
-                        "description": "Current mode of play, can be `pre_match`, `auto`, `telop`, or `post_match`."
-                    },
-                    "play": {
-                        "type": "integer"
-                    },
-                    "time_remaining": {
-                        "type": "integer",
-                        "description": "Amount of time remaining in the match, only valid during `auto` and `teleop` modes."
-                    },
-                    "blue_auto_quest": {
-                        "type": "integer",
-                        "description": "1 if the blue alliance is credited with the AUTO QUEST, 0 if not."
-                    },
-                    "blue_boost_count": {
-                        "type": "integer",
-                        "description": "Number of POWER CUBES in the BOOST section of the blue alliance VAULT."
-                    },
-                    "blue_boost_played": {
-                        "type": "integer",
-                        "description": "Returns 1 if the blue alliance BOOST was played, or 0 if not played."
-                    },
-                    "blue_current_powerup": {
-                        "type": "string",
-                        "description": "Name of the current blue alliance POWER UP being played, or `null`."
-                    },
-                    "blue_face_the_boss": {
-                        "type": "integer",
-                        "description": "1 if the blue alliance is credited with FACING THE BOSS, 0 if not."
-                    },
-                    "blue_force_count": {
-                        "type": "integer",
-                        "description": "Number of POWER CUBES in the FORCE section of the blue alliance VAULT."
-                    },
-                    "blue_force_played": {
-                        "type": "integer",
-                        "description": "Returns 1 if the blue alliance FORCE was played, or 0 if not played."
-                    },
-                    "blue_levitate_count": {
-                        "type": "integer",
-                        "description": "Number of POWER CUBES in the LEVITATE section of the blue alliance VAULT."
-                    },
-                    "blue_levitate_played": {
-                        "type": "integer",
-                        "description": "Returns 1 if the blue alliance LEVITATE was played, or 0 if not played."
-                    },
-                    "blue_powerup_time_remaining": {
-                        "type": "string",
-                        "description": "Number of seconds remaining in the blue alliance POWER UP time, or 0 if none is active."
-                    },
-                    "blue_scale_owned": {
-                        "type": "integer",
-                        "description": "1 if the blue alliance owns the SCALE, 0 if not."
-                    },
-                    "blue_score": {
-                        "type": "integer",
-                        "description": "Current score for the blue alliance."
-                    },
-                    "blue_switch_owned": {
-                        "type": "integer",
-                        "description": "1 if the blue alliance owns their SWITCH, 0 if not."
-                    },
-                    "red_auto_quest": {
-                        "type": "integer",
-                        "description": "1 if the red alliance is credited with the AUTO QUEST, 0 if not."
-                    },
-                    "red_boost_count": {
-                        "type": "integer",
-                        "description": "Number of POWER CUBES in the BOOST section of the red alliance VAULT."
-                    },
-                    "red_boost_played": {
-                        "type": "integer",
-                        "description": "Returns 1 if the red alliance BOOST was played, or 0 if not played."
-                    },
-                    "red_current_powerup": {
-                        "type": "string",
-                        "description": "Name of the current red alliance POWER UP being played, or `null`."
-                    },
-                    "red_face_the_boss": {
-                        "type": "integer",
-                        "description": "1 if the red alliance is credited with FACING THE BOSS, 0 if not."
-                    },
-                    "red_force_count": {
-                        "type": "integer",
-                        "description": "Number of POWER CUBES in the FORCE section of the red alliance VAULT."
-                    },
-                    "red_force_played": {
-                        "type": "integer",
-                        "description": "Returns 1 if the red alliance FORCE was played, or 0 if not played."
-                    },
-                    "red_levitate_count": {
-                        "type": "integer",
-                        "description": "Number of POWER CUBES in the LEVITATE section of the red alliance VAULT."
-                    },
-                    "red_levitate_played": {
-                        "type": "integer",
-                        "description": "Returns 1 if the red alliance LEVITATE was played, or 0 if not played."
-                    },
-                    "red_powerup_time_remaining": {
-                        "type": "string",
-                        "description": "Number of seconds remaining in the red alliance POWER UP time, or 0 if none is active."
-                    },
-                    "red_scale_owned": {
-                        "type": "integer",
-                        "description": "1 if the red alliance owns the SCALE, 0 if not."
-                    },
-                    "red_score": {
-                        "type": "integer",
-                        "description": "Current score for the red alliance."
-                    },
-                    "red_switch_owned": {
-                        "type": "integer",
-                        "description": "1 if the red alliance owns their SWITCH, 0 if not."
-                    }
-                },
-                "description": "Timeseries data for the 2018 game *FIRST* POWER UP.\n*WARNING:* This is *not* official data, and is subject to a significant possibility of error, or missing data. Do not rely on this data for any purpose. In fact, pretend we made it up.\n*WARNING:* This model is currently under active development and may change at any time, including in breaking ways."
-            },
-            "Match_Score_Breakdown_2019": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2019_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2019_Alliance"
-                    }
-                },
-                "description": "See the 2019 FMS API documentation for a description of each value. https://frcevents2.docs.apiary.io/#/reference/match-results/score-details"
-            },
-            "Match_Score_Breakdown_2019_Alliance": {
-                "type": "object",
-                "properties": {
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "bay1": {
-                        "type": "string"
-                    },
-                    "bay2": {
-                        "type": "string"
-                    },
-                    "bay3": {
-                        "type": "string"
-                    },
-                    "bay4": {
-                        "type": "string"
-                    },
-                    "bay5": {
-                        "type": "string"
-                    },
-                    "bay6": {
-                        "type": "string"
-                    },
-                    "bay7": {
-                        "type": "string"
-                    },
-                    "bay8": {
-                        "type": "string"
-                    },
-                    "cargoPoints": {
-                        "type": "integer"
-                    },
-                    "completeRocketRankingPoint": {
-                        "type": "boolean"
-                    },
-                    "completedRocketFar": {
-                        "type": "boolean"
-                    },
-                    "completedRocketNear": {
-                        "type": "boolean"
-                    },
-                    "endgameRobot1": {
-                        "type": "string"
-                    },
-                    "endgameRobot2": {
-                        "type": "string"
-                    },
-                    "endgameRobot3": {
-                        "type": "string"
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "habClimbPoints": {
-                        "type": "integer"
-                    },
-                    "habDockingRankingPoint": {
-                        "type": "boolean"
-                    },
-                    "habLineRobot1": {
-                        "type": "string"
-                    },
-                    "habLineRobot2": {
-                        "type": "string"
-                    },
-                    "habLineRobot3": {
-                        "type": "string"
-                    },
-                    "hatchPanelPoints": {
-                        "type": "integer"
-                    },
-                    "lowLeftRocketFar": {
-                        "type": "string"
-                    },
-                    "lowLeftRocketNear": {
-                        "type": "string"
-                    },
-                    "lowRightRocketFar": {
-                        "type": "string"
-                    },
-                    "lowRightRocketNear": {
-                        "type": "string"
-                    },
-                    "midLeftRocketFar": {
-                        "type": "string"
-                    },
-                    "midLeftRocketNear": {
-                        "type": "string"
-                    },
-                    "midRightRocketFar": {
-                        "type": "string"
-                    },
-                    "midRightRocketNear": {
-                        "type": "string"
-                    },
-                    "preMatchBay1": {
-                        "type": "string"
-                    },
-                    "preMatchBay2": {
-                        "type": "string"
-                    },
-                    "preMatchBay3": {
-                        "type": "string"
-                    },
-                    "preMatchBay6": {
-                        "type": "string"
-                    },
-                    "preMatchBay7": {
-                        "type": "string"
-                    },
-                    "preMatchBay8": {
-                        "type": "string"
-                    },
-                    "preMatchLevelRobot1": {
-                        "type": "string"
-                    },
-                    "preMatchLevelRobot2": {
-                        "type": "string"
-                    },
-                    "preMatchLevelRobot3": {
-                        "type": "string"
-                    },
-                    "rp": {
-                        "type": "integer"
-                    },
-                    "sandStormBonusPoints": {
-                        "type": "integer"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "topLeftRocketFar": {
-                        "type": "string"
-                    },
-                    "topLeftRocketNear": {
-                        "type": "string"
-                    },
-                    "topRightRocketFar": {
-                        "type": "string"
-                    },
-                    "topRightRocketNear": {
-                        "type": "string"
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2020": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2020_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2020_Alliance"
-                    }
-                },
-                "description": "See the 2020 FMS API documentation for a description of each value. https://frcevents2.docs.apiary.io/#/reference/match-results/score-details"
-            },
-            "Match_Score_Breakdown_2020_Alliance": {
-                "type": "object",
-                "properties": {
-                    "initLineRobot1": {
-                        "type": "string"
-                    },
-                    "endgameRobot1": {
-                        "type": "string"
-                    },
-                    "initLineRobot2": {
-                        "type": "string"
-                    },
-                    "endgameRobot2": {
-                        "type": "string"
-                    },
-                    "initLineRobot3": {
-                        "type": "string"
-                    },
-                    "endgameRobot3": {
-                        "type": "string"
-                    },
-                    "autoCellsBottom": {
-                        "type": "integer"
-                    },
-                    "autoCellsOuter": {
-                        "type": "integer"
-                    },
-                    "autoCellsInner": {
-                        "type": "integer"
-                    },
-                    "teleopCellsBottom": {
-                        "type": "integer"
-                    },
-                    "teleopCellsOuter": {
-                        "type": "integer"
-                    },
-                    "teleopCellsInner": {
-                        "type": "integer"
-                    },
-                    "stage1Activated": {
-                        "type": "boolean"
-                    },
-                    "stage2Activated": {
-                        "type": "boolean"
-                    },
-                    "stage3Activated": {
-                        "type": "boolean"
-                    },
-                    "stage3TargetColor": {
-                        "type": "string"
-                    },
-                    "endgameRungIsLevel": {
-                        "type": "string"
-                    },
-                    "autoInitLinePoints": {
-                        "type": "integer"
-                    },
-                    "autoCellPoints": {
-                        "type": "integer"
-                    },
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "teleopCellPoints": {
-                        "type": "integer"
-                    },
-                    "controlPanelPoints": {
-                        "type": "integer"
-                    },
-                    "endgamePoints": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "shieldOperationalRankingPoint": {
-                        "type": "boolean"
-                    },
-                    "shieldEnergizedRankingPoint": {
-                        "type": "boolean"
-                    },
-                    "tba_shieldEnergizedRankingPointFromFoul": {
-                        "type": "boolean",
-                        "description": "Unofficial TBA-computed value that indicates whether the shieldEnergizedRankingPoint was earned normally or awarded due to a foul."
-                    },
-                    "tba_numRobotsHanging": {
-                        "type": "integer",
-                        "description": "Unofficial TBA-computed value that counts the number of robots who were hanging at the end of the match."
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "rp": {
-                        "type": "integer"
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2022": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2022_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2022_Alliance"
-                    }
-                },
-                "description": "See the 2022 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
-            },
-            "Match_Score_Breakdown_2022_Alliance": {
-                "type": "object",
-                "properties": {
-                    "taxiRobot1": {
-                        "type": "string",
-                        "enum": [
-                            "Yes",
-                            "No"
-                        ]
-                    },
-                    "endgameRobot1": {
-                        "type": "string",
-                        "enum": [
-                            "Traversal",
-                            "High",
-                            "Mid",
-                            "Low",
-                            "None"
-                        ]
-                    },
-                    "taxiRobot2": {
-                        "type": "string",
-                        "enum": [
-                            "Yes",
-                            "No"
-                        ]
-                    },
-                    "endgameRobot2": {
-                        "type": "string",
-                        "enum": [
-                            "Traversal",
-                            "High",
-                            "Mid",
-                            "Low",
-                            "None"
-                        ]
-                    },
-                    "taxiRobot3": {
-                        "type": "string",
-                        "enum": [
-                            "Yes",
-                            "No"
-                        ]
-                    },
-                    "endgameRobot3": {
-                        "type": "string",
-                        "enum": [
-                            "Traversal",
-                            "High",
-                            "Mid",
-                            "Low",
-                            "None"
-                        ]
-                    },
-                    "autoCargoLowerNear": {
-                        "type": "integer"
-                    },
-                    "autoCargoLowerFar": {
-                        "type": "integer"
-                    },
-                    "autoCargoLowerBlue": {
-                        "type": "integer"
-                    },
-                    "autoCargoLowerRed": {
-                        "type": "integer"
-                    },
-                    "autoCargoUpperNear": {
-                        "type": "integer"
-                    },
-                    "autoCargoUpperFar": {
-                        "type": "integer"
-                    },
-                    "autoCargoUpperBlue": {
-                        "type": "integer"
-                    },
-                    "autoCargoUpperRed": {
-                        "type": "integer"
-                    },
-                    "autoCargoTotal": {
-                        "type": "integer"
-                    },
-                    "teleopCargoLowerNear": {
-                        "type": "integer"
-                    },
-                    "teleopCargoLowerFar": {
-                        "type": "integer"
-                    },
-                    "teleopCargoLowerBlue": {
-                        "type": "integer"
-                    },
-                    "teleopCargoLowerRed": {
-                        "type": "integer"
-                    },
-                    "teleopCargoUpperNear": {
-                        "type": "integer"
-                    },
-                    "teleopCargoUpperFar": {
-                        "type": "integer"
-                    },
-                    "teleopCargoUpperBlue": {
-                        "type": "integer"
-                    },
-                    "teleopCargoUpperRed": {
-                        "type": "integer"
-                    },
-                    "teleopCargoTotal": {
-                        "type": "integer"
-                    },
-                    "matchCargoTotal": {
-                        "type": "integer"
-                    },
-                    "autoTaxiPoints": {
-                        "type": "integer"
-                    },
-                    "autoCargoPoints": {
-                        "type": "integer"
-                    },
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "quintetAchieved": {
-                        "type": "boolean"
-                    },
-                    "teleopCargoPoints": {
-                        "type": "integer"
-                    },
-                    "endgamePoints": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "cargoBonusRankingPoint": {
-                        "type": "boolean"
-                    },
-                    "hangarBonusRankingPoint": {
-                        "type": "boolean"
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "rp": {
-                        "type": "integer"
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2023": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2023_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2023_Alliance"
-                    }
-                },
-                "description": "See the 2023 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
-            },
-            "Match_Score_Breakdown_2023_Alliance": {
-                "type": "object",
-                "properties": {
-                    "activationBonusAchieved": {
-                        "type": "boolean"
-                    },
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "autoBridgeState": {
-                        "type": "string",
-                        "enum": [
-                            "NotLevel",
-                            "Level"
-                        ]
-                    },
-                    "autoChargeStationPoints": {
-                        "type": "integer"
-                    },
-                    "autoChargeStationRobot1": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Docked"
-                        ]
-                    },
-                    "autoChargeStationRobot2": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Docked"
-                        ]
-                    },
-                    "autoChargeStationRobot3": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Docked"
-                        ]
-                    },
-                    "autoDocked": {
-                        "type": "boolean"
-                    },
-                    "autoCommunity": {
-                        "type": "object",
-                        "required": [
-                            "B",
-                            "M",
-                            "T"
-                        ],
-                        "properties": {
-                            "B": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "None",
-                                        "Cone",
-                                        "Cube"
-                                    ]
-                                }
-                            },
-                            "M": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "None",
-                                        "Cone",
-                                        "Cube"
-                                    ]
-                                }
-                            },
-                            "T": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "None",
-                                        "Cone",
-                                        "Cube"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "autoGamePieceCount": {
-                        "type": "integer"
-                    },
-                    "autoGamePiecePoints": {
-                        "type": "integer"
-                    },
-                    "autoMobilityPoints": {
-                        "type": "integer"
-                    },
-                    "mobilityRobot1": {
-                        "type": "string",
-                        "enum": [
-                            "Yes",
-                            "No"
-                        ]
-                    },
-                    "mobilityRobot2": {
-                        "type": "string",
-                        "enum": [
-                            "Yes",
-                            "No"
-                        ]
-                    },
-                    "mobilityRobot3": {
-                        "type": "string",
-                        "enum": [
-                            "Yes",
-                            "No"
-                        ]
-                    },
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "coopGamePieceCount": {
-                        "type": "integer"
-                    },
-                    "coopertitionCriteriaMet": {
-                        "type": "boolean"
-                    },
-                    "endGameBridgeState": {
-                        "type": "string",
-                        "enum": [
-                            "NotLevel",
-                            "Level"
-                        ]
-                    },
-                    "endGameChargeStationPoints": {
-                        "type": "integer"
-                    },
-                    "endGameChargeStationRobot1": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Docked",
-                            "Park"
-                        ]
-                    },
-                    "endGameChargeStationRobot2": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Docked",
-                            "Park"
-                        ]
-                    },
-                    "endGameChargeStationRobot3": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Docked",
-                            "Park"
-                        ]
-                    },
-                    "endGameParkPoints": {
-                        "type": "integer"
-                    },
-                    "extraGamePieceCount": {
-                        "type": "integer"
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "linkPoints": {
-                        "type": "integer"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "nodes",
-                                "row"
-                            ],
-                            "properties": {
-                                "nodes": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "enum": [
-                                            "None",
-                                            "Cone",
-                                            "Cube"
-                                        ]
-                                    }
-                                },
-                                "row": {
-                                    "type": "string",
-                                    "enum": [
-                                        "Bottom",
-                                        "Mid",
-                                        "Top"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "sustainabilityBonusAchieved": {
-                        "type": "boolean"
-                    },
-                    "teleopCommunity": {
-                        "type": "object",
-                        "required": [
-                            "B",
-                            "M",
-                            "T"
-                        ],
-                        "properties": {
-                            "B": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "None",
-                                        "Cone",
-                                        "Cube"
-                                    ]
-                                }
-                            },
-                            "M": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "None",
-                                        "Cone",
-                                        "Cube"
-                                    ]
-                                }
-                            },
-                            "T": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "None",
-                                        "Cone",
-                                        "Cube"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "teleopGamePieceCount": {
-                        "type": "integer"
-                    },
-                    "teleopGamePiecePoints": {
-                        "type": "integer"
-                    },
-                    "totalChargeStationPoints": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "rp": {
-                        "type": "integer"
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2024": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2024_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2024_Alliance"
-                    }
-                },
-                "description": "See the 2024 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
-            },
-            "Match_Score_Breakdown_2024_Alliance": {
-                "type": "object",
-                "properties": {
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "autoAmpNoteCount": {
-                        "type": "integer"
-                    },
-                    "autoAmpNotePoints": {
-                        "type": "integer"
-                    },
-                    "autoLeavePoints": {
-                        "type": "integer"
-                    },
-                    "autoLineRobot1": {
-                        "type": "string"
-                    },
-                    "autoLineRobot2": {
-                        "type": "string"
-                    },
-                    "autoLineRobot3": {
-                        "type": "string"
-                    },
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "autoSpeakerNoteCount": {
-                        "type": "integer"
-                    },
-                    "autoSpeakerNotePoints": {
-                        "type": "integer"
-                    },
-                    "autoTotalNotePoints": {
-                        "type": "integer"
-                    },
-                    "coopNotePlayed": {
-                        "type": "boolean"
-                    },
-                    "coopertitionBonusAchieved": {
-                        "type": "boolean"
-                    },
-                    "coopertitionCriteriaMet": {
-                        "type": "boolean"
-                    },
-                    "endGameHarmonyPoints": {
-                        "type": "integer"
-                    },
-                    "endGameNoteInTrapPoints": {
-                        "type": "integer"
-                    },
-                    "endGameOnStagePoints": {
-                        "type": "integer"
-                    },
-                    "endGameParkPoints": {
-                        "type": "integer"
-                    },
-                    "endGameRobot1": {
-                        "type": "string"
-                    },
-                    "endGameRobot2": {
-                        "type": "string"
-                    },
-                    "endGameRobot3": {
-                        "type": "string"
-                    },
-                    "endGameSpotLightBonusPoints": {
-                        "type": "integer"
-                    },
-                    "endGameTotalStagePoints": {
-                        "type": "integer"
-                    },
-                    "ensembleBonusAchieved": {
-                        "type": "boolean"
-                    },
-                    "ensembleBonusOnStageRobotsThreshold": {
-                        "type": "integer"
-                    },
-                    "ensembleBonusStagePointsThreshold": {
-                        "type": "integer"
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "g206Penalty": {
-                        "type": "boolean"
-                    },
-                    "g408Penalty": {
-                        "type": "boolean"
-                    },
-                    "g424Penalty": {
-                        "type": "boolean"
-                    },
-                    "melodyBonusAchieved": {
-                        "type": "boolean"
-                    },
-                    "melodyBonusThreshold": {
-                        "type": "integer"
-                    },
-                    "melodyBonusThresholdCoop": {
-                        "type": "integer"
-                    },
-                    "melodyBonusThresholdNonCoop": {
-                        "type": "integer"
-                    },
-                    "micCenterStage": {
-                        "type": "boolean"
-                    },
-                    "micStageLeft": {
-                        "type": "boolean"
-                    },
-                    "micStageRight": {
-                        "type": "boolean"
-                    },
-                    "rp": {
-                        "type": "integer"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "teleopAmpNoteCount": {
-                        "type": "integer"
-                    },
-                    "teleopAmpNotePoints": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "teleopSpeakerNoteAmplifiedCount": {
-                        "type": "integer"
-                    },
-                    "teleopSpeakerNoteAmplifiedPoints": {
-                        "type": "integer"
-                    },
-                    "teleopSpeakerNoteCount": {
-                        "type": "integer"
-                    },
-                    "teleopSpeakerNotePoints": {
-                        "type": "integer"
-                    },
-                    "teleopTotalNotePoints": {
-                        "type": "integer"
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    },
-                    "trapCenterStage": {
-                        "type": "boolean"
-                    },
-                    "trapStageLeft": {
-                        "type": "boolean"
-                    },
-                    "trapStageRight": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "Match_Score_Breakdown_2025": {
-                "type": "object",
-                "required": [
-                    "blue",
-                    "red"
-                ],
-                "properties": {
-                    "blue": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2025_Alliance"
-                    },
-                    "red": {
-                        "$ref": "#/components/schemas/Match_Score_Breakdown_2025_Alliance"
-                    }
-                },
-                "description": "See the 2025 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
-            },
-            "Match_Score_Breakdown_2025_Alliance": {
-                "type": "object",
-                "properties": {
-                    "adjustPoints": {
-                        "type": "integer"
-                    },
-                    "algaePoints": {
-                        "type": "integer"
-                    },
-                    "autoBonusAchieved": {
-                        "type": "boolean"
-                    },
-                    "autoCoralCount": {
-                        "type": "integer"
-                    },
-                    "autoCoralPoints": {
-                        "type": "integer"
-                    },
-                    "autoLineRobot1": {
-                        "type": "string",
-                        "enum": [
-                            "No",
-                            "Yes"
-                        ]
-                    },
-                    "autoLineRobot2": {
-                        "type": "string",
-                        "enum": [
-                            "No",
-                            "Yes"
-                        ]
-                    },
-                    "autoLineRobot3": {
-                        "type": "string",
-                        "enum": [
-                            "No",
-                            "Yes"
-                        ]
-                    },
-                    "autoMobilityPoints": {
-                        "type": "integer"
-                    },
-                    "autoPoints": {
-                        "type": "integer"
-                    },
-                    "autoReef": {
-                        "type": "object",
-                        "required": [
-                            "topRow",
-                            "midRow",
-                            "botRow",
-                            "trough"
-                        ],
-                        "properties": {
-                            "topRow": {
-                                "type": "object",
-                                "required": [
-                                    "nodeA",
-                                    "nodeB",
-                                    "nodeC",
-                                    "nodeD",
-                                    "nodeE",
-                                    "nodeF",
-                                    "nodeG",
-                                    "nodeH",
-                                    "nodeI",
-                                    "nodeJ",
-                                    "nodeK",
-                                    "nodeL"
-                                ],
-                                "properties": {
-                                    "nodeA": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeB": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeC": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeD": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeE": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeF": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeG": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeH": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeI": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeJ": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeK": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeL": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            },
-                            "midRow": {
-                                "type": "object",
-                                "required": [
-                                    "nodeA",
-                                    "nodeB",
-                                    "nodeC",
-                                    "nodeD",
-                                    "nodeE",
-                                    "nodeF",
-                                    "nodeG",
-                                    "nodeH",
-                                    "nodeI",
-                                    "nodeJ",
-                                    "nodeK",
-                                    "nodeL"
-                                ],
-                                "properties": {
-                                    "nodeA": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeB": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeC": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeD": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeE": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeF": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeG": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeH": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeI": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeJ": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeK": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeL": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            },
-                            "botRow": {
-                                "type": "object",
-                                "required": [
-                                    "nodeA",
-                                    "nodeB",
-                                    "nodeC",
-                                    "nodeD",
-                                    "nodeE",
-                                    "nodeF",
-                                    "nodeG",
-                                    "nodeH",
-                                    "nodeI",
-                                    "nodeJ",
-                                    "nodeK",
-                                    "nodeL"
-                                ],
-                                "properties": {
-                                    "nodeA": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeB": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeC": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeD": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeE": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeF": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeG": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeH": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeI": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeJ": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeK": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeL": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            },
-                            "trough": {
-                                "type": "integer"
-                            },
-                            "tba_botRowCount": {
-                                "type": "integer",
-                                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the botRow object."
-                            },
-                            "tba_midRowCount": {
-                                "type": "integer",
-                                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the midRow object."
-                            },
-                            "tba_topRowCount": {
-                                "type": "integer",
-                                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the topRow object."
-                            }
-                        }
-                    },
-                    "bargeBonusAchieved": {
-                        "type": "boolean"
-                    },
-                    "coopertitionCriteriaMet": {
-                        "type": "boolean"
-                    },
-                    "coralBonusAchieved": {
-                        "type": "boolean"
-                    },
-                    "endGameBargePoints": {
-                        "type": "integer"
-                    },
-                    "endGameRobot1": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Parked",
-                            "ShallowCage",
-                            "DeepCage"
-                        ]
-                    },
-                    "endGameRobot2": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Parked",
-                            "ShallowCage",
-                            "DeepCage"
-                        ]
-                    },
-                    "endGameRobot3": {
-                        "type": "string",
-                        "enum": [
-                            "None",
-                            "Parked",
-                            "ShallowCage",
-                            "DeepCage"
-                        ]
-                    },
-                    "foulCount": {
-                        "type": "integer"
-                    },
-                    "foulPoints": {
-                        "type": "integer"
-                    },
-                    "g206Penalty": {
-                        "type": "boolean"
-                    },
-                    "g410Penalty": {
-                        "type": "boolean"
-                    },
-                    "g418Penalty": {
-                        "type": "boolean"
-                    },
-                    "g428Penalty": {
-                        "type": "boolean"
-                    },
-                    "netAlgaeCount": {
-                        "type": "integer"
-                    },
-                    "rp": {
-                        "type": "integer"
-                    },
-                    "techFoulCount": {
-                        "type": "integer"
-                    },
-                    "teleopCoralCount": {
-                        "type": "integer"
-                    },
-                    "teleopCoralPoints": {
-                        "type": "integer"
-                    },
-                    "teleopPoints": {
-                        "type": "integer"
-                    },
-                    "teleopReef": {
-                        "type": "object",
-                        "required": [
-                            "topRow",
-                            "midRow",
-                            "botRow",
-                            "trough"
-                        ],
-                        "properties": {
-                            "topRow": {
-                                "type": "object",
-                                "required": [
-                                    "nodeA",
-                                    "nodeB",
-                                    "nodeC",
-                                    "nodeD",
-                                    "nodeE",
-                                    "nodeF",
-                                    "nodeG",
-                                    "nodeH",
-                                    "nodeI",
-                                    "nodeJ",
-                                    "nodeK",
-                                    "nodeL"
-                                ],
-                                "properties": {
-                                    "nodeA": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeB": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeC": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeD": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeE": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeF": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeG": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeH": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeI": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeJ": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeK": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeL": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            },
-                            "midRow": {
-                                "type": "object",
-                                "required": [
-                                    "nodeA",
-                                    "nodeB",
-                                    "nodeC",
-                                    "nodeD",
-                                    "nodeE",
-                                    "nodeF",
-                                    "nodeG",
-                                    "nodeH",
-                                    "nodeI",
-                                    "nodeJ",
-                                    "nodeK",
-                                    "nodeL"
-                                ],
-                                "properties": {
-                                    "nodeA": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeB": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeC": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeD": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeE": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeF": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeG": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeH": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeI": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeJ": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeK": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeL": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            },
-                            "botRow": {
-                                "type": "object",
-                                "required": [
-                                    "nodeA",
-                                    "nodeB",
-                                    "nodeC",
-                                    "nodeD",
-                                    "nodeE",
-                                    "nodeF",
-                                    "nodeG",
-                                    "nodeH",
-                                    "nodeI",
-                                    "nodeJ",
-                                    "nodeK",
-                                    "nodeL"
-                                ],
-                                "properties": {
-                                    "nodeA": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeB": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeC": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeD": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeE": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeF": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeG": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeH": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeI": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeJ": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeK": {
-                                        "type": "boolean"
-                                    },
-                                    "nodeL": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            },
-                            "trough": {
-                                "type": "integer"
-                            },
-                            "tba_botRowCount": {
-                                "type": "integer",
-                                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the botRow object."
-                            },
-                            "tba_midRowCount": {
-                                "type": "integer",
-                                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the midRow object."
-                            },
-                            "tba_topRowCount": {
-                                "type": "integer",
-                                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the topRow object."
-                            }
-                        }
-                    },
-                    "totalPoints": {
-                        "type": "integer"
-                    },
-                    "wallAlgaeCount": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "Media": {
-                "required": [
-                    "type",
-                    "foreign_key",
-                    "team_keys"
-                ],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "String type of the media element.",
-                        "enum": [
-                            "youtube",
-                            "cdphotothread",
-                            "imgur",
-                            "facebook-profile",
-                            "youtube-channel",
-                            "twitter-profile",
-                            "github-profile",
-                            "instagram-profile",
-                            "periscope-profile",
-                            "gitlab-profile",
-                            "grabcad",
-                            "instagram-image",
-                            "external-link",
-                            "avatar",
-                            "onshape"
-                        ]
-                    },
-                    "foreign_key": {
-                        "type": "string",
-                        "description": "The key used to identify this media on the media site."
-                    },
-                    "details": {
-                        "type": "object",
-                        "additionalProperties": true,
-                        "description": "If required, a JSON dict of additional media information."
-                    },
-                    "preferred": {
-                        "type": "boolean",
-                        "description": "True if the media is of high quality."
-                    },
-                    "team_keys": {
-                        "type": "array",
-                        "description": "List of teams that this media belongs to. Most likely length 1.",
-                        "items": {
-                            "type": "string",
-                            "description": "Team key."
-                        }
-                    },
-                    "direct_url": {
-                        "type": "string",
-                        "description": "Direct URL to the media."
-                    },
-                    "view_url": {
-                        "type": "string",
-                        "description": "The URL that leads to the full web page for the media, if one exists."
-                    }
-                },
-                "description": "The `Media` object contains a reference for most any media associated with a team or event on TBA."
-            },
-            "Elimination_Alliance": {
-                "type": "object",
-                "required": [
-                    "picks",
-                    "declines"
-                ],
-                "properties": {
-                    "name": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Alliance name, may be null."
-                    },
-                    "backup": {
-                        "type": [
-                            "object",
-                            "null"
-                        ],
-                        "required": [
-                            "in",
-                            "out"
-                        ],
-                        "properties": {
-                            "in": {
-                                "type": "string",
-                                "description": "Team key that was called in as the backup."
-                            },
-                            "out": {
-                                "type": "string",
-                                "description": "Team key that was replaced by the backup team."
-                            }
-                        },
-                        "description": "Backup team called in, may be null."
-                    },
-                    "declines": {
-                        "type": "array",
-                        "description": "List of teams that declined the alliance.",
-                        "items": {
-                            "type": "string",
-                            "description": "Team key that declined the alliance."
-                        }
-                    },
-                    "picks": {
-                        "type": "array",
-                        "description": "List of team keys picked for the alliance. First pick is captain.",
-                        "items": {
-                            "type": "string",
-                            "description": "Team key picked for the alliance."
-                        }
-                    },
-                    "status": {
-                        "type": "object",
-                        "properties": {
-                            "playoff_average": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "level": {
-                                "type": "string"
-                            },
-                            "record": {
-                                "type": [
-                                    "object",
-                                    "null"
-                                ],
-                                "$ref": "#/components/schemas/WLT_Record"
-                            },
-                            "current_level_record": {
-                                "type": [
-                                    "object",
-                                    "null"
-                                ],
-                                "$ref": "#/components/schemas/WLT_Record"
-                            },
-                            "status": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "Award": {
-                "required": [
-                    "award_type",
-                    "event_key",
-                    "name",
-                    "recipient_list",
-                    "year"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "The name of the award as provided by FIRST. May vary for the same award type."
-                    },
-                    "award_type": {
-                        "type": "integer",
-                        "description": "Type of award given. See https://github.com/the-blue-alliance/the-blue-alliance/blob/master/consts/award_type.py#L6"
-                    },
-                    "event_key": {
-                        "type": "string",
-                        "description": "The event_key of the event the award was won at."
-                    },
-                    "recipient_list": {
-                        "type": "array",
-                        "description": "A list of recipients of the award at the event. May have either a team_key or an awardee, both, or neither (in the case the award wasn't awarded at the event).",
-                        "items": {
-                            "$ref": "#/components/schemas/Award_Recipient"
-                        }
-                    },
-                    "year": {
-                        "type": "integer",
-                        "description": "The year this award was won."
-                    }
-                }
-            },
-            "Award_Recipient": {
-                "type": "object",
-                "required": [
-                    "team_key",
-                    "awardee"
-                ],
-                "properties": {
-                    "team_key": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "The TBA team key for the team that was given the award. May be null."
-                    },
-                    "awardee": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "The name of the individual given the award. May be null."
-                    }
-                },
-                "description": "An `Award_Recipient` object represents the team and/or person who received an award at an event."
-            },
-            "District": {
-                "required": [
-                    "abbreviation",
-                    "display_name",
-                    "key",
-                    "year"
-                ],
-                "type": "object",
-                "properties": {
-                    "abbreviation": {
-                        "type": "string",
-                        "description": "The short identifier for the district."
-                    },
-                    "display_name": {
-                        "type": "string",
-                        "description": "The long name for the district."
-                    },
-                    "key": {
-                        "type": "string",
-                        "description": "Key for this district, e.g. `2016ne`."
-                    },
-                    "year": {
-                        "type": "integer",
-                        "description": "Year this district participated."
-                    }
-                }
-            },
-            "District_Ranking": {
-                "required": [
-                    "point_total",
-                    "rank",
-                    "team_key"
-                ],
-                "type": "object",
-                "properties": {
-                    "team_key": {
-                        "type": "string",
-                        "description": "TBA team key for the team."
-                    },
-                    "rank": {
-                        "type": "integer",
-                        "description": "Numerical rank of the team, 1 being top rank."
-                    },
-                    "rookie_bonus": {
-                        "type": "integer",
-                        "description": "Any points added to a team as a result of the rookie bonus."
-                    },
-                    "point_total": {
-                        "type": "integer",
-                        "description": "Total district points for the team."
-                    },
-                    "event_points": {
-                        "type": "array",
-                        "description": "List of events that contributed to the point total for the team.",
-                        "items": {
-                            "required": [
-                                "alliance_points",
-                                "award_points",
-                                "district_cmp",
-                                "elim_points",
-                                "event_key",
-                                "qual_points",
-                                "total"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "district_cmp": {
-                                    "type": "boolean",
-                                    "description": "`true` if this event is a District Championship event."
-                                },
-                                "total": {
-                                    "type": "integer",
-                                    "description": "Total points awarded at this event."
-                                },
-                                "alliance_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for alliance selection."
-                                },
-                                "elim_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for elimination match performance."
-                                },
-                                "award_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for event awards."
-                                },
-                                "event_key": {
-                                    "type": "string",
-                                    "description": "TBA Event key for this event."
-                                },
-                                "qual_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for qualification match performance."
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Rank of a team in a district."
-            },
-            "District_Advancement": {
-                "required": [
-                    "cmp",
-                    "dcmp"
-                ],
-                "type": "object",
-                "properties": {
-                    "dcmp": {
-                        "type": "boolean",
-                        "description": "Whether or not the team qualified for their District Championship"
-                    },
-                    "cmp": {
-                        "type": "boolean",
-                        "description": "Whether or not the team qualified for the FIRST Championship"
-                    }
-                },
-                "description": "Advancement status of a team in a district."
-            },
-            "Regional_Advancement": {
-                "required": [
-                    "cmp",
-                    "cmp_status"
-                ],
-                "type": "object",
-                "properties": {
-                    "cmp": {
-                        "type": "boolean",
-                        "description": "Whether or not the team qualified for Championship."
-                    },
-                    "cmp_status": {
-                        "type": "string",
-                        "enum": [
-                            "NotInvited",
-                            "PreQualified",
-                            "EventQualified",
-                            "PoolQualified",
-                            "Declined"
-                        ]
-                    },
-                    "qualifying_event": {
-                        "type": "string",
-                        "description": "The event key at which the team qualified"
-                    },
-                    "qualifying_award_name": {
-                        "type": "string",
-                        "description": "The name of the award which qualified the team"
-                    },
-                    "qualifying_pool_week": {
-                        "type": "integer",
-                        "description": "Which week number's regional pool invitation the team got"
-                    }
-                },
-                "description": "Information about how a regional team qualified for FIRST Championship."
-            },
-            "Regional_Ranking": {
-                "required": [
-                    "point_total",
-                    "rank",
-                    "team_key"
-                ],
-                "type": "object",
-                "properties": {
-                    "team_key": {
-                        "type": "string",
-                        "description": "TBA team key for the team."
-                    },
-                    "rank": {
-                        "type": "integer",
-                        "description": "Numerical rank of the team, 1 being top rank."
-                    },
-                    "rookie_bonus": {
-                        "type": "integer",
-                        "description": "Any points added to a team as a result of the rookie bonus."
-                    },
-                    "single_event_bonus": {
-                        "type": "integer",
-                        "description": "Additional points awarded in lieu of a second event, based on first event performance"
-                    },
-                    "point_total": {
-                        "type": "integer",
-                        "description": "Total district points for the team."
-                    },
-                    "event_points": {
-                        "type": "array",
-                        "description": "List of events that contributed to the point total for the team.",
-                        "items": {
-                            "required": [
-                                "alliance_points",
-                                "award_points",
-                                "elim_points",
-                                "event_key",
-                                "qual_points",
-                                "total"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "total": {
-                                    "type": "integer",
-                                    "description": "Total points awarded at this event."
-                                },
-                                "alliance_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for alliance selection."
-                                },
-                                "elim_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for elimination match performance."
-                                },
-                                "award_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for event awards."
-                                },
-                                "event_key": {
-                                    "type": "string",
-                                    "description": "TBA Event key for this event."
-                                },
-                                "qual_points": {
-                                    "type": "integer",
-                                    "description": "Points awarded for qualification match performance."
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Rank of a team in the regional pool."
-            },
-            "WLT_Record": {
-                "required": [
-                    "losses",
-                    "ties",
-                    "wins"
-                ],
-                "type": "object",
-                "properties": {
-                    "losses": {
-                        "type": "integer",
-                        "description": "Number of losses."
-                    },
-                    "wins": {
-                        "type": "integer",
-                        "description": "Number of wins."
-                    },
-                    "ties": {
-                        "type": "integer",
-                        "description": "Number of ties."
-                    }
-                },
-                "description": "A Win-Loss-Tie record for a team, or an alliance."
-            },
-            "Webcast": {
-                "required": [
-                    "channel",
-                    "type"
-                ],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Type of webcast, typically descriptive of the streaming provider.",
-                        "enum": [
-                            "youtube",
-                            "twitch",
-                            "ustream",
-                            "iframe",
-                            "html5",
-                            "rtmp",
-                            "livestream",
-                            "direct_link",
-                            "mms",
-                            "justin",
-                            "stemtv",
-                            "dacast"
-                        ]
-                    },
-                    "channel": {
-                        "type": "string",
-                        "description": "Type specific channel information. May be the YouTube stream, or Twitch channel name. In the case of iframe types, contains HTML to embed the stream in an HTML iframe."
-                    },
-                    "date": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "The date for the webcast in `yyyy-mm-dd` format. May be null."
-                    },
-                    "file": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "File identification as may be required for some types. May be null."
-                    }
-                }
-            },
-            "LeaderboardInsight": {
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "type": "object",
-                        "properties": {
-                            "rankings": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "value": {
-                                            "type": "number",
-                                            "description": "Value of the insight that the corresponding team/event/matches have, e.g. number of blue banners, or number of matches played."
-                                        },
-                                        "keys": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "description": "Team/Event/Match keys that have the corresponding value."
-                                        }
-                                    },
-                                    "required": [
-                                        "value",
-                                        "keys"
-                                    ]
-                                }
-                            },
-                            "key_type": {
-                                "type": "string",
-                                "enum": [
-                                    "team",
-                                    "event",
-                                    "match"
-                                ],
-                                "description": "What type of key is used in the rankings; either 'team', 'event', or 'match'."
-                            }
-                        },
-                        "required": [
-                            "rankings",
-                            "key_type"
-                        ]
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Name of the insight."
-                    },
-                    "year": {
-                        "type": "integer",
-                        "description": "Year the insight was measured in (year=0 for overall insights)."
-                    }
-                },
-                "required": [
-                    "data",
-                    "name",
-                    "year"
-                ]
-            },
-            "NotablesInsight": {
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "type": "object",
-                        "properties": {
-                            "entries": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "context": {
-                                            "type": "array",
-                                            "description": "A list of events this team achieved the notable at. This type may change over time.",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "team_key": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "context",
-                                        "team_key"
-                                    ]
-                                }
-                            }
-                        },
-                        "required": [
-                            "entries"
-                        ]
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "year": {
-                        "type": "integer"
-                    }
-                },
-                "required": [
-                    "data",
-                    "name",
-                    "year"
-                ]
-            },
-            "History": {
-                "type": "object",
-                "properties": {
-                    "events": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Event"
-                        }
-                    },
-                    "awards": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Award"
-                        }
-                    }
-                },
-                "required": [
-                    "events",
-                    "awards"
-                ]
-            },
-            "SearchIndex": {
-                "type": "object",
-                "properties": {
-                    "teams": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "key": {
-                                    "type": "string"
-                                },
-                                "nickname": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "key",
-                                "nickname"
-                            ]
-                        }
-                    },
-                    "events": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "key": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "key",
-                                "name"
-                            ]
-                        }
-                    }
-                },
-                "required": [
-                    "teams",
-                    "events"
-                ]
+              },
+              "required": [
+                "district_seasons",
+                "total_district_points",
+                "total_pre_dcmp_district_points",
+                "district_event_wins",
+                "dcmp_wins",
+                "team_awards",
+                "individual_awards",
+                "quals_record",
+                "elims_record",
+                "in_district_extra_play_count",
+                "total_matches_played",
+                "dcmp_appearances",
+                "cmp_appearances"
+              ]
             }
+          }
         },
-        "responses": {
-            "Unauthorized": {
-                "description": "Authorization information is missing or invalid.",
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "type": "object",
-                            "required": [
-                                "Error"
-                            ],
-                            "properties": {
-                                "Error": {
-                                    "type": "string",
-                                    "description": "Authorization error description."
-                                }
-                            }
-                        }
-                    }
+        "required": [
+          "district_data"
+        ]
+      },
+      "District_Ranking": {
+        "required": [
+          "event_points",
+          "point_total",
+          "rank",
+          "rookie_bonus",
+          "team_key"
+        ],
+        "type": "object",
+        "properties": {
+          "team_key": {
+            "type": "string",
+            "description": "TBA team key for the team."
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Numerical rank of the team, 1 being top rank."
+          },
+          "rookie_bonus": {
+            "type": "integer",
+            "description": "Any points added to a team as a result of the rookie bonus."
+          },
+          "point_total": {
+            "type": "integer",
+            "description": "Total district points for the team."
+          },
+          "event_points": {
+            "type": "array",
+            "description": "List of events that contributed to the point total for the team.",
+            "items": {
+              "required": [
+                "alliance_points",
+                "award_points",
+                "district_cmp",
+                "elim_points",
+                "event_key",
+                "qual_points",
+                "total"
+              ],
+              "type": "object",
+              "properties": {
+                "district_cmp": {
+                  "type": "boolean",
+                  "description": "`true` if this event is a District Championship event."
+                },
+                "total": {
+                  "type": "integer",
+                  "description": "Total points awarded at this event."
+                },
+                "alliance_points": {
+                  "type": "integer",
+                  "description": "Points awarded for alliance selection."
+                },
+                "elim_points": {
+                  "type": "integer",
+                  "description": "Points awarded for elimination match performance."
+                },
+                "award_points": {
+                  "type": "integer",
+                  "description": "Points awarded for event awards."
+                },
+                "event_key": {
+                  "type": "string",
+                  "description": "TBA Event key for this event."
+                },
+                "qual_points": {
+                  "type": "integer",
+                  "description": "Points awarded for qualification match performance."
                 }
-            },
-            "NotFound": {
-                "description": "Not Found"
-            },
-            "NotModified": {
-                "description": "Not Modified - Use Local Cached Value"
+              }
             }
+          },
+          "adjustments": {
+            "type": "integer",
+            "description": "Any points adjustments applied to the team."
+          },
+          "other_bonus": {
+            "type": "integer",
+            "description": "Any other bonus points awarded to the team."
+          }
         },
-        "parameters": {
-            "year": {
-                "name": "year",
-                "in": "path",
-                "description": "Competition Year (or Season). Must be 4 digits.",
-                "required": true,
-                "schema": {
-                    "type": "integer"
-                }
+        "description": "Rank of a team in a district."
+      },
+      "Double_Elim_Round": {
+        "type": "string",
+        "enum": [
+          "Finals",
+          "Round 1",
+          "Round 2",
+          "Round 3",
+          "Round 4",
+          "Round 5"
+        ],
+        "description": "Double elimination round, if applicable."
+      },
+      "Elimination_Alliance": {
+        "type": "object",
+        "required": [
+          "picks",
+          "declines"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Alliance name."
+          },
+          "backup": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "in",
+              "out"
+            ],
+            "properties": {
+              "in": {
+                "type": "string",
+                "description": "Team key that was called in as the backup."
+              },
+              "out": {
+                "type": "string",
+                "description": "Team key that was replaced by the backup team."
+              }
             },
-            "media_tag": {
-                "name": "media_tag",
-                "in": "path",
-                "description": "Media Tag which describes the Media.",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "If-None-Match": {
-                "name": "If-None-Match",
-                "in": "header",
-                "description": "Value of the `ETag` header in the most recently cached response by the client.",
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "page_num": {
-                "name": "page_num",
-                "in": "path",
-                "description": "Page number of results to return, zero-indexed",
-                "required": true,
-                "schema": {
-                    "type": "integer"
-                }
-            },
-            "match_key": {
-                "name": "match_key",
-                "in": "path",
-                "description": "TBA Match Key, eg `2016nytr_qm1`",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "district_key": {
-                "name": "district_key",
-                "in": "path",
-                "description": "TBA District Key, eg `2016fim`",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "team_key": {
-                "name": "team_key",
-                "in": "path",
-                "description": "TBA Team Key, eg `frc254`",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "event_key": {
-                "name": "event_key",
-                "in": "path",
-                "description": "TBA Event Key, eg `2016nytr`",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "district_abbreviation": {
-                "name": "district_abbreviation",
-                "in": "path",
-                "description": "District abbreviation, eg `ne` or `fim`",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
+            "description": "Backup team called in, may be null."
+          },
+          "declines": {
+            "type": "array",
+            "description": "List of teams that declined the alliance.",
+            "items": {
+              "type": "string",
+              "description": "Team key that declined the alliance."
             }
-        },
-        "securitySchemes": {
-            "apiKey": {
-                "type": "apiKey",
-                "description": "Your TBA v3 API Key can be obtained from your [Account Page](/account) on the TBA website.",
-                "name": "X-TBA-Auth-Key",
-                "in": "header"
+          },
+          "picks": {
+            "type": "array",
+            "description": "List of team keys picked for the alliance. First pick is captain.",
+            "items": {
+              "type": "string",
+              "description": "Team key picked for the alliance."
             }
+          },
+          "status": {
+            "type": "object",
+            "required": [
+              "level",
+              "playoff_type",
+              "status"
+            ],
+            "properties": {
+              "playoff_average": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "format": "double",
+                "description": "Average match score during playoffs. Year specific. May be null."
+              },
+              "playoff_type": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "format": "int64",
+                "description": "Playoff type, may be null."
+              },
+              "level": {
+                "$ref": "#/components/schemas/Comp_Level",
+                "description": "Match level, qm/ef/qf/sf/f."
+              },
+              "record": {
+                "description": "W-L-T record for the alliance, may be null.",
+                "$ref": "#/components/schemas/WLT_Record"
+              },
+              "current_level_record": {
+                "description": "W-L-T record for the alliance at the current level, may be null.",
+                "$ref": "#/components/schemas/WLT_Record"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "eliminated",
+                  "playing",
+                  "won"
+                ],
+                "description": "Status of the alliance."
+              },
+              "advanced_to_round_robin_finals": {
+                "type": "boolean",
+                "description": "Whether the alliance advanced to round robin finals."
+              },
+              "double_elim_round": {
+                "$ref": "#/components/schemas/Double_Elim_Round"
+              },
+              "round_robin_rank": {
+                "type": "integer",
+                "description": "Rank in round robin play."
+              }
+            }
+          }
         }
+      },
+      "EndGameChargeStationRobot_2023": {
+        "type": "string",
+        "enum": [
+          "Docked",
+          "None",
+          "Park",
+          "Parked"
+        ]
+      },
+      "EndGameRobot_2024": {
+        "type": "string",
+        "enum": [
+          "CenterStage",
+          "None",
+          "Parked",
+          "StageLeft",
+          "StageRight"
+        ]
+      },
+      "EndGameRobot_2025": {
+        "type": "string",
+        "enum": [
+          "DeepCage",
+          "None",
+          "Parked",
+          "ShallowCage"
+        ]
+      },
+      "TowerRobot_2026": {
+        "type": "string",
+        "enum": [
+          "Level1",
+          "Level2",
+          "Level3",
+          "None"
+        ]
+      },
+      "HubScore_2026": {
+        "type": "object",
+        "required": [
+          "autoCount",
+          "autoPoints",
+          "endgameCount",
+          "endgamePoints",
+          "shift1Count",
+          "shift1Points",
+          "shift2Count",
+          "shift2Points",
+          "shift3Count",
+          "shift3Points",
+          "shift4Count",
+          "shift4Points",
+          "teleopCount",
+          "teleopPoints",
+          "totalCount",
+          "totalPoints",
+          "transitionCount",
+          "transitionPoints"
+        ],
+        "properties": {
+          "autoCount": {
+            "type": "integer"
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "endgameCount": {
+            "type": "integer"
+          },
+          "endgamePoints": {
+            "type": "integer"
+          },
+          "shift1Count": {
+            "type": "integer"
+          },
+          "shift1Points": {
+            "type": "integer"
+          },
+          "shift2Count": {
+            "type": "integer"
+          },
+          "shift2Points": {
+            "type": "integer"
+          },
+          "shift3Count": {
+            "type": "integer"
+          },
+          "shift3Points": {
+            "type": "integer"
+          },
+          "shift4Count": {
+            "type": "integer"
+          },
+          "shift4Points": {
+            "type": "integer"
+          },
+          "teleopCount": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "totalCount": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          },
+          "transitionCount": {
+            "type": "integer"
+          },
+          "transitionPoints": {
+            "type": "integer"
+          }
+        }
+      },
+      "EndgameRobot_2018": {
+        "type": "string",
+        "enum": [
+          "Climbing",
+          "Levitate",
+          "None",
+          "Parking",
+          "Unknown"
+        ]
+      },
+      "EndgameRobot_2019": {
+        "type": "string",
+        "enum": [
+          "HabLevel1",
+          "HabLevel2",
+          "HabLevel3",
+          "None",
+          "Unknown"
+        ]
+      },
+      "EndgameRobot_2020": {
+        "type": "string",
+        "enum": [
+          "Hang",
+          "None",
+          "Park"
+        ]
+      },
+      "EndgameRobot_2022": {
+        "type": "string",
+        "enum": [
+          "High",
+          "Low",
+          "Mid",
+          "None",
+          "Traversal"
+        ]
+      },
+      "EndgameRungIsLevel_2020": {
+        "type": "string",
+        "enum": [
+          "IsLevel",
+          "NotLevel"
+        ]
+      },
+      "Event": {
+        "required": [
+          "key",
+          "name",
+          "event_code",
+          "event_type",
+          "city",
+          "state_prov",
+          "country",
+          "start_date",
+          "end_date",
+          "year",
+          "short_name",
+          "event_type_string",
+          "week",
+          "address",
+          "postal_code",
+          "gmaps_place_id",
+          "gmaps_url",
+          "lat",
+          "lng",
+          "location_name",
+          "timezone",
+          "website",
+          "first_event_id",
+          "first_event_code",
+          "webcasts",
+          "division_keys",
+          "parent_event_key",
+          "playoff_type",
+          "playoff_type_string",
+          "remap_teams"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "TBA event key with the format yyyy[EVENT_CODE], where yyyy is the year, and EVENT_CODE is the event code of the event."
+          },
+          "name": {
+            "type": "string",
+            "description": "Official name of event on record either provided by FIRST or organizers of offseason event."
+          },
+          "event_code": {
+            "type": "string",
+            "description": "Event short code, as provided by FIRST."
+          },
+          "event_type": {
+            "type": "integer",
+            "description": "Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/event_type.py#L8"
+          },
+          "district": {
+            "$ref": "#/components/schemas/District"
+          },
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "City, town, village, etc. the event is located in."
+          },
+          "state_prov": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "State or Province the event is located in."
+          },
+          "country": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Country the event is located in."
+          },
+          "start_date": {
+            "type": "string",
+            "description": "Event start date in `yyyy-mm-dd` format.",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "Event end date in `yyyy-mm-dd` format.",
+            "format": "date"
+          },
+          "year": {
+            "type": "integer",
+            "description": "Year the event data is for."
+          },
+          "short_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Same as `name` but doesn't include event specifiers, such as 'Regional' or 'District'. May be null."
+          },
+          "event_type_string": {
+            "type": "string",
+            "description": "Event Type, eg Regional, District, or Offseason."
+          },
+          "week": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Week of the event relative to the first official season event, zero-indexed. Only valid for Regionals, Districts, and District Championships. Null otherwise. (Eg. A season with a week 0 'preseason' event does not count, and week 1 events will show 0 here. Seasons with a week 0.5 regional event will show week 0 for those event(s) and week 1 for week 1 events and so on.)"
+          },
+          "address": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Address of the event's venue, if available."
+          },
+          "postal_code": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Postal code from the event address."
+          },
+          "gmaps_place_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Google Maps Place ID for the event address. Will be NULL, for future development."
+          },
+          "gmaps_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Link to address location on Google Maps. Will be NULL, for future development.",
+            "format": "url"
+          },
+          "lat": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Latitude for the event address. Will be NULL, for future development.",
+            "format": "double"
+          },
+          "lng": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Longitude for the event address. Will be NULL, for future development.",
+            "format": "double"
+          },
+          "location_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Name of the location at the address for the event, eg. Blue Alliance High School."
+          },
+          "timezone": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "IANA Timezone identifier."
+          },
+          "website": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The event's website, if any."
+          },
+          "first_event_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The FIRST internal Event ID, used to link to the event on the FRC webpage."
+          },
+          "first_event_code": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Public facing event code used by FIRST (on frc-events.firstinspires.org, for example)"
+          },
+          "webcasts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Webcast"
+            }
+          },
+          "division_keys": {
+            "type": "array",
+            "description": "An array of event keys for the divisions at this event.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "parent_event_key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The TBA Event key that represents the event's parent. Used to link back to the event from a division event. It is also the inverse relation of `divison_keys`."
+          },
+          "playoff_type": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Playoff Type, as defined under `PlayoffType`: https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/playoff_type.py#L37, or null."
+          },
+          "playoff_type_string": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "String representation of the `playoff_type`, or null."
+          },
+          "remap_teams": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Map of temporary \"off-season demo\" team numbers to pre-rookie and B teams. Both keys and values are team keys in the format 'frc####'. Key is the old team key ('frc' + numeric only), value is the new team key ('frc' + numeric + may include a letter suffix).",
+            "additionalProperties": {
+              "type": "string",
+              "description": "Team key in the format 'frc####'"
+            }
+          }
+        }
+      },
+      "Event_COPRs": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "A key-value pair with team key (eg `frc254`) as key and CCWM as value."
+        },
+        "description": "Component OPRs for teams at the event."
+      },
+      "Event_District_Points": {
+        "required": [
+          "points"
+        ],
+        "type": "object",
+        "properties": {
+          "points": {
+            "type": "object",
+            "additionalProperties": {
+              "required": [
+                "alliance_points",
+                "award_points",
+                "elim_points",
+                "qual_points",
+                "total"
+              ],
+              "type": "object",
+              "properties": {
+                "total": {
+                  "type": "integer",
+                  "description": "Total points awarded at this event."
+                },
+                "alliance_points": {
+                  "type": "integer",
+                  "description": "Points awarded for alliance selection"
+                },
+                "elim_points": {
+                  "type": "integer",
+                  "description": "Points awarded for elimination match performance."
+                },
+                "award_points": {
+                  "type": "integer",
+                  "description": "Points awarded for event awards."
+                },
+                "qual_points": {
+                  "type": "integer",
+                  "description": "Points awarded for qualification match performance."
+                }
+              }
+            },
+            "description": "Points gained for each team at the event. Stored as a key-value pair with the team key as the key, and an object describing the points as its value."
+          },
+          "tiebreakers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "highest_match_scores": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "qual_wins": {
+                  "type": "integer"
+                }
+              }
+            },
+            "description": "Tiebreaker values for each team at the event. Stored as a key-value pair with the team key as the key, and an object describing the tiebreaker elements as its value."
+          }
+        }
+      },
+      "Event_Insights": {
+        "type": "object",
+        "properties": {
+          "qual": {
+            "type": "object",
+            "properties": {},
+            "description": "Inights for the qualification round of an event"
+          },
+          "playoff": {
+            "type": "object",
+            "properties": {},
+            "description": "Insights for the playoff round of an event"
+          }
+        },
+        "description": "A year-specific event insight object expressed as a JSON string, separated in to `qual` and `playoff` fields. See also Event_Insights_2016, Event_Insights_2017, etc."
+      },
+      "Event_Insights_2016": {
+        "required": [
+          "A_ChevalDeFrise",
+          "A_Portcullis",
+          "B_Moat",
+          "B_Ramparts",
+          "C_Drawbridge",
+          "C_SallyPort",
+          "D_RockWall",
+          "D_RoughTerrain",
+          "LowBar",
+          "average_auto_score",
+          "average_boulder_score",
+          "average_crossing_score",
+          "average_foul_score",
+          "average_high_goals",
+          "average_low_goals",
+          "average_score",
+          "average_tower_score",
+          "average_win_margin",
+          "average_win_score",
+          "breaches",
+          "captures",
+          "challenges",
+          "high_score",
+          "scales"
+        ],
+        "type": "object",
+        "properties": {
+          "LowBar": {
+            "type": "array",
+            "description": "For the Low Bar - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "A_ChevalDeFrise": {
+            "type": "array",
+            "description": "For the Cheval De Frise - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "A_Portcullis": {
+            "type": "array",
+            "description": "For the Portcullis - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "B_Ramparts": {
+            "type": "array",
+            "description": "For the Ramparts - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "B_Moat": {
+            "type": "array",
+            "description": "For the Moat - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "C_SallyPort": {
+            "type": "array",
+            "description": "For the Sally Port - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "C_Drawbridge": {
+            "type": "array",
+            "description": "For the Drawbridge - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "D_RoughTerrain": {
+            "type": "array",
+            "description": "For the Rough Terrain - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "D_RockWall": {
+            "type": "array",
+            "description": "For the Rock Wall - An array with three values, number of times damaged, number of opportunities to damage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "average_high_goals": {
+            "type": "number",
+            "description": "Average number of high goals scored.",
+            "format": "float"
+          },
+          "average_low_goals": {
+            "type": "number",
+            "description": "Average number of low goals scored.",
+            "format": "float"
+          },
+          "breaches": {
+            "type": "array",
+            "description": "An array with three values, number of times breached, number of opportunities to breach, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "scales": {
+            "type": "array",
+            "description": "An array with three values, number of times scaled, number of opportunities to scale, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "challenges": {
+            "type": "array",
+            "description": "An array with three values, number of times challenged, number of opportunities to challenge, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "captures": {
+            "type": "array",
+            "description": "An array with three values, number of times captured, number of opportunities to capture, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "average_win_score": {
+            "type": "number",
+            "description": "Average winning score.",
+            "format": "float"
+          },
+          "average_win_margin": {
+            "type": "number",
+            "description": "Average margin of victory.",
+            "format": "float"
+          },
+          "average_score": {
+            "type": "number",
+            "description": "Average total score.",
+            "format": "float"
+          },
+          "average_auto_score": {
+            "type": "number",
+            "description": "Average autonomous score.",
+            "format": "float"
+          },
+          "average_crossing_score": {
+            "type": "number",
+            "description": "Average crossing score.",
+            "format": "float"
+          },
+          "average_boulder_score": {
+            "type": "number",
+            "description": "Average boulder score.",
+            "format": "float"
+          },
+          "average_tower_score": {
+            "type": "number",
+            "description": "Average tower score.",
+            "format": "float"
+          },
+          "average_foul_score": {
+            "type": "number",
+            "description": "Average foul score.",
+            "format": "float"
+          },
+          "high_score": {
+            "type": "array",
+            "description": "An array with three values, high score, match key from the match with the high score, and the name of the match.",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "Insights for FIRST Stronghold qualification and elimination matches."
+      },
+      "Event_Insights_2017": {
+        "required": [
+          "average_foul_score",
+          "average_fuel_points",
+          "average_fuel_points_auto",
+          "average_fuel_points_teleop",
+          "average_high_goals",
+          "average_high_goals_auto",
+          "average_high_goals_teleop",
+          "average_low_goals",
+          "average_low_goals_auto",
+          "average_low_goals_teleop",
+          "average_mobility_points_auto",
+          "average_points_auto",
+          "average_points_teleop",
+          "average_rotor_points",
+          "average_rotor_points_auto",
+          "average_rotor_points_teleop",
+          "average_score",
+          "average_takeoff_points_teleop",
+          "average_win_margin",
+          "average_win_score",
+          "high_kpa",
+          "high_score",
+          "kpa_achieved",
+          "mobility_counts",
+          "rotor_1_engaged",
+          "rotor_1_engaged_auto",
+          "rotor_2_engaged",
+          "rotor_2_engaged_auto",
+          "rotor_3_engaged",
+          "rotor_4_engaged",
+          "takeoff_counts",
+          "unicorn_matches"
+        ],
+        "type": "object",
+        "properties": {
+          "average_foul_score": {
+            "type": "number",
+            "description": "Average foul score.",
+            "format": "float"
+          },
+          "average_fuel_points": {
+            "type": "number",
+            "description": "Average fuel points scored.",
+            "format": "float"
+          },
+          "average_fuel_points_auto": {
+            "type": "number",
+            "description": "Average fuel points scored during auto.",
+            "format": "float"
+          },
+          "average_fuel_points_teleop": {
+            "type": "number",
+            "description": "Average fuel points scored during teleop.",
+            "format": "float"
+          },
+          "average_high_goals": {
+            "type": "number",
+            "description": "Average points scored in the high goal.",
+            "format": "float"
+          },
+          "average_high_goals_auto": {
+            "type": "number",
+            "description": "Average points scored in the high goal during auto.",
+            "format": "float"
+          },
+          "average_high_goals_teleop": {
+            "type": "number",
+            "description": "Average points scored in the high goal during teleop.",
+            "format": "float"
+          },
+          "average_low_goals": {
+            "type": "number",
+            "description": "Average points scored in the low goal.",
+            "format": "float"
+          },
+          "average_low_goals_auto": {
+            "type": "number",
+            "description": "Average points scored in the low goal during auto.",
+            "format": "float"
+          },
+          "average_low_goals_teleop": {
+            "type": "number",
+            "description": "Average points scored in the low goal during teleop.",
+            "format": "float"
+          },
+          "average_mobility_points_auto": {
+            "type": "number",
+            "description": "Average mobility points scored during auto.",
+            "format": "float"
+          },
+          "average_points_auto": {
+            "type": "number",
+            "description": "Average points scored during auto.",
+            "format": "float"
+          },
+          "average_points_teleop": {
+            "type": "number",
+            "description": "Average points scored during teleop.",
+            "format": "float"
+          },
+          "average_rotor_points": {
+            "type": "number",
+            "description": "Average rotor points scored.",
+            "format": "float"
+          },
+          "average_rotor_points_auto": {
+            "type": "number",
+            "description": "Average rotor points scored during auto.",
+            "format": "float"
+          },
+          "average_rotor_points_teleop": {
+            "type": "number",
+            "description": "Average rotor points scored during teleop.",
+            "format": "float"
+          },
+          "average_score": {
+            "type": "number",
+            "description": "Average score.",
+            "format": "float"
+          },
+          "average_takeoff_points_teleop": {
+            "type": "number",
+            "description": "Average takeoff points scored during teleop.",
+            "format": "float"
+          },
+          "average_win_margin": {
+            "type": "number",
+            "description": "Average margin of victory.",
+            "format": "float"
+          },
+          "average_win_score": {
+            "type": "number",
+            "description": "Average winning score.",
+            "format": "float"
+          },
+          "high_kpa": {
+            "type": "array",
+            "description": "An array with three values, kPa scored, match key from the match with the high kPa, and the name of the match",
+            "items": {
+              "type": "string"
+            }
+          },
+          "high_score": {
+            "type": "array",
+            "description": "An array with three values, high score, match key from the match with the high score, and the name of the match",
+            "items": {
+              "type": "string"
+            }
+          },
+          "kpa_achieved": {
+            "type": "array",
+            "description": "An array with three values, number of times kPa bonus achieved, number of opportunities to bonus, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "mobility_counts": {
+            "type": "array",
+            "description": "An array with three values, number of times mobility bonus achieved, number of opportunities to bonus, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "rotor_1_engaged": {
+            "type": "array",
+            "description": "An array with three values, number of times rotor 1 engaged, number of opportunities to engage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "rotor_1_engaged_auto": {
+            "type": "array",
+            "description": "An array with three values, number of times rotor 1 engaged in auto, number of opportunities to engage in auto, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "rotor_2_engaged": {
+            "type": "array",
+            "description": "An array with three values, number of times rotor 2 engaged, number of opportunities to engage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "rotor_2_engaged_auto": {
+            "type": "array",
+            "description": "An array with three values, number of times rotor 2 engaged in auto, number of opportunities to engage in auto, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "rotor_3_engaged": {
+            "type": "array",
+            "description": "An array with three values, number of times rotor 3 engaged, number of opportunities to engage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "rotor_4_engaged": {
+            "type": "array",
+            "description": "An array with three values, number of times rotor 4 engaged, number of opportunities to engage, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "takeoff_counts": {
+            "type": "array",
+            "description": "An array with three values, number of times takeoff was counted, number of opportunities to takeoff, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "unicorn_matches": {
+            "type": "array",
+            "description": "An array with three values, number of times a unicorn match (Win + kPa & Rotor Bonuses) occured, number of opportunities to have a unicorn match, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        "description": "Insights for FIRST STEAMWORKS qualification and elimination matches."
+      },
+      "Event_Insights_2018": {
+        "required": [
+          "auto_quest_achieved",
+          "average_boost_played",
+          "average_endgame_points",
+          "average_force_played",
+          "average_foul_score",
+          "average_points_auto",
+          "average_points_teleop",
+          "average_run_points_auto",
+          "average_scale_ownership_points",
+          "average_scale_ownership_points_auto",
+          "average_scale_ownership_points_teleop",
+          "average_score",
+          "average_switch_ownership_points",
+          "average_switch_ownership_points_auto",
+          "average_switch_ownership_points_teleop",
+          "average_vault_points",
+          "average_win_margin",
+          "average_win_score",
+          "boost_played_counts",
+          "climb_counts",
+          "face_the_boss_achieved",
+          "force_played_counts",
+          "high_score",
+          "levitate_played_counts",
+          "run_counts_auto",
+          "scale_neutral_percentage",
+          "scale_neutral_percentage_auto",
+          "scale_neutral_percentage_teleop",
+          "switch_owned_counts_auto",
+          "unicorn_matches",
+          "winning_opp_switch_denial_percentage_teleop",
+          "winning_own_switch_ownership_percentage",
+          "winning_own_switch_ownership_percentage_auto",
+          "winning_own_switch_ownership_percentage_teleop",
+          "winning_scale_ownership_percentage",
+          "winning_scale_ownership_percentage_auto",
+          "winning_scale_ownership_percentage_teleop"
+        ],
+        "type": "object",
+        "properties": {
+          "auto_quest_achieved": {
+            "type": "array",
+            "description": "An array with three values, number of times auto quest was completed, number of opportunities to complete the auto quest, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "average_boost_played": {
+            "type": "number",
+            "description": "Average number of boost power up scored (out of 3).",
+            "format": "float"
+          },
+          "average_endgame_points": {
+            "type": "number",
+            "description": "Average endgame points.",
+            "format": "float"
+          },
+          "average_force_played": {
+            "type": "number",
+            "description": "Average number of force power up scored (out of 3).",
+            "format": "float"
+          },
+          "average_foul_score": {
+            "type": "number",
+            "description": "Average foul score.",
+            "format": "float"
+          },
+          "average_points_auto": {
+            "type": "number",
+            "description": "Average points scored during auto.",
+            "format": "float"
+          },
+          "average_points_teleop": {
+            "type": "number",
+            "description": "Average points scored during teleop.",
+            "format": "float"
+          },
+          "average_run_points_auto": {
+            "type": "number",
+            "description": "Average mobility points scored during auto.",
+            "format": "float"
+          },
+          "average_scale_ownership_points": {
+            "type": "number",
+            "description": "Average scale ownership points scored.",
+            "format": "float"
+          },
+          "average_scale_ownership_points_auto": {
+            "type": "number",
+            "description": "Average scale ownership points scored during auto.",
+            "format": "float"
+          },
+          "average_scale_ownership_points_teleop": {
+            "type": "number",
+            "description": "Average scale ownership points scored during teleop.",
+            "format": "float"
+          },
+          "average_score": {
+            "type": "number",
+            "description": "Average score.",
+            "format": "float"
+          },
+          "average_switch_ownership_points": {
+            "type": "number",
+            "description": "Average switch ownership points scored.",
+            "format": "float"
+          },
+          "average_switch_ownership_points_auto": {
+            "type": "number",
+            "description": "Average switch ownership points scored during auto.",
+            "format": "float"
+          },
+          "average_switch_ownership_points_teleop": {
+            "type": "number",
+            "description": "Average switch ownership points scored during teleop.",
+            "format": "float"
+          },
+          "average_vault_points": {
+            "type": "number",
+            "description": "Average value points scored.",
+            "format": "float"
+          },
+          "average_win_margin": {
+            "type": "number",
+            "description": "Average margin of victory.",
+            "format": "float"
+          },
+          "average_win_score": {
+            "type": "number",
+            "description": "Average winning score.",
+            "format": "float"
+          },
+          "boost_played_counts": {
+            "type": "array",
+            "description": "An array with three values, number of times a boost power up was played, number of opportunities to play a boost power up, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "climb_counts": {
+            "type": "array",
+            "description": "An array with three values, number of times a climb occurred, number of opportunities to climb, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "face_the_boss_achieved": {
+            "type": "array",
+            "description": "An array with three values, number of times an alliance faced the boss, number of opportunities to face the boss, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "force_played_counts": {
+            "type": "array",
+            "description": "An array with three values, number of times a force power up was played, number of opportunities to play a force power up, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "high_score": {
+            "type": "array",
+            "description": "An array with three values, high score, match key from the match with the high score, and the name of the match",
+            "items": {
+              "type": "string"
+            }
+          },
+          "levitate_played_counts": {
+            "type": "array",
+            "description": "An array with three values, number of times a levitate power up was played, number of opportunities to play a levitate power up, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "run_counts_auto": {
+            "type": "array",
+            "description": "An array with three values, number of times a team scored mobility points in auto, number of opportunities to score mobility points in auto, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "scale_neutral_percentage": {
+            "type": "number",
+            "description": "Average scale neutral percentage.",
+            "format": "float"
+          },
+          "scale_neutral_percentage_auto": {
+            "type": "number",
+            "description": "Average scale neutral percentage during auto.",
+            "format": "float"
+          },
+          "scale_neutral_percentage_teleop": {
+            "type": "number",
+            "description": "Average scale neutral percentage during teleop.",
+            "format": "float"
+          },
+          "switch_owned_counts_auto": {
+            "type": "array",
+            "description": "An array with three values, number of times a switch was owned during auto, number of opportunities to own a switch during auto, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "unicorn_matches": {
+            "type": "array",
+            "description": "An array with three values, number of times a unicorn match (Win + Auto Quest + Face the Boss) occurred, number of opportunities to have a unicorn match, and percentage.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "winning_opp_switch_denial_percentage_teleop": {
+            "type": "number",
+            "description": "Average opposing switch denail percentage for the winning alliance during teleop.",
+            "format": "float"
+          },
+          "winning_own_switch_ownership_percentage": {
+            "type": "number",
+            "description": "Average own switch ownership percentage for the winning alliance.",
+            "format": "float"
+          },
+          "winning_own_switch_ownership_percentage_auto": {
+            "type": "number",
+            "description": "Average own switch ownership percentage for the winning alliance during auto.",
+            "format": "float"
+          },
+          "winning_own_switch_ownership_percentage_teleop": {
+            "type": "number",
+            "description": "Average own switch ownership percentage for the winning alliance during teleop.",
+            "format": "float"
+          },
+          "winning_scale_ownership_percentage": {
+            "type": "number",
+            "description": "Average scale ownership percentage for the winning alliance.",
+            "format": "float"
+          },
+          "winning_scale_ownership_percentage_auto": {
+            "type": "number",
+            "description": "Average scale ownership percentage for the winning alliance during auto.",
+            "format": "float"
+          },
+          "winning_scale_ownership_percentage_teleop": {
+            "type": "number",
+            "description": "Average scale ownership percentage for the winning alliance during teleop.",
+            "format": "float"
+          }
+        },
+        "description": "Insights for FIRST Power Up qualification and elimination matches."
+      },
+      "Event_OPRs": {
+        "type": "object",
+        "properties": {
+          "oprs": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "OPR for team.",
+              "format": "float"
+            },
+            "description": "A key-value pair with team key (eg `frc254`) as key and OPR as value."
+          },
+          "dprs": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "DPR for team.",
+              "format": "float"
+            },
+            "description": "A key-value pair with team key (eg `frc254`) as key and DPR as value."
+          },
+          "ccwms": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "CCWM for team.",
+              "format": "float"
+            },
+            "description": "A key-value pair with team key (eg `frc254`) as key and CCWM as value."
+          }
+        },
+        "description": "OPR, DPR, and CCWM for teams at the event."
+      },
+      "Event_Predictions": {
+        "type": "object",
+        "description": "JSON Object containing prediction information for the event. Contains year-specific information and is subject to change."
+      },
+      "Event_Ranking": {
+        "required": [
+          "rankings",
+          "sort_order_info",
+          "extra_stats_info"
+        ],
+        "type": "object",
+        "properties": {
+          "rankings": {
+            "type": "array",
+            "description": "List of rankings at the event.",
+            "items": {
+              "required": [
+                "dq",
+                "matches_played",
+                "rank",
+                "team_key",
+                "extra_stats",
+                "qual_average",
+                "sort_orders"
+              ],
+              "type": "object",
+              "properties": {
+                "matches_played": {
+                  "type": "integer",
+                  "description": "Number of matches played by this team."
+                },
+                "qual_average": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "The average match score during qualifications. Year specific. May be null if not relevant for a given year."
+                },
+                "extra_stats": {
+                  "type": "array",
+                  "description": "Additional special data on the team's performance calculated by TBA.",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "sort_orders": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  },
+                  "description": "Additional year-specific information. See parent `sort_order_info` for details."
+                },
+                "record": {
+                  "$ref": "#/components/schemas/WLT_Record"
+                },
+                "rank": {
+                  "type": "integer",
+                  "description": "The team's rank at the event as provided by FIRST."
+                },
+                "dq": {
+                  "type": "integer",
+                  "description": "Number of times disqualified."
+                },
+                "team_key": {
+                  "type": "string",
+                  "description": "The team with this rank."
+                }
+              }
+            }
+          },
+          "extra_stats_info": {
+            "type": "array",
+            "description": "List of special TBA-generated values provided in the `extra_stats` array for each item.",
+            "items": {
+              "required": [
+                "name",
+                "precision"
+              ],
+              "type": "object",
+              "properties": {
+                "precision": {
+                  "type": "number",
+                  "description": "Integer expressing the number of digits of precision in the number provided in `sort_orders`."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the field used in the `extra_stats` array."
+                }
+              }
+            }
+          },
+          "sort_order_info": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "List of year-specific values provided in the `sort_orders` array for each team.",
+            "items": {
+              "required": [
+                "name",
+                "precision"
+              ],
+              "type": "object",
+              "properties": {
+                "precision": {
+                  "type": "integer",
+                  "description": "Integer expressing the number of digits of precision in the number provided in `sort_orders`."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the field used in the `sort_order` array."
+                }
+              }
+            }
+          }
+        }
+      },
+      "Event_Simple": {
+        "required": [
+          "key",
+          "name",
+          "event_code",
+          "event_type",
+          "city",
+          "state_prov",
+          "country",
+          "start_date",
+          "end_date",
+          "year"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "TBA event key with the format yyyy[EVENT_CODE], where yyyy is the year, and EVENT_CODE is the event code of the event."
+          },
+          "name": {
+            "type": "string",
+            "description": "Official name of event on record either provided by FIRST or organizers of offseason event."
+          },
+          "event_code": {
+            "type": "string",
+            "description": "Event short code, as provided by FIRST."
+          },
+          "event_type": {
+            "type": "integer",
+            "description": "Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/event_type.py#L8"
+          },
+          "district": {
+            "$ref": "#/components/schemas/District"
+          },
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "City, town, village, etc. the event is located in."
+          },
+          "state_prov": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "State or Province the event is located in."
+          },
+          "country": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Country the event is located in."
+          },
+          "start_date": {
+            "type": "string",
+            "description": "Event start date in `yyyy-mm-dd` format.",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "Event end date in `yyyy-mm-dd` format.",
+            "format": "date"
+          },
+          "year": {
+            "type": "integer",
+            "description": "Year the event data is for."
+          }
+        }
+      },
+      "HabLine_2019": {
+        "type": "string",
+        "enum": [
+          "CrossedHabLineInSandstorm",
+          "CrossedHabLineInTeleop",
+          "None",
+          "Unknown"
+        ]
+      },
+      "History": {
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            }
+          },
+          "awards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Award"
+            }
+          }
+        },
+        "required": [
+          "events",
+          "awards"
+        ]
+      },
+      "InitLineRobot_2020": {
+        "type": "string",
+        "enum": [
+          "Exited",
+          "None"
+        ]
+      },
+      "LeaderboardInsight": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "rankings": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "number",
+                      "description": "Value of the insight that the corresponding team/event/matches have, e.g. number of blue banners, or number of matches played."
+                    },
+                    "keys": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Team/Event/Match keys that have the corresponding value."
+                    }
+                  },
+                  "required": [
+                    "value",
+                    "keys"
+                  ]
+                }
+              },
+              "key_type": {
+                "type": "string",
+                "enum": [
+                  "team",
+                  "event",
+                  "match"
+                ],
+                "description": "What type of key is used in the rankings; either 'team', 'event', or 'match'."
+              }
+            },
+            "required": [
+              "rankings",
+              "key_type"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the insight."
+          },
+          "year": {
+            "type": "integer",
+            "description": "Year the insight was measured in (year=0 for overall insights)."
+          }
+        },
+        "required": [
+          "data",
+          "name",
+          "year"
+        ]
+      },
+      "Match": {
+        "required": [
+          "comp_level",
+          "event_key",
+          "key",
+          "match_number",
+          "set_number",
+          "alliances",
+          "winning_alliance",
+          "time",
+          "actual_time",
+          "predicted_time",
+          "post_result_time",
+          "videos"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may be appended to the competition level if more than one match in required per set."
+          },
+          "comp_level": {
+            "$ref": "#/components/schemas/Comp_Level"
+          },
+          "set_number": {
+            "type": "integer",
+            "description": "The set number in a series of matches where more than one match is required in the match series."
+          },
+          "match_number": {
+            "type": "integer",
+            "description": "The match number of the match in the competition level."
+          },
+          "alliances": {
+            "type": "object",
+            "required": [
+              "red",
+              "blue"
+            ],
+            "properties": {
+              "red": {
+                "$ref": "#/components/schemas/Match_alliance"
+              },
+              "blue": {
+                "$ref": "#/components/schemas/Match_alliance"
+              }
+            },
+            "description": "A list of alliances, the teams on the alliances, and their score."
+          },
+          "winning_alliance": {
+            "type": "string",
+            "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.",
+            "enum": [
+              "red",
+              "blue",
+              ""
+            ]
+          },
+          "event_key": {
+            "type": "string",
+            "description": "Event key of the event the match was played at."
+          },
+          "time": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the scheduled match time, as taken from the published schedule.",
+            "format": "int64"
+          },
+          "actual_time": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of actual match start time.",
+            "format": "int64"
+          },
+          "predicted_time": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the TBA predicted match start time.",
+            "format": "int64"
+          },
+          "post_result_time": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) when the match result was posted.",
+            "format": "int64"
+          },
+          "score_breakdown": {
+            "description": "Score breakdown for auto, teleop, etc. points. Varies from year to year. May be null.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2015"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2016"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2017"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2018"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2019"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2020"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2022"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2023"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2024"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2025"
+              },
+              {
+                "$ref": "#/components/schemas/Match_Score_Breakdown_2026"
+              }
+            ]
+          },
+          "videos": {
+            "type": "array",
+            "description": "Array of video objects associated with this match.",
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "key"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Can be one of 'youtube' or 'tba'"
+                },
+                "key": {
+                  "type": "string",
+                  "description": "Unique key representing this video"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Match_Score_Breakdown_2015": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red",
+          "coopertition",
+          "coopertition_points"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2015_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2015_Alliance"
+          },
+          "coopertition": {
+            "type": "string",
+            "enum": [
+              "None",
+              "Unknown",
+              "Stack"
+            ]
+          },
+          "coopertition_points": {
+            "type": "integer"
+          }
+        },
+        "description": "See the 2015 FMS API documentation for a description of each value"
+      },
+      "Match_Score_Breakdown_2015_Alliance": {
+        "type": "object",
+        "properties": {
+          "auto": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "auto_points": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "teleop_points": {
+            "type": "integer"
+          },
+          "container_points": {
+            "type": "integer"
+          },
+          "tote_points": {
+            "type": "integer"
+          },
+          "litter_points": {
+            "type": "integer"
+          },
+          "foul": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "foul_points": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "adjust_points": {
+            "type": "integer"
+          },
+          "total_points": {
+            "type": "integer"
+          },
+          "foul_count": {
+            "type": "integer"
+          },
+          "tote_count_far": {
+            "type": "integer"
+          },
+          "tote_count_near": {
+            "type": "integer"
+          },
+          "tote_set": {
+            "type": "boolean"
+          },
+          "tote_stack": {
+            "type": "boolean"
+          },
+          "container_count_level1": {
+            "type": "integer"
+          },
+          "container_count_level2": {
+            "type": "integer"
+          },
+          "container_count_level3": {
+            "type": "integer"
+          },
+          "container_count_level4": {
+            "type": "integer"
+          },
+          "container_count_level5": {
+            "type": "integer"
+          },
+          "container_count_level6": {
+            "type": "integer"
+          },
+          "container_set": {
+            "type": "boolean"
+          },
+          "litter_count_container": {
+            "type": "integer"
+          },
+          "litter_count_landfill": {
+            "type": "integer"
+          },
+          "litter_count_unprocessed": {
+            "type": "integer"
+          },
+          "robot_set": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2016": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2016_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2016_Alliance"
+          }
+        },
+        "description": "See the 2016 FMS API documentation for a description of each value."
+      },
+      "Match_Score_Breakdown_2016_Alliance": {
+        "type": "object",
+        "required": [
+          "autoBoulderPoints",
+          "autoCrossingPoints",
+          "autoPoints",
+          "autoReachPoints",
+          "breachPoints",
+          "capturePoints",
+          "foulPoints",
+          "position1crossings",
+          "position2",
+          "position2crossings",
+          "position3",
+          "position3crossings",
+          "position4",
+          "position4crossings",
+          "position5",
+          "position5crossings",
+          "tba_rpEarned",
+          "teleopBoulderPoints",
+          "teleopBouldersHigh",
+          "teleopBouldersLow",
+          "teleopChallengePoints",
+          "teleopCrossingPoints",
+          "teleopDefensesBreached",
+          "teleopScalePoints",
+          "teleopTowerCaptured",
+          "totalPoints"
+        ],
+        "properties": {
+          "autoPoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "breachPoints": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "capturePoints": {
+            "type": "integer"
+          },
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          },
+          "tba_rpEarned": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "robot1Auto": {
+            "$ref": "#/components/schemas/RobotAuto_2016_WithUnknown"
+          },
+          "robot2Auto": {
+            "$ref": "#/components/schemas/RobotAuto_2016_WithoutUnknown"
+          },
+          "robot3Auto": {
+            "$ref": "#/components/schemas/RobotAuto_2016_WithUnknown"
+          },
+          "autoReachPoints": {
+            "type": "integer"
+          },
+          "autoCrossingPoints": {
+            "type": "integer"
+          },
+          "autoBouldersLow": {
+            "type": "integer"
+          },
+          "autoBouldersHigh": {
+            "type": "integer"
+          },
+          "autoBoulderPoints": {
+            "type": "integer"
+          },
+          "teleopCrossingPoints": {
+            "type": "integer"
+          },
+          "teleopBouldersLow": {
+            "type": "integer"
+          },
+          "teleopBouldersHigh": {
+            "type": "integer"
+          },
+          "teleopBoulderPoints": {
+            "type": "integer"
+          },
+          "teleopDefensesBreached": {
+            "type": "boolean"
+          },
+          "teleopChallengePoints": {
+            "type": "integer"
+          },
+          "teleopScalePoints": {
+            "type": "integer"
+          },
+          "teleopTowerCaptured": {
+            "type": "boolean"
+          },
+          "towerFaceA": {
+            "$ref": "#/components/schemas/TowerFace_2016"
+          },
+          "towerFaceB": {
+            "$ref": "#/components/schemas/TowerFace_2016"
+          },
+          "towerFaceC": {
+            "$ref": "#/components/schemas/TowerFace_2016"
+          },
+          "towerEndStrength": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "position2": {
+            "$ref": "#/components/schemas/Position_2016"
+          },
+          "position3": {
+            "$ref": "#/components/schemas/Position_2016"
+          },
+          "position4": {
+            "$ref": "#/components/schemas/Position_2016"
+          },
+          "position5": {
+            "$ref": "#/components/schemas/Position_2016"
+          },
+          "position1crossings": {
+            "type": "integer"
+          },
+          "position2crossings": {
+            "type": "integer"
+          },
+          "position3crossings": {
+            "type": "integer"
+          },
+          "position4crossings": {
+            "type": "integer"
+          },
+          "position5crossings": {
+            "type": "integer"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2017": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2017_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2017_Alliance"
+          }
+        },
+        "description": "See the 2017 FMS API documentation for a description of each value."
+      },
+      "Match_Score_Breakdown_2017_Alliance": {
+        "type": "object",
+        "required": [
+          "autoFuelHigh",
+          "autoFuelLow",
+          "autoFuelPoints",
+          "autoMobilityPoints",
+          "autoPoints",
+          "autoRotorPoints",
+          "foulPoints",
+          "kPaBonusPoints",
+          "kPaRankingPointAchieved",
+          "rotor1Auto",
+          "rotor1Engaged",
+          "rotor2Auto",
+          "rotor2Engaged",
+          "rotor3Engaged",
+          "rotor4Engaged",
+          "rotorBonusPoints",
+          "rotorRankingPointAchieved",
+          "teleopFuelHigh",
+          "teleopFuelLow",
+          "teleopFuelPoints",
+          "teleopPoints",
+          "teleopRotorPoints",
+          "teleopTakeoffPoints",
+          "totalPoints"
+        ],
+        "properties": {
+          "autoPoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          },
+          "robot1Auto": {
+            "$ref": "#/components/schemas/RobotAuto_2017"
+          },
+          "robot2Auto": {
+            "$ref": "#/components/schemas/RobotAuto_2017"
+          },
+          "robot3Auto": {
+            "$ref": "#/components/schemas/RobotAuto_2017"
+          },
+          "rotor1Auto": {
+            "type": "boolean"
+          },
+          "rotor2Auto": {
+            "type": "boolean"
+          },
+          "autoFuelLow": {
+            "type": "integer"
+          },
+          "autoFuelHigh": {
+            "type": "integer"
+          },
+          "autoMobilityPoints": {
+            "type": "integer"
+          },
+          "autoRotorPoints": {
+            "type": "integer"
+          },
+          "autoFuelPoints": {
+            "type": "integer"
+          },
+          "teleopFuelPoints": {
+            "type": "integer"
+          },
+          "teleopFuelLow": {
+            "type": "integer"
+          },
+          "teleopFuelHigh": {
+            "type": "integer"
+          },
+          "teleopRotorPoints": {
+            "type": "integer"
+          },
+          "kPaRankingPointAchieved": {
+            "type": "boolean"
+          },
+          "teleopTakeoffPoints": {
+            "type": "integer"
+          },
+          "kPaBonusPoints": {
+            "type": "integer"
+          },
+          "rotorBonusPoints": {
+            "type": "integer"
+          },
+          "rotor1Engaged": {
+            "type": "boolean"
+          },
+          "rotor2Engaged": {
+            "type": "boolean"
+          },
+          "rotor3Engaged": {
+            "type": "boolean"
+          },
+          "rotor4Engaged": {
+            "type": "boolean"
+          },
+          "rotorRankingPointAchieved": {
+            "type": "boolean"
+          },
+          "tba_rpEarned": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "touchpadNear": {
+            "$ref": "#/components/schemas/Touchpad_2017"
+          },
+          "touchpadMiddle": {
+            "$ref": "#/components/schemas/Touchpad_2017"
+          },
+          "touchpadFar": {
+            "$ref": "#/components/schemas/Touchpad_2017"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2018": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2018_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2018_Alliance"
+          }
+        },
+        "description": "See the 2018 FMS API documentation for a description of each value. https://frcevents2.docs.apiary.io/#/reference/match-results/score-details"
+      },
+      "Match_Score_Breakdown_2018_Alliance": {
+        "type": "object",
+        "required": [
+          "autoOwnershipPoints",
+          "autoPoints",
+          "autoRunPoints",
+          "autoScaleOwnershipSec",
+          "autoSwitchOwnershipSec",
+          "endgamePoints",
+          "faceTheBossRankingPoint",
+          "foulPoints",
+          "rp",
+          "teleopOwnershipPoints",
+          "teleopPoints",
+          "teleopScaleBoostSec",
+          "teleopScaleOwnershipSec",
+          "teleopSwitchBoostSec",
+          "teleopSwitchOwnershipSec",
+          "totalPoints",
+          "vaultBoostPlayed",
+          "vaultBoostTotal",
+          "vaultForcePlayed",
+          "vaultForceTotal",
+          "vaultLevitatePlayed",
+          "vaultLevitateTotal",
+          "vaultPoints"
+        ],
+        "properties": {
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "autoOwnershipPoints": {
+            "type": "integer"
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "autoQuestRankingPoint": {
+            "type": "boolean"
+          },
+          "autoRobot1": {
+            "$ref": "#/components/schemas/AutoRobot_2018"
+          },
+          "autoRobot2": {
+            "$ref": "#/components/schemas/AutoRobot_2018"
+          },
+          "autoRobot3": {
+            "$ref": "#/components/schemas/AutoRobot_2018"
+          },
+          "autoRunPoints": {
+            "type": "integer"
+          },
+          "autoScaleOwnershipSec": {
+            "type": "integer"
+          },
+          "autoSwitchAtZero": {
+            "type": "boolean"
+          },
+          "autoSwitchOwnershipSec": {
+            "type": "integer"
+          },
+          "endgamePoints": {
+            "type": "integer"
+          },
+          "endgameRobot1": {
+            "$ref": "#/components/schemas/EndgameRobot_2018"
+          },
+          "endgameRobot2": {
+            "$ref": "#/components/schemas/EndgameRobot_2018"
+          },
+          "endgameRobot3": {
+            "$ref": "#/components/schemas/EndgameRobot_2018"
+          },
+          "faceTheBossRankingPoint": {
+            "type": "boolean"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "rp": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "teleopOwnershipPoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "teleopScaleBoostSec": {
+            "type": "integer"
+          },
+          "teleopScaleForceSec": {
+            "type": "integer"
+          },
+          "teleopScaleOwnershipSec": {
+            "type": "integer"
+          },
+          "teleopSwitchBoostSec": {
+            "type": "integer"
+          },
+          "teleopSwitchForceSec": {
+            "type": "integer"
+          },
+          "teleopSwitchOwnershipSec": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          },
+          "vaultBoostPlayed": {
+            "type": "integer"
+          },
+          "vaultBoostTotal": {
+            "type": "integer"
+          },
+          "vaultForcePlayed": {
+            "type": "integer"
+          },
+          "vaultForceTotal": {
+            "type": "integer"
+          },
+          "vaultLevitatePlayed": {
+            "type": "integer"
+          },
+          "vaultLevitateTotal": {
+            "type": "integer"
+          },
+          "vaultPoints": {
+            "type": "integer"
+          },
+          "tba_gameData": {
+            "type": "string",
+            "enum": [
+              "",
+              "LLL",
+              "LRL",
+              "RLR",
+              "RRR"
+            ],
+            "description": "Unofficial TBA-computed value of the FMS provided GameData given to the alliance teams at the start of the match. 3 Character String containing `L` and `R` only. The first character represents the near switch, the 2nd the scale, and the 3rd the far, opposing, switch from the alliance's perspective. An `L` in a position indicates the platform on the left will be lit for the alliance while an `R` will indicate the right platform will be lit for the alliance. See also [WPI Screen Steps](https://wpilib.screenstepslive.com/s/currentCS/m/getting_started/l/826278-2018-game-data-details)."
+          }
+        }
+      },
+      "Match_Score_Breakdown_2019": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2019_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2019_Alliance"
+          }
+        },
+        "description": "See the 2019 FMS API documentation for a description of each value. https://frcevents2.docs.apiary.io/#/reference/match-results/score-details"
+      },
+      "Match_Score_Breakdown_2019_Alliance": {
+        "type": "object",
+        "required": [
+          "bay1",
+          "bay2",
+          "bay3",
+          "bay4",
+          "bay5",
+          "bay6",
+          "bay7",
+          "bay8",
+          "cargoPoints",
+          "completeRocketRankingPoint",
+          "endgameRobot1",
+          "endgameRobot2",
+          "endgameRobot3",
+          "foulPoints",
+          "habClimbPoints",
+          "habDockingRankingPoint",
+          "habLineRobot1",
+          "habLineRobot2",
+          "habLineRobot3",
+          "hatchPanelPoints",
+          "lowLeftRocketFar",
+          "lowLeftRocketNear",
+          "lowRightRocketFar",
+          "lowRightRocketNear",
+          "midLeftRocketFar",
+          "midLeftRocketNear",
+          "midRightRocketFar",
+          "midRightRocketNear",
+          "preMatchBay1",
+          "preMatchBay2",
+          "preMatchBay3",
+          "preMatchBay6",
+          "preMatchBay7",
+          "preMatchBay8",
+          "preMatchLevelRobot1",
+          "preMatchLevelRobot2",
+          "preMatchLevelRobot3",
+          "rp",
+          "sandStormBonusPoints",
+          "teleopPoints",
+          "topLeftRocketFar",
+          "topLeftRocketNear",
+          "topRightRocketFar",
+          "topRightRocketNear",
+          "totalPoints"
+        ],
+        "properties": {
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "bay1": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "bay2": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "bay3": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "bay4": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "bay5": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "bay6": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "bay7": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "bay8": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "cargoPoints": {
+            "type": "integer"
+          },
+          "completeRocketRankingPoint": {
+            "type": "boolean"
+          },
+          "completedRocketFar": {
+            "type": "boolean"
+          },
+          "completedRocketNear": {
+            "type": "boolean"
+          },
+          "endgameRobot1": {
+            "$ref": "#/components/schemas/EndgameRobot_2019"
+          },
+          "endgameRobot2": {
+            "$ref": "#/components/schemas/EndgameRobot_2019"
+          },
+          "endgameRobot3": {
+            "$ref": "#/components/schemas/EndgameRobot_2019"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "habClimbPoints": {
+            "type": "integer"
+          },
+          "habDockingRankingPoint": {
+            "type": "boolean"
+          },
+          "habLineRobot1": {
+            "$ref": "#/components/schemas/HabLine_2019"
+          },
+          "habLineRobot2": {
+            "$ref": "#/components/schemas/HabLine_2019"
+          },
+          "habLineRobot3": {
+            "$ref": "#/components/schemas/HabLine_2019"
+          },
+          "hatchPanelPoints": {
+            "type": "integer"
+          },
+          "lowLeftRocketFar": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "lowLeftRocketNear": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "lowRightRocketFar": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "lowRightRocketNear": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "midLeftRocketFar": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "midLeftRocketNear": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "midRightRocketFar": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "midRightRocketNear": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "preMatchBay1": {
+            "$ref": "#/components/schemas/PreMatchBay_2019"
+          },
+          "preMatchBay2": {
+            "$ref": "#/components/schemas/PreMatchBay_2019"
+          },
+          "preMatchBay3": {
+            "$ref": "#/components/schemas/PreMatchBay_2019"
+          },
+          "preMatchBay6": {
+            "$ref": "#/components/schemas/PreMatchBay_2019"
+          },
+          "preMatchBay7": {
+            "$ref": "#/components/schemas/PreMatchBay_2019"
+          },
+          "preMatchBay8": {
+            "$ref": "#/components/schemas/PreMatchBay_2019"
+          },
+          "preMatchLevelRobot1": {
+            "$ref": "#/components/schemas/EndgameRobot_2019"
+          },
+          "preMatchLevelRobot2": {
+            "$ref": "#/components/schemas/EndgameRobot_2019"
+          },
+          "preMatchLevelRobot3": {
+            "$ref": "#/components/schemas/EndgameRobot_2019"
+          },
+          "rp": {
+            "type": "integer"
+          },
+          "sandStormBonusPoints": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "topLeftRocketFar": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "topLeftRocketNear": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "topRightRocketFar": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "topRightRocketNear": {
+            "$ref": "#/components/schemas/Bay_2019"
+          },
+          "totalPoints": {
+            "type": "integer"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2020": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2020_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2020_Alliance"
+          }
+        },
+        "description": "See the 2020 FMS API documentation for a description of each value. https://frcevents2.docs.apiary.io/#/reference/match-results/score-details"
+      },
+      "Match_Score_Breakdown_2020_Alliance": {
+        "type": "object",
+        "required": [
+          "autoCellPoints",
+          "autoCellsBottom",
+          "autoCellsInner",
+          "autoCellsOuter",
+          "autoInitLinePoints",
+          "autoPoints",
+          "controlPanelPoints",
+          "endgamePoints",
+          "endgameRobot1",
+          "endgameRobot2",
+          "endgameRobot3",
+          "endgameRungIsLevel",
+          "foulCount",
+          "foulPoints",
+          "initLineRobot1",
+          "initLineRobot2",
+          "initLineRobot3",
+          "shieldEnergizedRankingPoint",
+          "shieldOperationalRankingPoint",
+          "stage1Activated",
+          "stage2Activated",
+          "stage3Activated",
+          "stage3TargetColor",
+          "techFoulCount",
+          "teleopCellPoints",
+          "teleopCellsBottom",
+          "teleopCellsInner",
+          "teleopCellsOuter",
+          "teleopPoints",
+          "totalPoints"
+        ],
+        "properties": {
+          "initLineRobot1": {
+            "$ref": "#/components/schemas/InitLineRobot_2020"
+          },
+          "endgameRobot1": {
+            "$ref": "#/components/schemas/EndgameRobot_2020"
+          },
+          "initLineRobot2": {
+            "$ref": "#/components/schemas/InitLineRobot_2020"
+          },
+          "endgameRobot2": {
+            "$ref": "#/components/schemas/EndgameRobot_2020"
+          },
+          "initLineRobot3": {
+            "$ref": "#/components/schemas/InitLineRobot_2020"
+          },
+          "endgameRobot3": {
+            "$ref": "#/components/schemas/EndgameRobot_2020"
+          },
+          "autoCellsBottom": {
+            "type": "integer"
+          },
+          "autoCellsOuter": {
+            "type": "integer"
+          },
+          "autoCellsInner": {
+            "type": "integer"
+          },
+          "teleopCellsBottom": {
+            "type": "integer"
+          },
+          "teleopCellsOuter": {
+            "type": "integer"
+          },
+          "teleopCellsInner": {
+            "type": "integer"
+          },
+          "stage1Activated": {
+            "type": "boolean"
+          },
+          "stage2Activated": {
+            "type": "boolean"
+          },
+          "stage3Activated": {
+            "type": "boolean"
+          },
+          "stage3TargetColor": {
+            "$ref": "#/components/schemas/Stage3TargetColor_2020"
+          },
+          "endgameRungIsLevel": {
+            "$ref": "#/components/schemas/EndgameRungIsLevel_2020"
+          },
+          "autoInitLinePoints": {
+            "type": "integer"
+          },
+          "autoCellPoints": {
+            "type": "integer"
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "teleopCellPoints": {
+            "type": "integer"
+          },
+          "controlPanelPoints": {
+            "type": "integer"
+          },
+          "endgamePoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "shieldOperationalRankingPoint": {
+            "type": "boolean"
+          },
+          "shieldEnergizedRankingPoint": {
+            "type": "boolean"
+          },
+          "tba_shieldEnergizedRankingPointFromFoul": {
+            "type": "boolean",
+            "description": "Unofficial TBA-computed value that indicates whether the shieldEnergizedRankingPoint was earned normally or awarded due to a foul."
+          },
+          "tba_numRobotsHanging": {
+            "type": "integer",
+            "description": "Unofficial TBA-computed value that counts the number of robots who were hanging at the end of the match."
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "rp": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2022": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2022_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2022_Alliance"
+          }
+        },
+        "description": "See the 2022 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
+      },
+      "Match_Score_Breakdown_2022_Alliance": {
+        "type": "object",
+        "properties": {
+          "taxiRobot1": {
+            "$ref": "#/components/schemas/TaxiRobot_2022"
+          },
+          "endgameRobot1": {
+            "$ref": "#/components/schemas/EndgameRobot_2022"
+          },
+          "taxiRobot2": {
+            "$ref": "#/components/schemas/TaxiRobot_2022"
+          },
+          "endgameRobot2": {
+            "$ref": "#/components/schemas/EndgameRobot_2022"
+          },
+          "taxiRobot3": {
+            "$ref": "#/components/schemas/TaxiRobot_2022"
+          },
+          "endgameRobot3": {
+            "$ref": "#/components/schemas/EndgameRobot_2022"
+          },
+          "autoCargoLowerNear": {
+            "type": "integer"
+          },
+          "autoCargoLowerFar": {
+            "type": "integer"
+          },
+          "autoCargoLowerBlue": {
+            "type": "integer"
+          },
+          "autoCargoLowerRed": {
+            "type": "integer"
+          },
+          "autoCargoUpperNear": {
+            "type": "integer"
+          },
+          "autoCargoUpperFar": {
+            "type": "integer"
+          },
+          "autoCargoUpperBlue": {
+            "type": "integer"
+          },
+          "autoCargoUpperRed": {
+            "type": "integer"
+          },
+          "autoCargoTotal": {
+            "type": "integer"
+          },
+          "teleopCargoLowerNear": {
+            "type": "integer"
+          },
+          "teleopCargoLowerFar": {
+            "type": "integer"
+          },
+          "teleopCargoLowerBlue": {
+            "type": "integer"
+          },
+          "teleopCargoLowerRed": {
+            "type": "integer"
+          },
+          "teleopCargoUpperNear": {
+            "type": "integer"
+          },
+          "teleopCargoUpperFar": {
+            "type": "integer"
+          },
+          "teleopCargoUpperBlue": {
+            "type": "integer"
+          },
+          "teleopCargoUpperRed": {
+            "type": "integer"
+          },
+          "teleopCargoTotal": {
+            "type": "integer"
+          },
+          "matchCargoTotal": {
+            "type": "integer"
+          },
+          "autoTaxiPoints": {
+            "type": "integer"
+          },
+          "autoCargoPoints": {
+            "type": "integer"
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "quintetAchieved": {
+            "type": "boolean"
+          },
+          "teleopCargoPoints": {
+            "type": "integer"
+          },
+          "endgamePoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "cargoBonusRankingPoint": {
+            "type": "boolean"
+          },
+          "hangarBonusRankingPoint": {
+            "type": "boolean"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "rp": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "totalPoints": {
+            "type": "integer"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2023": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2023_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2023_Alliance"
+          }
+        },
+        "description": "See the 2023 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
+      },
+      "Match_Score_Breakdown_2023_Alliance": {
+        "type": "object",
+        "required": [
+          "autoMobilityPoints",
+          "autoPoints",
+          "foulCount",
+          "foulPoints",
+          "mobilityRobot1",
+          "mobilityRobot2",
+          "mobilityRobot3",
+          "rp",
+          "techFoulCount",
+          "teleopPoints",
+          "totalPoints"
+        ],
+        "properties": {
+          "activationBonusAchieved": {
+            "type": "boolean"
+          },
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "autoBridgeState": {
+            "$ref": "#/components/schemas/BridgeState_2023"
+          },
+          "autoChargeStationPoints": {
+            "type": "integer"
+          },
+          "autoChargeStationRobot1": {
+            "$ref": "#/components/schemas/AutoChargeStationRobot_2023"
+          },
+          "autoChargeStationRobot2": {
+            "$ref": "#/components/schemas/AutoChargeStationRobot_2023"
+          },
+          "autoChargeStationRobot3": {
+            "$ref": "#/components/schemas/AutoChargeStationRobot_2023"
+          },
+          "autoDocked": {
+            "type": "boolean"
+          },
+          "autoCommunity": {
+            "type": "object",
+            "required": [
+              "B",
+              "M",
+              "T"
+            ],
+            "properties": {
+              "B": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              },
+              "M": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              },
+              "T": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              }
+            }
+          },
+          "autoGamePieceCount": {
+            "type": "integer"
+          },
+          "autoGamePiecePoints": {
+            "type": "integer"
+          },
+          "autoMobilityPoints": {
+            "type": "integer"
+          },
+          "mobilityRobot1": {
+            "$ref": "#/components/schemas/MobilityRobot_2023"
+          },
+          "mobilityRobot2": {
+            "$ref": "#/components/schemas/MobilityRobot_2023"
+          },
+          "mobilityRobot3": {
+            "$ref": "#/components/schemas/MobilityRobot_2023"
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "coopGamePieceCount": {
+            "type": "integer"
+          },
+          "coopertitionCriteriaMet": {
+            "type": "boolean"
+          },
+          "endGameBridgeState": {
+            "$ref": "#/components/schemas/BridgeState_2023"
+          },
+          "endGameChargeStationPoints": {
+            "type": "integer"
+          },
+          "endGameChargeStationRobot1": {
+            "$ref": "#/components/schemas/EndGameChargeStationRobot_2023"
+          },
+          "endGameChargeStationRobot2": {
+            "$ref": "#/components/schemas/EndGameChargeStationRobot_2023"
+          },
+          "endGameChargeStationRobot3": {
+            "$ref": "#/components/schemas/EndGameChargeStationRobot_2023"
+          },
+          "endGameParkPoints": {
+            "type": "integer"
+          },
+          "extraGamePieceCount": {
+            "type": "integer"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "linkPoints": {
+            "type": "integer"
+          },
+          "links": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "required": [
+                "nodes",
+                "row"
+              ],
+              "properties": {
+                "nodes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "None",
+                      "Cone",
+                      "Cube"
+                    ]
+                  }
+                },
+                "row": {
+                  "type": "string",
+                  "enum": [
+                    "Bottom",
+                    "Mid",
+                    "Top"
+                  ]
+                }
+              }
+            }
+          },
+          "sustainabilityBonusAchieved": {
+            "type": "boolean"
+          },
+          "teleopCommunity": {
+            "type": "object",
+            "required": [
+              "B",
+              "M",
+              "T"
+            ],
+            "properties": {
+              "B": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              },
+              "M": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              },
+              "T": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "None",
+                    "Cone",
+                    "Cube"
+                  ]
+                }
+              }
+            }
+          },
+          "teleopGamePieceCount": {
+            "type": "integer"
+          },
+          "teleopGamePiecePoints": {
+            "type": "integer"
+          },
+          "totalChargeStationPoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "rp": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2024": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2024_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2024_Alliance"
+          }
+        },
+        "description": "See the 2024 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
+      },
+      "Match_Score_Breakdown_2024_Alliance": {
+        "type": "object",
+        "required": [
+          "rp",
+          "totalPoints"
+        ],
+        "properties": {
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "autoAmpNoteCount": {
+            "type": "integer"
+          },
+          "autoAmpNotePoints": {
+            "type": "integer"
+          },
+          "autoLeavePoints": {
+            "type": "integer"
+          },
+          "autoLineRobot1": {
+            "$ref": "#/components/schemas/AutoLineRobot_2024"
+          },
+          "autoLineRobot2": {
+            "$ref": "#/components/schemas/AutoLineRobot_2024"
+          },
+          "autoLineRobot3": {
+            "$ref": "#/components/schemas/AutoLineRobot_2024"
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "autoSpeakerNoteCount": {
+            "type": "integer"
+          },
+          "autoSpeakerNotePoints": {
+            "type": "integer"
+          },
+          "autoTotalNotePoints": {
+            "type": "integer"
+          },
+          "coopNotePlayed": {
+            "type": "boolean"
+          },
+          "coopertitionBonusAchieved": {
+            "type": "boolean"
+          },
+          "coopertitionCriteriaMet": {
+            "type": "boolean"
+          },
+          "endGameHarmonyPoints": {
+            "type": "integer"
+          },
+          "endGameNoteInTrapPoints": {
+            "type": "integer"
+          },
+          "endGameOnStagePoints": {
+            "type": "integer"
+          },
+          "endGameParkPoints": {
+            "type": "integer"
+          },
+          "endGameRobot1": {
+            "$ref": "#/components/schemas/EndGameRobot_2024"
+          },
+          "endGameRobot2": {
+            "$ref": "#/components/schemas/EndGameRobot_2024"
+          },
+          "endGameRobot3": {
+            "$ref": "#/components/schemas/EndGameRobot_2024"
+          },
+          "endGameSpotLightBonusPoints": {
+            "type": "integer"
+          },
+          "endGameTotalStagePoints": {
+            "type": "integer"
+          },
+          "ensembleBonusAchieved": {
+            "type": "boolean"
+          },
+          "ensembleBonusOnStageRobotsThreshold": {
+            "type": "integer"
+          },
+          "ensembleBonusStagePointsThreshold": {
+            "type": "integer"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "g206Penalty": {
+            "type": "boolean"
+          },
+          "g408Penalty": {
+            "type": "boolean"
+          },
+          "g424Penalty": {
+            "type": "boolean"
+          },
+          "melodyBonusAchieved": {
+            "type": "boolean"
+          },
+          "melodyBonusThreshold": {
+            "type": "integer"
+          },
+          "melodyBonusThresholdCoop": {
+            "type": "integer"
+          },
+          "melodyBonusThresholdNonCoop": {
+            "type": "integer"
+          },
+          "micCenterStage": {
+            "type": "boolean"
+          },
+          "micStageLeft": {
+            "type": "boolean"
+          },
+          "micStageRight": {
+            "type": "boolean"
+          },
+          "rp": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "teleopAmpNoteCount": {
+            "type": "integer"
+          },
+          "teleopAmpNotePoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "teleopSpeakerNoteAmplifiedCount": {
+            "type": "integer"
+          },
+          "teleopSpeakerNoteAmplifiedPoints": {
+            "type": "integer"
+          },
+          "teleopSpeakerNoteCount": {
+            "type": "integer"
+          },
+          "teleopSpeakerNotePoints": {
+            "type": "integer"
+          },
+          "teleopTotalNotePoints": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          },
+          "trapCenterStage": {
+            "type": "boolean"
+          },
+          "trapStageLeft": {
+            "type": "boolean"
+          },
+          "trapStageRight": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2025": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2025_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2025_Alliance"
+          }
+        },
+        "description": "See the 2025 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
+      },
+      "Match_Score_Breakdown_2025_Alliance": {
+        "type": "object",
+        "required": [
+          "algaePoints",
+          "autoCoralCount",
+          "autoCoralPoints",
+          "autoLineRobot1",
+          "autoLineRobot2",
+          "autoLineRobot3",
+          "autoMobilityPoints",
+          "autoPoints",
+          "autoReef",
+          "endGameBargePoints",
+          "endGameRobot1",
+          "endGameRobot2",
+          "endGameRobot3",
+          "foulCount",
+          "foulPoints",
+          "g206Penalty",
+          "g410Penalty",
+          "g418Penalty",
+          "g428Penalty",
+          "netAlgaeCount",
+          "rp",
+          "techFoulCount",
+          "teleopCoralCount",
+          "teleopCoralPoints",
+          "teleopPoints",
+          "teleopReef",
+          "totalPoints",
+          "wallAlgaeCount"
+        ],
+        "properties": {
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "algaePoints": {
+            "type": "integer"
+          },
+          "autoBonusAchieved": {
+            "type": "boolean"
+          },
+          "autoCoralCount": {
+            "type": "integer"
+          },
+          "autoCoralPoints": {
+            "type": "integer"
+          },
+          "autoLineRobot1": {
+            "$ref": "#/components/schemas/AutoLineRobot_2024"
+          },
+          "autoLineRobot2": {
+            "$ref": "#/components/schemas/AutoLineRobot_2024"
+          },
+          "autoLineRobot3": {
+            "$ref": "#/components/schemas/AutoLineRobot_2024"
+          },
+          "autoMobilityPoints": {
+            "type": "integer"
+          },
+          "autoPoints": {
+            "type": "integer"
+          },
+          "autoReef": {
+            "type": "object",
+            "required": [
+              "topRow",
+              "midRow",
+              "botRow",
+              "trough"
+            ],
+            "properties": {
+              "topRow": {
+                "$ref": "#/components/schemas/ReefRow_2025"
+              },
+              "midRow": {
+                "$ref": "#/components/schemas/ReefRow_2025"
+              },
+              "botRow": {
+                "$ref": "#/components/schemas/ReefRow_2025"
+              },
+              "trough": {
+                "type": "integer"
+              },
+              "tba_botRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the botRow object."
+              },
+              "tba_midRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the midRow object."
+              },
+              "tba_topRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the topRow object."
+              }
+            }
+          },
+          "bargeBonusAchieved": {
+            "type": "boolean"
+          },
+          "coopertitionCriteriaMet": {
+            "type": "boolean"
+          },
+          "coralBonusAchieved": {
+            "type": "boolean"
+          },
+          "endGameBargePoints": {
+            "type": "integer"
+          },
+          "endGameRobot1": {
+            "$ref": "#/components/schemas/EndGameRobot_2025"
+          },
+          "endGameRobot2": {
+            "$ref": "#/components/schemas/EndGameRobot_2025"
+          },
+          "endGameRobot3": {
+            "$ref": "#/components/schemas/EndGameRobot_2025"
+          },
+          "foulCount": {
+            "type": "integer"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "g206Penalty": {
+            "type": "boolean"
+          },
+          "g410Penalty": {
+            "type": "boolean"
+          },
+          "g418Penalty": {
+            "type": "boolean"
+          },
+          "g428Penalty": {
+            "type": "boolean"
+          },
+          "netAlgaeCount": {
+            "type": "integer"
+          },
+          "rp": {
+            "type": "integer"
+          },
+          "techFoulCount": {
+            "type": "integer"
+          },
+          "teleopCoralCount": {
+            "type": "integer"
+          },
+          "teleopCoralPoints": {
+            "type": "integer"
+          },
+          "teleopPoints": {
+            "type": "integer"
+          },
+          "teleopReef": {
+            "type": "object",
+            "required": [
+              "topRow",
+              "midRow",
+              "botRow",
+              "trough"
+            ],
+            "properties": {
+              "topRow": {
+                "$ref": "#/components/schemas/ReefRow_2025"
+              },
+              "midRow": {
+                "$ref": "#/components/schemas/ReefRow_2025"
+              },
+              "botRow": {
+                "$ref": "#/components/schemas/ReefRow_2025"
+              },
+              "trough": {
+                "type": "integer"
+              },
+              "tba_botRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the botRow object."
+              },
+              "tba_midRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the midRow object."
+              },
+              "tba_topRowCount": {
+                "type": "integer",
+                "description": "Unofficial TBA-computed value that sums the total number of game pieces scored in the topRow object."
+              }
+            }
+          },
+          "totalPoints": {
+            "type": "integer"
+          },
+          "wallAlgaeCount": {
+            "type": "integer"
+          }
+        }
+      },
+      "Match_Score_Breakdown_2026": {
+        "type": "object",
+        "required": [
+          "blue",
+          "red"
+        ],
+        "properties": {
+          "blue": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2026_Alliance"
+          },
+          "red": {
+            "$ref": "#/components/schemas/Match_Score_Breakdown_2026_Alliance"
+          }
+        },
+        "description": "See the 2026 FMS API documentation for a description of each value. https://frc-api-docs.firstinspires.org"
+      },
+      "Match_Score_Breakdown_2026_Alliance": {
+        "type": "object",
+        "required": [
+          "adjustPoints",
+          "autoTowerPoints",
+          "autoTowerRobot1",
+          "autoTowerRobot2",
+          "autoTowerRobot3",
+          "endGameTowerPoints",
+          "endGameTowerRobot1",
+          "endGameTowerRobot2",
+          "endGameTowerRobot3",
+          "energizedAchieved",
+          "foulPoints",
+          "g206Penalty",
+          "hubScore",
+          "majorFoulCount",
+          "minorFoulCount",
+          "rp",
+          "superchargedAchieved",
+          "totalAutoPoints",
+          "totalPoints",
+          "totalTeleopPoints",
+          "totalTowerPoints",
+          "traversalAchieved"
+        ],
+        "properties": {
+          "adjustPoints": {
+            "type": "integer"
+          },
+          "autoTowerPoints": {
+            "type": "integer"
+          },
+          "autoTowerRobot1": {
+            "$ref": "#/components/schemas/TowerRobot_2026"
+          },
+          "autoTowerRobot2": {
+            "$ref": "#/components/schemas/TowerRobot_2026"
+          },
+          "autoTowerRobot3": {
+            "$ref": "#/components/schemas/TowerRobot_2026"
+          },
+          "endGameTowerPoints": {
+            "type": "integer"
+          },
+          "endGameTowerRobot1": {
+            "$ref": "#/components/schemas/TowerRobot_2026"
+          },
+          "endGameTowerRobot2": {
+            "$ref": "#/components/schemas/TowerRobot_2026"
+          },
+          "endGameTowerRobot3": {
+            "$ref": "#/components/schemas/TowerRobot_2026"
+          },
+          "energizedAchieved": {
+            "type": "boolean"
+          },
+          "foulPoints": {
+            "type": "integer"
+          },
+          "g206Penalty": {
+            "type": "boolean"
+          },
+          "hubScore": {
+            "$ref": "#/components/schemas/HubScore_2026"
+          },
+          "majorFoulCount": {
+            "type": "integer"
+          },
+          "minorFoulCount": {
+            "type": "integer"
+          },
+          "rp": {
+            "type": "integer"
+          },
+          "superchargedAchieved": {
+            "type": "boolean"
+          },
+          "totalAutoPoints": {
+            "type": "integer"
+          },
+          "totalPoints": {
+            "type": "integer"
+          },
+          "totalTeleopPoints": {
+            "type": "integer"
+          },
+          "totalTowerPoints": {
+            "type": "integer"
+          },
+          "traversalAchieved": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Match_Simple": {
+        "required": [
+          "key",
+          "comp_level",
+          "set_number",
+          "match_number",
+          "alliances",
+          "winning_alliance",
+          "event_key",
+          "time",
+          "predicted_time",
+          "actual_time"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may append the competition level if more than one match in required per set."
+          },
+          "comp_level": {
+            "$ref": "#/components/schemas/Comp_Level"
+          },
+          "set_number": {
+            "type": "integer",
+            "description": "The set number in a series of matches where more than one match is required in the match series."
+          },
+          "match_number": {
+            "type": "integer",
+            "description": "The match number of the match in the competition level."
+          },
+          "alliances": {
+            "type": "object",
+            "required": [
+              "red",
+              "blue"
+            ],
+            "properties": {
+              "red": {
+                "$ref": "#/components/schemas/Match_alliance"
+              },
+              "blue": {
+                "$ref": "#/components/schemas/Match_alliance"
+              }
+            },
+            "description": "A list of alliances, the teams on the alliances, and their score."
+          },
+          "winning_alliance": {
+            "type": "string",
+            "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.",
+            "enum": [
+              "red",
+              "blue",
+              ""
+            ]
+          },
+          "event_key": {
+            "type": "string",
+            "description": "Event key of the event the match was played at."
+          },
+          "time": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the scheduled match time, as taken from the published schedule.",
+            "format": "int64"
+          },
+          "predicted_time": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of the TBA predicted match start time.",
+            "format": "int64"
+          },
+          "actual_time": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "UNIX timestamp (seconds since 1-Jan-1970 00:00:00) of actual match start time.",
+            "format": "int64"
+          }
+        }
+      },
+      "Match_Timeseries_2018": {
+        "type": "object",
+        "properties": {
+          "event_key": {
+            "type": "string",
+            "description": "TBA event key with the format yyyy[EVENT_CODE], where yyyy is the year, and EVENT_CODE is the event code of the event."
+          },
+          "match_id": {
+            "type": "string",
+            "description": "Match ID consisting of the level, match number, and set number, eg `qm45` or `f1m1`."
+          },
+          "mode": {
+            "type": "string",
+            "description": "Current mode of play, can be `pre_match`, `auto`, `telop`, or `post_match`."
+          },
+          "play": {
+            "type": "integer"
+          },
+          "time_remaining": {
+            "type": "integer",
+            "description": "Amount of time remaining in the match, only valid during `auto` and `teleop` modes."
+          },
+          "blue_auto_quest": {
+            "type": "integer",
+            "description": "1 if the blue alliance is credited with the AUTO QUEST, 0 if not."
+          },
+          "blue_boost_count": {
+            "type": "integer",
+            "description": "Number of POWER CUBES in the BOOST section of the blue alliance VAULT."
+          },
+          "blue_boost_played": {
+            "type": "integer",
+            "description": "Returns 1 if the blue alliance BOOST was played, or 0 if not played."
+          },
+          "blue_current_powerup": {
+            "type": "string",
+            "description": "Name of the current blue alliance POWER UP being played, or `null`."
+          },
+          "blue_face_the_boss": {
+            "type": "integer",
+            "description": "1 if the blue alliance is credited with FACING THE BOSS, 0 if not."
+          },
+          "blue_force_count": {
+            "type": "integer",
+            "description": "Number of POWER CUBES in the FORCE section of the blue alliance VAULT."
+          },
+          "blue_force_played": {
+            "type": "integer",
+            "description": "Returns 1 if the blue alliance FORCE was played, or 0 if not played."
+          },
+          "blue_levitate_count": {
+            "type": "integer",
+            "description": "Number of POWER CUBES in the LEVITATE section of the blue alliance VAULT."
+          },
+          "blue_levitate_played": {
+            "type": "integer",
+            "description": "Returns 1 if the blue alliance LEVITATE was played, or 0 if not played."
+          },
+          "blue_powerup_time_remaining": {
+            "type": "string",
+            "description": "Number of seconds remaining in the blue alliance POWER UP time, or 0 if none is active."
+          },
+          "blue_scale_owned": {
+            "type": "integer",
+            "description": "1 if the blue alliance owns the SCALE, 0 if not."
+          },
+          "blue_score": {
+            "type": "integer",
+            "description": "Current score for the blue alliance."
+          },
+          "blue_switch_owned": {
+            "type": "integer",
+            "description": "1 if the blue alliance owns their SWITCH, 0 if not."
+          },
+          "red_auto_quest": {
+            "type": "integer",
+            "description": "1 if the red alliance is credited with the AUTO QUEST, 0 if not."
+          },
+          "red_boost_count": {
+            "type": "integer",
+            "description": "Number of POWER CUBES in the BOOST section of the red alliance VAULT."
+          },
+          "red_boost_played": {
+            "type": "integer",
+            "description": "Returns 1 if the red alliance BOOST was played, or 0 if not played."
+          },
+          "red_current_powerup": {
+            "type": "string",
+            "description": "Name of the current red alliance POWER UP being played, or `null`."
+          },
+          "red_face_the_boss": {
+            "type": "integer",
+            "description": "1 if the red alliance is credited with FACING THE BOSS, 0 if not."
+          },
+          "red_force_count": {
+            "type": "integer",
+            "description": "Number of POWER CUBES in the FORCE section of the red alliance VAULT."
+          },
+          "red_force_played": {
+            "type": "integer",
+            "description": "Returns 1 if the red alliance FORCE was played, or 0 if not played."
+          },
+          "red_levitate_count": {
+            "type": "integer",
+            "description": "Number of POWER CUBES in the LEVITATE section of the red alliance VAULT."
+          },
+          "red_levitate_played": {
+            "type": "integer",
+            "description": "Returns 1 if the red alliance LEVITATE was played, or 0 if not played."
+          },
+          "red_powerup_time_remaining": {
+            "type": "string",
+            "description": "Number of seconds remaining in the red alliance POWER UP time, or 0 if none is active."
+          },
+          "red_scale_owned": {
+            "type": "integer",
+            "description": "1 if the red alliance owns the SCALE, 0 if not."
+          },
+          "red_score": {
+            "type": "integer",
+            "description": "Current score for the red alliance."
+          },
+          "red_switch_owned": {
+            "type": "integer",
+            "description": "1 if the red alliance owns their SWITCH, 0 if not."
+          }
+        },
+        "description": "Timeseries data for the 2018 game *FIRST* POWER UP.\n*WARNING:* This is *not* official data, and is subject to a significant possibility of error, or missing data. Do not rely on this data for any purpose. In fact, pretend we made it up.\n*WARNING:* This model is currently under active development and may change at any time, including in breaking ways."
+      },
+      "Match_alliance": {
+        "required": [
+          "score",
+          "team_keys",
+          "surrogate_team_keys",
+          "dq_team_keys"
+        ],
+        "type": "object",
+        "properties": {
+          "score": {
+            "type": "integer",
+            "description": "Score for this alliance. Will be -1 for an unplayed match."
+          },
+          "team_keys": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "TBA Team keys (eg `frc254`) for teams on this alliance."
+            }
+          },
+          "surrogate_team_keys": {
+            "type": "array",
+            "description": "TBA team keys (eg `frc254`) of any teams playing as a surrogate.",
+            "items": {
+              "type": "string",
+              "description": "Team key of a surrogate team."
+            }
+          },
+          "dq_team_keys": {
+            "type": "array",
+            "description": "TBA team keys (eg `frc254`) of any disqualified teams.",
+            "items": {
+              "type": "string",
+              "description": "Team key of a disqualified team."
+            }
+          }
+        }
+      },
+      "Media": {
+        "required": [
+          "type",
+          "foreign_key",
+          "team_keys"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "String type of the media element.",
+            "enum": [
+              "youtube",
+              "cdphotothread",
+              "imgur",
+              "facebook-profile",
+              "youtube-channel",
+              "twitter-profile",
+              "github-profile",
+              "instagram-profile",
+              "periscope-profile",
+              "gitlab-profile",
+              "grabcad",
+              "instagram-image",
+              "external-link",
+              "avatar",
+              "onshape",
+              "cd-thread"
+            ]
+          },
+          "foreign_key": {
+            "type": "string",
+            "description": "The key used to identify this media on the media site."
+          },
+          "details": {
+            "type": "object",
+            "description": "If required, a JSON dict of additional media information.",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              {
+                "properties": {
+                  "base64Image": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "base64Image"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "author_id": {
+                    "type": "integer"
+                  },
+                  "author_name": {
+                    "type": "string"
+                  },
+                  "author_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "height": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "html": {
+                    "type": "string"
+                  },
+                  "media_id": {
+                    "type": "string"
+                  },
+                  "provider_name": {
+                    "type": "string"
+                  },
+                  "provider_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "thumbnail_height": {
+                    "type": "integer"
+                  },
+                  "thumbnail_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "thumbnail_width": {
+                    "type": "integer"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "width": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "author_id",
+                  "author_name",
+                  "author_url",
+                  "height",
+                  "html",
+                  "media_id",
+                  "provider_name",
+                  "provider_url",
+                  "thumbnail_height",
+                  "thumbnail_url",
+                  "thumbnail_width",
+                  "title",
+                  "type",
+                  "version",
+                  "width"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "model_created": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "model_description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "model_image": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "model_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "model_created",
+                  "model_description",
+                  "model_image",
+                  "model_name"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "image_partial": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "image_partial"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "thread_title": {
+                    "type": "string"
+                  },
+                  "image_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "thread_title",
+                  "image_url"
+                ]
+              }
+            ]
+          },
+          "preferred": {
+            "type": "boolean",
+            "description": "True if the media is of high quality."
+          },
+          "team_keys": {
+            "type": "array",
+            "description": "List of teams that this media belongs to. Most likely length 1.",
+            "items": {
+              "type": "string",
+              "description": "Team key."
+            }
+          },
+          "direct_url": {
+            "type": "string",
+            "description": "Direct URL to the media."
+          },
+          "view_url": {
+            "type": "string",
+            "description": "The URL that leads to the full web page for the media, if one exists."
+          }
+        },
+        "description": "The `Media` object contains a reference for most any media associated with a team or event on TBA."
+      },
+      "MobilityRobot_2023": {
+        "type": "string",
+        "enum": [
+          "No",
+          "Yes"
+        ]
+      },
+      "NotablesInsight": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "entries": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "context": {
+                      "type": "array",
+                      "description": "A list of events this team achieved the notable at. This type may change over time.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "team_key": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "context",
+                    "team_key"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "entries"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "year": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "data",
+          "name",
+          "year"
+        ]
+      },
+      "Position_2016": {
+        "type": "string",
+        "enum": [
+          "",
+          "A_ChevalDeFrise",
+          "A_Portcullis",
+          "B_Moat",
+          "B_Ramparts",
+          "C_Drawbridge",
+          "C_SallyPort",
+          "D_RockWall",
+          "D_RoughTerrain",
+          "NotSpecified"
+        ]
+      },
+      "PreMatchBay_2019": {
+        "type": "string",
+        "enum": [
+          "Cargo",
+          "Panel",
+          "Unknown"
+        ]
+      },
+      "ReefRow_2025": {
+        "type": "object",
+        "required": [
+          "nodeA",
+          "nodeB",
+          "nodeC",
+          "nodeD",
+          "nodeE",
+          "nodeF",
+          "nodeG",
+          "nodeH",
+          "nodeI",
+          "nodeJ",
+          "nodeK",
+          "nodeL"
+        ],
+        "properties": {
+          "nodeA": {
+            "type": "boolean"
+          },
+          "nodeB": {
+            "type": "boolean"
+          },
+          "nodeC": {
+            "type": "boolean"
+          },
+          "nodeD": {
+            "type": "boolean"
+          },
+          "nodeE": {
+            "type": "boolean"
+          },
+          "nodeF": {
+            "type": "boolean"
+          },
+          "nodeG": {
+            "type": "boolean"
+          },
+          "nodeH": {
+            "type": "boolean"
+          },
+          "nodeI": {
+            "type": "boolean"
+          },
+          "nodeJ": {
+            "type": "boolean"
+          },
+          "nodeK": {
+            "type": "boolean"
+          },
+          "nodeL": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Regional_Advancement": {
+        "required": [
+          "cmp",
+          "cmp_status"
+        ],
+        "type": "object",
+        "properties": {
+          "cmp": {
+            "type": "boolean",
+            "description": "Whether or not the team qualified for Championship."
+          },
+          "cmp_status": {
+            "type": "string",
+            "enum": [
+              "NotInvited",
+              "PreQualified",
+              "EventQualified",
+              "PoolQualified",
+              "Declined"
+            ]
+          },
+          "qualifying_event": {
+            "type": "string",
+            "description": "The event key at which the team qualified"
+          },
+          "qualifying_award_name": {
+            "type": "string",
+            "description": "The name of the award which qualified the team"
+          },
+          "qualifying_pool_week": {
+            "type": "integer",
+            "description": "Which week number's regional pool invitation the team got"
+          }
+        },
+        "description": "Information about how a regional team qualified for FIRST Championship."
+      },
+      "Regional_Ranking": {
+        "required": [
+          "point_total",
+          "rank",
+          "team_key"
+        ],
+        "type": "object",
+        "properties": {
+          "team_key": {
+            "type": "string",
+            "description": "TBA team key for the team."
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Numerical rank of the team, 1 being top rank."
+          },
+          "rookie_bonus": {
+            "type": "integer",
+            "description": "Any points added to a team as a result of the rookie bonus."
+          },
+          "single_event_bonus": {
+            "type": "integer",
+            "description": "Additional points awarded in lieu of a second event, based on first event performance"
+          },
+          "point_total": {
+            "type": "integer",
+            "description": "Total district points for the team."
+          },
+          "event_points": {
+            "type": "array",
+            "description": "List of events that contributed to the point total for the team.",
+            "items": {
+              "required": [
+                "alliance_points",
+                "award_points",
+                "elim_points",
+                "event_key",
+                "qual_points",
+                "total"
+              ],
+              "type": "object",
+              "properties": {
+                "total": {
+                  "type": "integer",
+                  "description": "Total points awarded at this event."
+                },
+                "alliance_points": {
+                  "type": "integer",
+                  "description": "Points awarded for alliance selection."
+                },
+                "elim_points": {
+                  "type": "integer",
+                  "description": "Points awarded for elimination match performance."
+                },
+                "award_points": {
+                  "type": "integer",
+                  "description": "Points awarded for event awards."
+                },
+                "event_key": {
+                  "type": "string",
+                  "description": "TBA Event key for this event."
+                },
+                "qual_points": {
+                  "type": "integer",
+                  "description": "Points awarded for qualification match performance."
+                }
+              }
+            }
+          }
+        },
+        "description": "Rank of a team in the regional pool."
+      },
+      "RobotAuto_2016_WithUnknown": {
+        "type": "string",
+        "enum": [
+          "Crossed",
+          "None",
+          "Reached",
+          "Unknown"
+        ]
+      },
+      "RobotAuto_2016_WithoutUnknown": {
+        "type": "string",
+        "enum": [
+          "Crossed",
+          "Reached",
+          "None"
+        ]
+      },
+      "RobotAuto_2017": {
+        "type": "string",
+        "enum": [
+          "Mobility",
+          "None",
+          "Unknown"
+        ]
+      },
+      "SearchIndex": {
+        "type": "object",
+        "properties": {
+          "teams": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "nickname": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "nickname"
+              ]
+            }
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name"
+              ]
+            }
+          }
+        },
+        "required": [
+          "teams",
+          "events"
+        ]
+      },
+      "Stage3TargetColor_2020": {
+        "type": "string",
+        "enum": [
+          "Blue",
+          "Green",
+          "Red",
+          "Unknown",
+          "Yellow"
+        ]
+      },
+      "TaxiRobot_2022": {
+        "type": "string",
+        "enum": [
+          "No",
+          "Yes"
+        ]
+      },
+      "Team": {
+        "required": [
+          "key",
+          "name",
+          "team_number",
+          "nickname",
+          "school_name",
+          "city",
+          "state_prov",
+          "country",
+          "address",
+          "postal_code",
+          "gmaps_place_id",
+          "gmaps_url",
+          "lat",
+          "lng",
+          "location_name",
+          "website",
+          "rookie_year",
+          "motto"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "TBA team key with the format `frcXXXX` with `XXXX` representing the team number."
+          },
+          "team_number": {
+            "type": "integer",
+            "description": "Official team number issued by FIRST."
+          },
+          "nickname": {
+            "type": "string",
+            "description": "Team nickname provided by FIRST."
+          },
+          "name": {
+            "type": "string",
+            "description": "Official long name registered with FIRST."
+          },
+          "school_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Name of team school or affilited group registered with FIRST."
+          },
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "City of team derived from parsing the address registered with FIRST."
+          },
+          "state_prov": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "State of team derived from parsing the address registered with FIRST."
+          },
+          "country": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Country of team derived from parsing the address registered with FIRST."
+          },
+          "address": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Will be NULL, for future development."
+          },
+          "postal_code": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Postal code from the team address."
+          },
+          "gmaps_place_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Will be NULL, for future development."
+          },
+          "gmaps_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Will be NULL, for future development.",
+            "format": "url"
+          },
+          "lat": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Will be NULL, for future development.",
+            "format": "double"
+          },
+          "lng": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Will be NULL, for future development.",
+            "format": "double"
+          },
+          "location_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Will be NULL, for future development."
+          },
+          "website": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Official website associated with the team.",
+            "format": "url"
+          },
+          "rookie_year": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "First year the team officially competed."
+          },
+          "motto": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Team's motto or tagline."
+          }
+        }
+      },
+      "Team_Event_Status": {
+        "type": "object",
+        "properties": {
+          "qual": {
+            "$ref": "#/components/schemas/Team_Event_Status_rank"
+          },
+          "alliance": {
+            "$ref": "#/components/schemas/Team_Event_Status_alliance"
+          },
+          "playoff": {
+            "$ref": "#/components/schemas/Team_Event_Status_playoff"
+          },
+          "alliance_status_str": {
+            "type": "string",
+            "description": "An HTML formatted string suitable for display to the user containing the team's alliance pick status."
+          },
+          "playoff_status_str": {
+            "type": "string",
+            "description": "An HTML formatter string suitable for display to the user containing the team's playoff status."
+          },
+          "overall_status_str": {
+            "type": "string",
+            "description": "An HTML formatted string suitable for display to the user containing the team's overall status summary of the event."
+          },
+          "next_match_key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "TBA match key for the next match the team is scheduled to play in at this event, or null."
+          },
+          "last_match_key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "TBA match key for the last match the team played in at this event, or null."
+          },
+          "pit_location": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The pit location for the team at this event, or null if not available."
+          }
+        }
+      },
+      "Team_Event_Status_alliance": {
+        "required": [
+          "number",
+          "pick"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Alliance name, may be null."
+          },
+          "number": {
+            "type": "integer",
+            "description": "Alliance number."
+          },
+          "backup": {
+            "$ref": "#/components/schemas/Team_Event_Status_alliance_backup"
+          },
+          "pick": {
+            "type": "integer",
+            "description": "Order the team was picked in the alliance from 0-2, with 0 being alliance captain."
+          }
+        }
+      },
+      "Team_Event_Status_alliance_backup": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "out": {
+            "type": "string",
+            "description": "TBA key for the team replaced by the backup."
+          },
+          "in": {
+            "type": "string",
+            "description": "TBA key for the backup team called in."
+          }
+        },
+        "description": "Backup status, may be null."
+      },
+      "Team_Event_Status_playoff": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "level": {
+            "$ref": "#/components/schemas/Comp_Level"
+          },
+          "current_level_record": {
+            "$ref": "#/components/schemas/WLT_Record"
+          },
+          "record": {
+            "$ref": "#/components/schemas/WLT_Record"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current competition status for the playoffs.",
+            "enum": [
+              "won",
+              "eliminated",
+              "playing"
+            ]
+          },
+          "playoff_average": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "double",
+            "description": "The average match score during playoffs. Year specific. May be null if not relevant for a given year."
+          }
+        },
+        "description": "Playoff status for this team, may be null if the team did not make playoffs, or playoffs have not begun."
+      },
+      "Team_Event_Status_rank": {
+        "type": "object",
+        "properties": {
+          "num_teams": {
+            "type": "integer",
+            "description": "Number of teams ranked."
+          },
+          "ranking": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "matches_played": {
+                "type": "integer",
+                "description": "Number of matches played."
+              },
+              "qual_average": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "For some years, average qualification score. Can be null.",
+                "format": "double"
+              },
+              "sort_orders": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "description": "Ordered list of values used to determine the rank. See the `sort_order_info` property for the name of each value.",
+                "items": {
+                  "type": "number",
+                  "format": "double"
+                }
+              },
+              "record": {
+                "$ref": "#/components/schemas/WLT_Record"
+              },
+              "rank": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Relative rank of this team."
+              },
+              "dq": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of matches the team was disqualified for."
+              },
+              "team_key": {
+                "type": "string",
+                "description": "TBA team key for this rank."
+              }
+            }
+          },
+          "sort_order_info": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "Ordered list of names corresponding to the elements of the `sort_orders` array.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "precision": {
+                  "type": "integer",
+                  "description": "The number of digits of precision used for this value, eg `2` would correspond to a value of `101.11` while `0` would correspond to `101`."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The descriptive name of the value used to sort the ranking."
+                }
+              }
+            }
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "Team_Robot": {
+        "required": [
+          "key",
+          "robot_name",
+          "team_key",
+          "year"
+        ],
+        "type": "object",
+        "properties": {
+          "year": {
+            "type": "integer",
+            "description": "Year this robot competed in."
+          },
+          "robot_name": {
+            "type": "string",
+            "description": "Name of the robot as provided by the team."
+          },
+          "key": {
+            "type": "string",
+            "description": "Internal TBA identifier for this robot."
+          },
+          "team_key": {
+            "type": "string",
+            "description": "TBA team key for this robot."
+          }
+        }
+      },
+      "Team_Simple": {
+        "required": [
+          "key",
+          "name",
+          "team_number",
+          "nickname",
+          "city",
+          "state_prov",
+          "country"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "TBA team key with the format `frcXXXX` with `XXXX` representing the team number."
+          },
+          "team_number": {
+            "type": "integer",
+            "description": "Official team number issued by FIRST."
+          },
+          "nickname": {
+            "type": "string",
+            "description": "Team nickname provided by FIRST."
+          },
+          "name": {
+            "type": "string",
+            "description": "Official long name registered with FIRST."
+          },
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "City of team derived from parsing the address registered with FIRST."
+          },
+          "state_prov": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "State of team derived from parsing the address registered with FIRST."
+          },
+          "country": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Country of team derived from parsing the address registered with FIRST."
+          }
+        }
+      },
+      "Touchpad_2017": {
+        "type": "string",
+        "enum": [
+          "None",
+          "ReadyForTakeoff"
+        ]
+      },
+      "TowerFace_2016": {
+        "type": "string",
+        "enum": [
+          "Both",
+          "Challenged",
+          "None",
+          "Scaled",
+          "Unknown"
+        ]
+      },
+      "WLT_Record": {
+        "required": [
+          "losses",
+          "ties",
+          "wins"
+        ],
+        "type": "object",
+        "properties": {
+          "losses": {
+            "type": "integer",
+            "description": "Number of losses."
+          },
+          "wins": {
+            "type": "integer",
+            "description": "Number of wins."
+          },
+          "ties": {
+            "type": "integer",
+            "description": "Number of ties."
+          }
+        },
+        "description": "A Win-Loss-Tie record for a team, or an alliance."
+      },
+      "Webcast": {
+        "required": [
+          "channel",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of webcast, typically descriptive of the streaming provider.",
+            "enum": [
+              "youtube",
+              "twitch",
+              "ustream",
+              "iframe",
+              "html5",
+              "rtmp",
+              "livestream",
+              "direct_link",
+              "mms",
+              "justin",
+              "stemtv",
+              "dacast"
+            ]
+          },
+          "channel": {
+            "type": "string",
+            "description": "Type specific channel information. May be the YouTube stream, or Twitch channel name. In the case of iframe types, contains HTML to embed the stream in an HTML iframe."
+          },
+          "date": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The date for the webcast in `yyyy-mm-dd` format. May be null."
+          },
+          "file": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "File identification as may be required for some types. May be null."
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The online status of the webcast, fetched from the streaming provider's API. May be null if not available.",
+            "enum": [
+              "unknown",
+              "online",
+              "offline"
+            ]
+          },
+          "stream_title": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The title of the stream from the streaming provider. May be null."
+          },
+          "viewer_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "The current viewer count from the streaming provider. May be null."
+          }
+        }
+      },
+      "Zebra": {
+        "required": [
+          "key",
+          "times",
+          "alliances"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "TBA match key with the format `yyyy[EVENT_CODE]_[COMP_LEVEL]m[MATCH_NUMBER]`, where `yyyy` is the year, and `EVENT_CODE` is the event code of the event, `COMP_LEVEL` is (qm, ef, qf, sf, f), and `MATCH_NUMBER` is the match number in the competition level. A set number may be appended to the competition level if more than one match in required per set."
+          },
+          "times": {
+            "type": "array",
+            "description": "A list of relative timestamps for each data point. Each timestamp will correspond to the X and Y value at the same index in a team xs and ys arrays. `times`, all teams `xs` and all teams `ys` are guarenteed to be the same length.",
+            "items": {
+              "type": "number",
+              "format": "double",
+              "examples": [
+                0,
+                0.1,
+                0.2
+              ]
+            }
+          },
+          "alliances": {
+            "type": "object",
+            "properties": {
+              "red": {
+                "type": "array",
+                "description": "Zebra MotionWorks data for teams on the red alliance",
+                "items": {
+                  "$ref": "#/components/schemas/Zebra_team"
+                }
+              },
+              "blue": {
+                "type": "array",
+                "description": "Zebra data for teams on the blue alliance",
+                "items": {
+                  "$ref": "#/components/schemas/Zebra_team"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Zebra_team": {
+        "required": [
+          "team_key",
+          "xs",
+          "ys"
+        ],
+        "type": "object",
+        "properties": {
+          "team_key": {
+            "type": "string",
+            "description": "The TBA team key for the Zebra MotionWorks data.",
+            "examples": [
+              "frc7332"
+            ]
+          },
+          "xs": {
+            "type": "array",
+            "description": "A list containing doubles and nulls representing a teams X position in feet at the corresponding timestamp. A null value represents no tracking data for a given timestamp.",
+            "items": {
+              "type": "number",
+              "format": "double",
+              "examples": [
+                2.73,
+                2.7,
+                null
+              ]
+            }
+          },
+          "ys": {
+            "type": "array",
+            "description": "A list containing doubles and nulls representing a teams Y position in feet at the corresponding timestamp. A null value represents no tracking data for a given timestamp.",
+            "items": {
+              "type": "number",
+              "format": "double",
+              "examples": [
+                2.73,
+                2.7,
+                null
+              ]
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Authorization information is missing or invalid.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "Error"
+              ],
+              "properties": {
+                "Error": {
+                  "type": "string",
+                  "description": "Authorization error description."
+                }
+              }
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Not Found"
+      },
+      "NotModified": {
+        "description": "Not Modified - Use Local Cached Value"
+      }
+    },
+    "parameters": {
+      "If-None-Match": {
+        "name": "If-None-Match",
+        "in": "header",
+        "description": "Value of the `ETag` header in the most recently cached response by the client.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "district_abbreviation": {
+        "name": "district_abbreviation",
+        "in": "path",
+        "description": "District abbreviation, eg `ne` or `fim`",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "district_key": {
+        "name": "district_key",
+        "in": "path",
+        "description": "TBA District Key, eg `2016fim`",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "event_key": {
+        "name": "event_key",
+        "in": "path",
+        "description": "TBA Event Key, eg `2016nytr`",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "match_key": {
+        "name": "match_key",
+        "in": "path",
+        "description": "TBA Match Key, eg `2016nytr_qm1`",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "media_tag": {
+        "name": "media_tag",
+        "in": "path",
+        "description": "Media Tag which describes the Media.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "page_num": {
+        "name": "page_num",
+        "in": "path",
+        "description": "Page number of results to return, zero-indexed",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "team_key": {
+        "name": "team_key",
+        "in": "path",
+        "description": "TBA Team Key, eg `frc254`",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "year": {
+        "name": "year",
+        "in": "path",
+        "description": "Competition Year (or Season). Must be 4 digits.",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "description": "Your TBA v3 API Key can be obtained from your [Account Page](/account) on the TBA website.",
+        "name": "X-TBA-Auth-Key",
+        "in": "header"
+      }
     }
+  }
 }

--- a/scripts/update-apiv3-spec.py
+++ b/scripts/update-apiv3-spec.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "requests",
+# ]
+# ///
+"""Refresh Packages/TBAAPI/Sources/TBAAPI/openapi.json from prod.
+
+Downloads the latest TBA API v3 swagger from
+https://www.thebluealliance.com/swagger/api_v3.json and patches out
+`oneOf`/`anyOf` branches whose only job is to express nullability via
+`{"type": "null"}` — a shape that's valid OpenAPI 3.1 but unsupported by
+swift-openapi-generator (see apple/swift-openapi-generator#817, which
+endorses dropping the null branch as the proper workaround).
+
+Run: uv run scripts/update-apiv3-spec.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import requests
+
+SPEC_URL = "https://www.thebluealliance.com/swagger/api_v3.json"
+OUT_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "Packages"
+    / "TBAAPI"
+    / "Sources"
+    / "TBAAPI"
+    / "openapi.json"
+)
+
+
+def _is_null_branch(node: object) -> bool:
+    return isinstance(node, dict) and node == {"type": "null"}
+
+
+def _strip_null_compositions(
+    node: object,
+    path: list[str],
+    patches: list[str],
+    nullified_properties: set[tuple[str, ...]],
+) -> object:
+    """Recursively strip `{"type":"null"}` branches from `oneOf`/`anyOf`.
+
+    After filtering, if only one branch remains the composition collapses
+    to that branch (merging any non-composition siblings like `description`).
+
+    When the stripped node lives under a `properties/<name>` parent, we record
+    `(parent_path_tuple, name)` so a second pass can drop the name from the
+    parent schema's `required` list — otherwise a field that was "required
+    but nullable" upstream collapses to "required and non-null," which breaks
+    decoding for historical records that legitimately send `null`.
+    """
+    if isinstance(node, dict):
+        for keyword in ("oneOf", "anyOf"):
+            branches = node.get(keyword)
+            if not isinstance(branches, list):
+                continue
+            filtered = [b for b in branches if not _is_null_branch(b)]
+            if len(filtered) == len(branches):
+                continue
+            patches.append("/".join(path) + f" ({keyword})")
+            if len(path) >= 2 and path[-2] == "properties":
+                parent_path = tuple(path[:-2])
+                nullified_properties.add(parent_path + (path[-1],))
+            siblings = {k: v for k, v in node.items() if k != keyword}
+            if len(filtered) == 1:
+                keep = filtered[0]
+                merged = {**siblings, **keep} if isinstance(keep, dict) else keep
+                return _strip_null_compositions(
+                    merged, path, patches, nullified_properties
+                )
+            return _strip_null_compositions(
+                {**siblings, keyword: filtered}, path, patches, nullified_properties
+            )
+        return {
+            k: _strip_null_compositions(v, path + [k], patches, nullified_properties)
+            for k, v in node.items()
+        }
+    if isinstance(node, list):
+        return [
+            _strip_null_compositions(
+                item, path + [str(i)], patches, nullified_properties
+            )
+            for i, item in enumerate(node)
+        ]
+    return node
+
+
+def _drop_nullified_required(
+    spec: dict, nullified: set[tuple[str, ...]]
+) -> list[str]:
+    """Remove nullified property names from their parent schema's `required`.
+
+    Returns a list of "<parent_path>.<field>" strings describing each removal.
+    """
+    removed: list[str] = []
+    for *parent_parts, name in sorted(nullified):
+        node: object = spec
+        for part in parent_parts:
+            if not isinstance(node, dict) or part not in node:
+                node = None
+                break
+            node = node[part]
+        if not isinstance(node, dict):
+            continue
+        required = node.get("required")
+        if isinstance(required, list) and name in required:
+            node["required"] = [r for r in required if r != name]
+            removed.append("/".join(parent_parts) + f".required[-{name}]")
+    return removed
+
+
+def _find_residual_null_compositions(node: object, path: list[str]) -> list[str]:
+    """Return paths where a `oneOf`/`anyOf` still contains a null branch."""
+    hits: list[str] = []
+    if isinstance(node, dict):
+        for keyword in ("oneOf", "anyOf"):
+            branches = node.get(keyword)
+            if isinstance(branches, list) and any(_is_null_branch(b) for b in branches):
+                hits.append("/".join(path) + f" ({keyword})")
+        for k, v in node.items():
+            hits.extend(_find_residual_null_compositions(v, path + [k]))
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            hits.extend(_find_residual_null_compositions(item, path + [str(i)]))
+    return hits
+
+
+def main() -> int:
+    print(f"Fetching {SPEC_URL}")
+    resp = requests.get(SPEC_URL, timeout=30)
+    resp.raise_for_status()
+    spec = resp.json()
+
+    version = spec.get("info", {}).get("version", "unknown")
+    print(f"Upstream version: {version}")
+
+    patches: list[str] = []
+    nullified: set[tuple[str, ...]] = set()
+    patched = _strip_null_compositions(spec, [], patches, nullified)
+
+    if patches:
+        print(f"Patched {len(patches)} null-branch composition(s):")
+        for p in patches:
+            print(f"  - {p}")
+    else:
+        print("No null-branch compositions found.")
+
+    required_removals = _drop_nullified_required(patched, nullified)
+    if required_removals:
+        print(f"Dropped {len(required_removals)} now-nullable field(s) from `required`:")
+        for r in required_removals:
+            print(f"  - {r}")
+
+    OUT_PATH.write_text(json.dumps(patched, indent=2) + "\n")
+    print(f"Wrote {OUT_PATH}")
+
+    residual = _find_residual_null_compositions(patched, [])
+    if residual:
+        print(
+            "ERROR: patched spec still contains `oneOf`/`anyOf` branches "
+            "with `{\"type\": \"null\"}` at:",
+            file=sys.stderr,
+        )
+        for r in residual:
+            print(f"  - {r}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIMatch+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIMatch+Helpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TBAAPI
 
-extension Match.CompLevelPayload {
+extension CompLevel {
 
     var sortOrder: Int {
         switch self {

--- a/the-blue-alliance-ios/ViewControllers/Base/Containers/ContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Containers/ContainerViewController.swift
@@ -138,7 +138,7 @@ class ContainerViewController: UIViewController, Alertable {
             for: .valueChanged
         )
 
-        if let navigationTitle = navigationTitle, let navigationSubtitle = navigationSubtitle {
+        if navigationTitle != nil || navigationSubtitle != nil {
             navigationTitleLabel.text = navigationTitle
             navigationSubtitleLabel.text = navigationSubtitle
             navigationItem.titleView = navigationStackView

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -197,8 +197,8 @@ class TeamViewController: HeaderContainerViewController {
     }
 
     private static func decodeAvatar(from media: Media?) -> UIImage? {
-        guard let base64 = media?.details?.additionalProperties.value["base64Image"] as? String,
-            let data = Data(base64Encoded: base64)
+        guard case let .case2(payload) = media?.details,
+            let data = Data(base64Encoded: payload.base64Image)
         else { return nil }
         return UIImage(data: data)
     }

--- a/the-blue-alliance-ios/ViewElements/Events/EventAllianceCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/EventAllianceCellViewModel.swift
@@ -19,10 +19,10 @@ struct EventAllianceCellViewModel {
 
     private static func allianceLevel(status: EliminationAlliance.StatusPayload?) -> String? {
         guard let level = status?.level else { return nil }
-        if level == "f", let s = status?.status {
-            return s == "won" ? "W" : "F"
+        if level == .f, let s = status?.status {
+            return s == .won ? "W" : "F"
         }
-        return level.uppercased()
+        return level.rawValue.uppercased()
     }
 
 }


### PR DESCRIPTION
## Summary

- Replaces hand-maintained spec refreshes with `scripts/update-apiv3-spec.py` (uv-runnable, pure Python w/ requests). Downloads the latest `api_v3.json` from prod and patches it for swift-openapi-generator compatibility.
- Refreshes `openapi.json` from v3.12.0 → v3.12.2.
- Fixes compile errors against the refreshed schema.
- Fixes an unrelated pre-existing bug where `ContainerViewController` wouldn't install its titleView when only the title (not subtitle) was set at init — visible on Team@Event screens where the subtitle is set async after the event fetch.

## Why the script exists

The current `swift-openapi-generator` (1.11.1, latest) does not support `{"type": "null"}` branches inside `oneOf`/`anyOf`. This is valid OpenAPI 3.1 (per JSON Schema 2020-12), and the upstream TBA swagger started using this shape in [tba#9263](https://github.com/the-blue-alliance/the-blue-alliance/pull/9263) to improve portability to other generators. The Swift generator bug is tracked at [apple/swift-openapi-generator#817](https://github.com/apple/swift-openapi-generator/issues/817) — maintainer [@czechboy0](https://github.com/czechboy0) explicitly recommends dropping the null branch as the workaround until a fix lands.

The script automates that: every `oneOf`/`anyOf: [X, {"type":"null"}]` is rewritten to just `X`, and any field that was `required` but newly nullable is removed from its parent schema's `required` list so the generator emits it as a Swift `Optional` (otherwise "required-but-nullable" collapses to "required-and-non-null," breaking decodes of historical payloads that legitimately send `null`).

It also includes a regression guard that fails loudly if upstream introduces a shape the script doesn't cover.

**Usage:** \`uv run scripts/update-apiv3-spec.py\`

## Compile-fix fallout

The v3.12.0→v3.12.2 refresh promoted several inline payloads to named component schemas and enum-typed some previously-string fields:

- \`Match.CompLevelPayload\` → named \`CompLevel\` component. Added typealias in \`TypeAliases.swift\`, retargeted \`APIMatch+Helpers\`.
- \`EliminationAlliance.StatusPayload.level\` is now \`CompLevel\` enum; \`.status\` is now a nested enum. \`EventAllianceCellViewModel\` comparisons updated from string literals to enum cases.
- \`Media.details\` is now a tagged-union \`oneOf\` of \`Case1Payload\` / \`Case2Payload\` / \`Case3Payload\`. \`TeamViewController.decodeAvatar\` switched to \`if case let .case2(payload) = ...\`.

## Bonus bug fix

\`ContainerViewController.init\` gated titleView installation on both \`navigationTitle != nil && navigationSubtitle != nil\`. Screens like \`TeamAtEventViewController\` pass the title at init and fill the subtitle in async after the event fetch — so the titleView was never installed and the nav bar stayed blank. Loosened the guard to "either non-nil."

## Test plan

- [x] \`uv run scripts/update-apiv3-spec.py\` succeeds, reports patched compositions and dropped required fields, no regression residuals
- [x] \`swift build\` inside \`Packages/TBAAPI/\` succeeds — generator produces \`TeamEventStatus.pitLocation\`, \`CompLevel\`, \`EliminationAlliance.StatusPayload.StatusPayload\`, \`Media.DetailsPayload\` cases
- [x] \`xcodebuild -scheme "The Blue Alliance" ... build\` succeeds
- [ ] Launch simulator, navigate Events → {recent event} → {team} — Team@Event nav bar now shows team number + event name/year
- [ ] Sanity check an event with alliance data — alliance status strings (W/F/picks) render correctly
- [ ] Sanity check a team with an avatar — avatar image loads on team detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)