### PR TITLE
Further CI speedups: fix cache key, wholemodule, skip indexing

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,13 +29,11 @@ jobs:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
-      - name: Cache SwiftPM + DerivedData
+      - name: Cache SwiftPM clones
         uses: actions/cache@v4
         with:
-          path: |
-            ~/Library/Developer/Xcode/DerivedData
-            ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved', '**/Package.swift', '**/*.pbxproj') }}
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
           restore-keys: ${{ runner.os }}-spm-
       - name: Install
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,13 +32,11 @@ jobs:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
-      - name: Cache SwiftPM + DerivedData
+      - name: Cache SwiftPM clones
         uses: actions/cache@v4
         with:
-          path: |
-            ~/Library/Developer/Xcode/DerivedData
-            ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved', '**/Package.swift', '**/*.pbxproj') }}
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
           restore-keys: ${{ runner.os }}-spm-
       - name: Install
         run: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,7 +32,9 @@ platform :ios do
       scheme: "The Blue Alliance",
       only_testing: ["TBAUnitTests"],
       destination: "platform=iOS Simulator,id=#{iphone["udid"]}",
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation " \
+              "SWIFT_COMPILATION_MODE=wholemodule " \
+              "COMPILER_INDEX_STORE_ENABLE=NO"
     )
   end
 


### PR DESCRIPTION
Follow-up to #1046 and #1045, based on what CI run 24704426446 showed us (cache restore/save keys mismatched, DerivedData cache unused, ~1,800 compile lines, 482 s in \`run_tests\`).

## Summary

- **Cache key**: drop \`**/Package.resolved\` from \`hashFiles\`. It's gitignored, so it didn't exist at cache-restore time but did at save time — every save got a unique key, every restore fell back to the \`macOS-spm-\` prefix and grabbed some older cache.
- **Cache path**: narrow to \`~/Library/Caches/org.swift.swiftpm\` (the shared SPM clone cache). DerivedData caching was effectively a no-op — \`git checkout\` resets source mtimes, so Xcode rebuilt everything even on a cache hit. This keeps the useful bit (no re-clone / re-fetch of SPM deps) and drops the noise.
- **xcargs \`SWIFT_COMPILATION_MODE=wholemodule\`**: scoped to the CI test lane via xcargs only; local Xcode keeps incremental. CI always does clean compiles, where wholemodule is typically 20-40% faster.
- **xcargs \`COMPILER_INDEX_STORE_ENABLE=NO\`**: the index store powers Jump to Definition / Find Usages / Quick Help in Xcode. CI never opens Xcode, so it's pure waste.

## Test plan

- [x] Local \`bundle exec fastlane test\` passes with the new xcargs (62 s in \`run_tests\` on warm caches).
- [ ] CI \`Test\` job wall-clock drops vs the ~510 s baseline on #1045's last run.
- [ ] Warm-cache second run: \`Cache SwiftPM clones\` step reports a hit; \`run_tests\` drops further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)