### PR TITLE
Fix crash when changing year on Team media tab

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -211,7 +211,9 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         }
         dataSource = CollectionViewDataSource<String, TeamMediaItem>(collectionView: collectionView)
         {
-            collectionView, indexPath, item in
+            collectionView,
+            indexPath,
+            item in
             return collectionView.dequeueConfiguredReusableCell(
                 using: cellRegistration,
                 for: indexPath,

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -41,21 +41,6 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
     private var imageErrors: [String: Error] = [:]
     private var downloadTasks: [String: Task<Void, Never>] = [:]
 
-    private lazy var cellRegistration = UICollectionView.CellRegistration<
-        MediaCollectionViewCell, TeamMediaItem
-    > {
-        [weak self] cell, _, item in
-        guard let self else { return }
-        if let image = self.imageCache[item.foreignKey] {
-            cell.state = .loaded(image)
-        } else if let error = self.imageErrors[item.foreignKey] {
-            cell.state = .error("Error loading media - \(error.localizedDescription)")
-        } else {
-            cell.state = .loading
-        }
-        cell.accessibilityIdentifier = "media.\(item.foreignKey)"
-    }
-
     // MARK: Init
 
     init(
@@ -210,12 +195,25 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
     // MARK: Data Source
 
     private func setupDataSource() {
+        let cellRegistration = UICollectionView.CellRegistration<
+            MediaCollectionViewCell, TeamMediaItem
+        > {
+            [weak self] cell, _, item in
+            guard let self else { return }
+            if let image = self.imageCache[item.foreignKey] {
+                cell.state = .loaded(image)
+            } else if let error = self.imageErrors[item.foreignKey] {
+                cell.state = .error("Error loading media - \(error.localizedDescription)")
+            } else {
+                cell.state = .loading
+            }
+            cell.accessibilityIdentifier = "media.\(item.foreignKey)"
+        }
         dataSource = CollectionViewDataSource<String, TeamMediaItem>(collectionView: collectionView)
         {
-            [weak self] collectionView, indexPath, item in
-            guard let self else { return UICollectionViewCell() }
+            collectionView, indexPath, item in
             return collectionView.dequeueConfiguredReusableCell(
-                using: self.cellRegistration,
+                using: cellRegistration,
                 for: indexPath,
                 item: item
             )


### PR DESCRIPTION
## Summary
- `TeamMediaCollectionViewController`'s `cellRegistration` was a `lazy var`, so its first access — and therefore its initialization — happened inside the diffable data source's cell provider closure.
- UIKit detects registrations created during cell-provider invocation and throws `NSInternalInconsistencyException`. Changing the year triggered a reload → cell provider → lazy init → crash.
- Move the registration into `setupDataSource()` as a local `let` captured by the provider closure, so it's built up front in `viewDidLoad` before any cell is requested. `[weak self]` capture on the registration's config closure is preserved to avoid the `self → dataSource → registration → self` cycle.

## Test plan
- [ ] Open a team detail screen → Media tab.
- [ ] Change the year via the year selector; verify no crash and media loads for the new year.
- [ ] Cycle through several years in a row; verify no crash and correct media per year.
- [ ] Verify images still load, error states still render, and cell reuse looks correct on scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)