### PR TITLE
Display pit locations on Team@Event and Event → Teams

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
@@ -23,6 +23,8 @@ public protocol TBAAPIProtocol {
     func teamEventStatus(teamKey: String, eventKey: String) async throws -> TeamEventStatus
     func teamMediaByYear(teamKey: String, year: Int) async throws -> [Media]
 
+    func eventTeamsStatuses(key eventKey: String) async throws -> [String: TeamEventStatus]
+
     // Events
     func eventsByYear(_ year: Int) async throws -> [Event]
     func event(key eventKey: String) async throws -> Event

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		5EC0D41A2C26041600000002 /* LegacyCoreDataCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041600000001 /* LegacyCoreDataCleanup.swift */; };
 		5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */; };
 		5EC0D41A2C26041700000002 /* APIEvent+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041700000001 /* APIEvent+Helpers.swift */; };
+		5EC0D41A2C2604FF00000002 /* APIEvent+Nexus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C2604FF00000001 /* APIEvent+Nexus.swift */; };
 		5EC0D41A2C26041700000004 /* WeekEventsGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041700000003 /* WeekEventsGrouping.swift */; };
 		5EC0D41A2C26041700000006 /* EventsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041700000005 /* EventsListViewController.swift */; };
 		5EC0D41A2C26041800000003 /* TBAAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041800000002 /* TBAAPIError.swift */; };
@@ -208,6 +209,7 @@
 		5EC0D41A2C26041600000001 /* LegacyCoreDataCleanup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCoreDataCleanup.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBALocalStore.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041700000001 /* APIEvent+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIEvent+Helpers.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C2604FF00000001 /* APIEvent+Nexus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIEvent+Nexus.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26041700000003 /* WeekEventsGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekEventsGrouping.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041700000005 /* EventsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsListViewController.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041800000002 /* TBAAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBAAPIError.swift; sourceTree = "<group>"; };
@@ -408,6 +410,7 @@
 			isa = PBXGroup;
 			children = (
 				5EC0D41A2C26041700000001 /* APIEvent+Helpers.swift */,
+				5EC0D41A2C2604FF00000001 /* APIEvent+Nexus.swift */,
 				5EC0D41A2C26041800000002 /* TBAAPIError.swift */,
 				5EC0D41A2C26041800000004 /* TBAAPI+Events.swift */,
 				5EC0D41A2C26041800000006 /* APIWebcast+Helpers.swift */,
@@ -1136,6 +1139,7 @@
 				5EC0D41A2C26041C00000004 /* TBAAPI+Search.swift in Sources */,
 				5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */,
 				5EC0D41A2C26041700000002 /* APIEvent+Helpers.swift in Sources */,
+				5EC0D41A2C2604FF00000002 /* APIEvent+Nexus.swift in Sources */,
 				5EC0D41A2C26041700000004 /* WeekEventsGrouping.swift in Sources */,
 				5EC0D41A2C26041700000006 /* EventsListViewController.swift in Sources */,
 				BA0000000000000000000002 /* EventSection.swift in Sources */,

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Nexus.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Nexus.swift
@@ -1,0 +1,8 @@
+import Foundation
+import TBAAPI
+
+extension Event {
+    func nexusTeamPitMapURL(teamNumber: Int) -> URL? {
+        URL(string: "https://frc.nexus/en/event/\(key)/team/\(teamNumber)/map")
+    }
+}

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift
@@ -151,6 +151,24 @@ extension TBAAPI {
         }
     }
 
