### PR TITLE
Curate TestFlight/Slack/GitHub release notes from a file

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,9 +27,6 @@ jobs:
           xcode-version: latest-stable
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
       - uses: actions/cache@v4
         with:
           path: vendor/bundle

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -196,10 +196,7 @@ platform :ios do
   end
 
   private_lane :commit_changelog do
-    changelog_from_git_commits(
-      pretty: "%s",
-      merge_commit_filtering: "exclude_merges"
-    )
+    File.read("metadata/release_notes/beta.md").strip
   end
 
   ## End Internal Lanes for Shipping Lanes ##

--- a/fastlane/metadata/release_notes/beta.md
+++ b/fastlane/metadata/release_notes/beta.md
@@ -1,0 +1,19 @@
+The Blue Alliance v3.3.0
+
+What's new:
+- Refreshed Liquid Glass app icon for iOS 26
+- Pit locations now show on Team@Event and Event → Teams screens, so you can find teams on the venue floor
+- 2026 Insights with an updated layout
+- District Championship events on the Week view now group by district (parent + divisions together), matching the Android app's sort
+- Team@Event Summary places Next Match and Most Recent Match side-by-side instead of splitting them across the screen
+- New Settings → Networking section with a cache policy toggle
+- New Settings → Privacy toggles to opt out of Firebase Analytics and Crashlytics
+
+Bug fixes:
+- Fixed a crash when changing the year on the Team Media tab
+- Corrected timezone handling across event date math — event date ranges, today-ending events in the Week picker, and related date-driven UI now use the event's own calendar day rather than the device's local timezone
+- Row spacing adjusted so 5-digit team numbers fit
+
+Under the hood:
+- Migrated off Core Data, upgraded Firebase to 12.12.1, adopted UISceneDelegate, and a range of iOS API modernizations
+- Refreshed to the latest TBA API schema (v3.12.2)


### PR DESCRIPTION
## Summary
- Replace the git-log changelog in fastlane's `commit_changelog` lane with a single curated file at `fastlane/metadata/release_notes/beta.md`. This is the input for TestFlight's "What to Test", the #app-releases Slack post, and the GitHub release body — testers now see human-readable notes instead of engineer-facing commit subjects.
- Revert #1026's `fetch-depth: 0` / `fetch-tags: true` on the push workflow, since the changelog no longer depends on tag history.
- Seed `beta.md` with the v3.3.0 beta notes for tonight's build.

## Test plan
- [ ] On the next `[beta]` push, confirm TestFlight's "What to Test" matches `fastlane/metadata/release_notes/beta.md` verbatim.
- [ ] Confirm the #github-ios / #app-releases Slack posts show the same notes.
- [ ] Confirm CI wall-clock time on `main` pushes drops back to pre-#1026 levels from the shallower checkout.
- [ ] Before the next `[app_store]` push, update `beta.md` to the final release notes so the GitHub release body matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)