+    public func eventTeamsStatuses(key eventKey: String) async throws -> [String: TeamEventStatus] {
+        let response = try await client.getEventTeamsStatuses(
+            path: .init(eventKey: eventKey)
+        )
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json.additionalProperties
+        case .notModified:
+            throw TBAAPIError.notModified
+        case .unauthorized:
+            throw TBAAPIError.unauthorized
+        case .notFound:
+            throw TBAAPIError.notFound
+        case .undocumented(let statusCode, _):
+            throw TBAAPIError.unexpectedStatus(statusCode)
+        }
+    }
+
     public func teamMediaByYear(teamKey: String, year: Int) async throws -> [Media] {
         let response = try await client.getTeamMediaByYear(
             path: .init(teamKey: teamKey, year: year)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift
@@ -5,6 +5,8 @@ class EventTeamsViewController: TeamsListViewController<Team> {
 
     let eventKey: String
 
+    private var pitLocations: [String: String] = [:]
+
     // MARK: Init
 
     init(eventKey: String, dependencies: Dependencies) {
@@ -18,7 +20,18 @@ class EventTeamsViewController: TeamsListViewController<Team> {
     }
 
     override func loadTeams() async throws -> [Team] {
-        try await dependencies.api.eventTeams(key: eventKey)
+        async let teams = dependencies.api.eventTeams(key: eventKey)
+        async let statuses = try? dependencies.api.eventTeamsStatuses(key: eventKey)
+
+        let loadedTeams = try await teams
+        let loadedStatuses = await statuses ?? [:]
+
+        pitLocations = loadedStatuses.compactMapValues { $0.pitLocation }
+        return loadedTeams
+    }
+
+    override func numberSubtitle(for team: Team) -> String? {
+        pitLocations[team.key].map { "Pit \($0)" }
     }
 
     override var noDataText: String? { "No teams for event" }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -9,6 +9,7 @@ protocol TeamSummaryViewControllerDelegate: AnyObject {
 
 private enum TeamSummarySection: Int {
     case teamInfo
+    case pitLocation
     case eventInfo
     case nextMatch
     case lastMatch
@@ -18,6 +19,7 @@ private enum TeamSummarySection: Int {
 
 private enum TeamSummaryItem: Hashable {
     case teamInfo(team: Team)
+    case pitLocation(location: String)
     case status(status: String)
     case rank(rank: Int, total: Int)
     case record(wins: Int, losses: Int, ties: Int, dqs: Int? = nil)
@@ -76,6 +78,16 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
                 switch item {
                 case .teamInfo(let team):
                     return self.cellForTeam(team, in: tableView, at: indexPath)
+                case .pitLocation(let location):
+                    let cell = Self.reverseSubtitleCell(
+                        in: tableView,
+                        title: "Pit Location",
+                        subtitle: "\(location) · via FRC Nexus",
+                        at: indexPath
+                    )
+                    cell.accessoryType = .disclosureIndicator
+                    cell.selectionStyle = .default
+                    return cell
                 case .status(let status):
                     return Self.reverseSubtitleCell(
                         in: tableView,
@@ -144,6 +156,12 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
         if let team {
             snapshot.appendSections([.teamInfo])
             snapshot.appendItems([.teamInfo(team: team)], toSection: .teamInfo)
+        }
+
+        // Pit location
+        if let pit = eventStatus?.pitLocation, !pit.isEmpty {
+            snapshot.appendSections([.pitLocation])
+            snapshot.appendItems([.pitLocation(location: pit)], toSection: .pitLocation)
         }
 
         // Status summary
@@ -345,12 +363,21 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: - Table View Delegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
         switch item {
         case .teamInfo:
             delegate?.teamInfoSelected(teamKey: teamKey)
         case .match(let match, _):
             delegate?.matchSelected(matchKey: match.key)
+        case .pitLocation:
+            guard let event,
+                let teamNumber = team?.teamNumber,
+                let url = event.nexusTeamPitMapURL(teamNumber: teamNumber),
+                urlOpener.canOpenURL(url)
+            else { return }
+            urlOpener.open(url, options: [:], completionHandler: nil)
         default:
             break
         }

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -49,6 +49,8 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
 
     func filter(_ teams: [APITeam]) -> [APITeam] { teams }
 
+    func numberSubtitle(for team: APITeam) -> String? { nil }
+
     // MARK: - Data Source
 
     private func setupDataSource() {
@@ -60,7 +62,8 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
             cell.viewModel = TeamCellViewModel(
                 teamNumber: "\(team.teamNumber)",
                 nickname: team.displayNickname,
-                location: team.locationString
+                location: team.locationString,
+                numberSubtitle: self.numberSubtitle(for: team)
             )
             cell.accessibilityIdentifier = "team.\(team.key)"
             return cell

--- a/the-blue-alliance-ios/ViewElements/Teams/TeamCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamCellViewModel.swift
@@ -5,11 +5,18 @@ struct TeamCellViewModel {
     let teamNumber: String
     let nickname: String
     let location: String?
+    let numberSubtitle: String?
 
-    init(teamNumber: String, nickname: String, location: String?) {
+    init(
+        teamNumber: String,
+        nickname: String,
+        location: String?,
+        numberSubtitle: String? = nil
+    ) {
         self.teamNumber = teamNumber
         self.nickname = nickname
         self.location = location
+        self.numberSubtitle = numberSubtitle
     }
 
 }

--- a/the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.swift
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.swift
@@ -18,6 +18,7 @@ class TeamTableViewCell: UITableViewCell, Reusable {
     // MARK: - Interface Builder
 
     @IBOutlet private weak var numberLabel: UILabel!
+    @IBOutlet private weak var numberSubtitleLabel: UILabel!
     @IBOutlet private weak var nameLabel: UILabel!
     @IBOutlet private weak var locationLabel: UILabel!
 
@@ -31,5 +32,9 @@ class TeamTableViewCell: UITableViewCell, Reusable {
         numberLabel.text = viewModel.teamNumber
         nameLabel.text = viewModel.nickname
         locationLabel.text = viewModel.location
+
+        let subtitle = viewModel.numberSubtitle?.isEmpty == false ? viewModel.numberSubtitle : nil
+        numberSubtitleLabel.text = subtitle
+        numberSubtitleLabel.isHidden = subtitle == nil
     }
 }

--- a/the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.xib
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.xib
@@ -22,15 +22,26 @@
                             <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="QYQ-jO-saV">
                                 <rect key="frame" x="0.0" y="0.0" width="324.66666666666669" height="54"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="10000" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxL-kB-K0K">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="pit-VS-001">
                                         <rect key="frame" x="0.0" y="0.0" width="55" height="54"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="10000" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxL-kB-K0K">
+                                                <rect key="frame" x="0.0" y="0.0" width="55" height="37"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="750" text="Pit A1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pit-LB-001">
+                                                <rect key="frame" x="0.0" y="37" width="55" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="55" id="eAG-vi-jop"/>
                                         </constraints>
-                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6eP-Ga-gQh">
                                         <rect key="frame" x="69.999999999999986" y="0.0" width="254.66666666666663" height="54"/>
                                         <subviews>
@@ -64,6 +75,7 @@
                 <outlet property="locationLabel" destination="Ana-Js-nEd" id="JDn-0C-7yo"/>
                 <outlet property="nameLabel" destination="5pm-5N-rYU" id="g6B-eW-e1b"/>
                 <outlet property="numberLabel" destination="vxL-kB-K0K" id="ISd-rw-rp5"/>
+                <outlet property="numberSubtitleLabel" destination="pit-LB-001" id="pit-CO-001"/>
             </connections>
             <point key="canvasLocation" x="-72.799999999999997" y="15.292353823088456"/>
         </tableViewCell>


### PR DESCRIPTION
## Summary

Brings iOS to parity with the website, PWA, and Android for FRC Nexus pit locations. Two UI touchpoints, driven by the nullable \`pit_location\` string on \`Team_Event_Status\` (APIv3 3.12.x):

1. **Team@Event Summary**: tappable "Pit Location" row between team info and the event summary. Subtitle is the pit code (e.g. \`A1\`) with "via FRC Nexus" attribution. Tapping opens \`https://frc.nexus/en/event/{eventKey}/team/{teamNumber}/map\` in Safari via the existing \`urlOpener\`.
2. **Event → Teams tab**: each team row gets a new line under the team number showing \`Pit X\` in secondary-label gray, matching Android's placement. The number slot is now a vertical stack — the label is hidden when the team has no pit data, so rows without data look identical to before.

## Architecture

- URL helper lives on \`Event\` itself: \`event.nexusTeamPitMapURL(teamNumber:)\`. The event already knows its own key, so callers don't thread it through.
- New bulk API helper \`TBAAPI.eventTeamsStatuses(key:)\` wraps \`GET /event/{event_key}/teams/statuses\` → \`[String: TeamEventStatus]\`. Added to \`TBAAPIProtocol\` for use through \`any TBAAPIProtocol\`.
- Generic \`TeamsListViewController\` gained an overridable \`numberSubtitle(for team:)\` hook (default \`nil\`). Every other subclass of this VC is untouched — \`EventTeamsViewController\` opts in.
- \`EventTeamsViewController.loadTeams()\` runs teams + statuses in parallel via \`async let\`. Pit fetch failures are swallowed (\`try?\`) so teams still render if the statuses endpoint 404s for a not-yet-run event.

## Visibility

Follows Android's pattern: show whenever \`pit_location\` is non-nil. The legacy web gates on \`official AND (future OR within_a_day)\`; the PWA, Android, and this PR don't. Nexus keeps historical pit snapshots so showing them on past events isn't misleading.

## Dependencies

**Stacked on #1037** — this PR's branch is based on \`chore/refresh-openapi-spec-v3.12.2\` (which adds \`pit_location\` to the generated \`TeamEventStatus\`). The diff shown here currently includes #1037's commit; once #1037 merges, I'll rebase this onto main and the diff will narrow to only the pit-specific files listed below.

**Pit-specific files (what changes once rebased):**
- \`the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Nexus.swift\` (new)
- \`the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift\`
- \`the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift\`
- \`the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift\`
- \`the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift\`
- \`the-blue-alliance-ios/ViewElements/Teams/TeamCellViewModel.swift\`
- \`the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.swift\`
- \`the-blue-alliance-ios/ViewElements/Teams/TeamTableViewCell.xib\`
- \`Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift\`
- \`the-blue-alliance-ios.xcodeproj/project.pbxproj\`

## Test plan

- [ ] \`xcodebuild\` succeeds on this branch
- [ ] In simulator, navigate Events → {current in-season event with Nexus data} → any team at that event
  - [ ] \"Pit Location\" row appears under the team info with the pit code
  - [ ] Tapping the row opens \`frc.nexus/.../team/<number>/map\` in Safari and the row deselects
- [ ] Same event → Teams tab
  - [ ] Team rows with pit data show \`Pit X\` beneath the team number
  - [ ] Team rows without pit data look identical to prior behavior (no gap, no extra spacing)
- [ ] Navigate to a historical event (no pit data) — neither the row nor the subtitle appears
- [ ] Navigate elsewhere (search, district teams list) — team rows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)