### PR TITLE
Add support for modern playoff types and alliance badges

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/APIEvent+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/APIEvent+Helpers.swift
@@ -165,3 +165,7 @@ extension Event {
         return "\(shortFormatter.string(from: start)) to \(longFormatter.string(from: end))"
     }
 }
+
+extension Event {
+    public var playoffTypeEnum: PlayoffType? { playoffType }
+}

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/PlayoffType+Display.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/PlayoffType+Display.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+extension PlayoffType {
+
+    public var isBracket: Bool {
+        switch kind {
+        case .bracket2Team, .bracket4Team, .bracket8Team, .bracket16Team:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public var isDoubleElim: Bool {
+        switch kind {
+        case .legacyDoubleElim8Team, .doubleElim8Team, .doubleElim4Team:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public var isRoundRobin: Bool { kind == .roundRobin6Team }
+
+    public var isFinalsOnly: Bool {
+        kind == .bo3Finals || kind == .bo5Finals
+    }
+
+    // Human-readable name, verbatim from TBA's TYPE_NAMES.
+    public var displayName: String {
+        switch kind {
+        case .bracket8Team: return "Elimination Bracket (8 Alliances)"
+        case .bracket16Team: return "Elimination Bracket (16 Alliances)"
+        case .bracket4Team: return "Elimination Bracket (4 Alliances)"
+        case .bracket2Team: return "Elimination Bracket (2 Alliances)"
+        case .averageScore8Team: return "Average Score (8 Alliances)"
+        case .roundRobin6Team: return "Round Robin (6 Alliances)"
+        case .doubleElim8Team: return "Double Elimination Bracket (8 Alliances)"
+        case .doubleElim4Team: return "Double Elimination Bracket (4 Alliances)"
+        case .legacyDoubleElim8Team: return "Legacy Double Elimination Bracket (8 Alliances)"
+        case .bo3Finals: return "Best of 3 Finals"
+        case .bo5Finals: return "Best of 5 Finals"
+        case .custom: return "Custom"
+        }
+    }
+}
+
+extension DoubleElimRound {
+
+    // The raw string already reads "Round 1", "Finals", etc.
+    public var title: String { rawValue }
+
+    public var sortOrder: Int {
+        switch self {
+        case .round1: return 0
+        case .round2: return 1
+        case .round3: return 2
+        case .round4: return 3
+        case .round5: return 4
+        case .finals: return 5
+        }
+    }
+}
+
+extension LegacyDoubleElimBracket {
+
+    public var title: String {
+        switch self {
+        case .winner: return "Upper Bracket"
+        case .loser: return "Lower Bracket"
+        }
+    }
+
+    public var sortOrder: Int {
+        switch self {
+        case .winner: return 0
+        case .loser: return 1
+        }
+    }
+}

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/PlayoffType+Kind.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/PlayoffType+Kind.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// The OpenAPI-generated `PlayoffType` has raw integer cases (`_0`, `_1`, …,
+// `_11`) because `namingStrategy: idiomatic` doesn't honor `x-enum-varnames`
+// on integer enums. `Kind` gives callers a readable enum to switch over
+// without scattering magic integer names across the codebase.
+extension PlayoffType {
+
+    public enum Kind: Hashable, Sendable, CaseIterable {
+        case bracket8Team
+        case bracket16Team
+        case bracket4Team
+        case bracket2Team
+        case averageScore8Team
+        case roundRobin6Team
+        case legacyDoubleElim8Team
+        case doubleElim8Team
+        case doubleElim4Team
+        case bo5Finals
+        case bo3Finals
+        case custom
+    }
+
+    public var kind: Kind {
+        switch self {
+        case ._0: return .bracket8Team
+        case ._1: return .bracket16Team
+        case ._2: return .bracket4Team
+        case ._9: return .bracket2Team
+        case ._3: return .averageScore8Team
+        case ._4: return .roundRobin6Team
+        case ._5: return .legacyDoubleElim8Team
+        case ._10: return .doubleElim8Team
+        case ._11: return .doubleElim4Team
+        case ._6: return .bo5Finals
+        case ._7: return .bo3Finals
+        case ._8: return .custom
+        }
+    }
+
+    // Named accessors mirroring `Kind`'s cases for use at call sites
+    // (`event.playoffType == .roundRobin6Team`). Switch statements still need
+    // `.kind` since static lets aren't pattern-matchable.
+    public static let bracket8Team: PlayoffType = ._0
+    public static let bracket16Team: PlayoffType = ._1
+    public static let bracket4Team: PlayoffType = ._2
+    public static let bracket2Team: PlayoffType = ._9
+    public static let averageScore8Team: PlayoffType = ._3
+    public static let roundRobin6Team: PlayoffType = ._4
+    public static let legacyDoubleElim8Team: PlayoffType = ._5
+    public static let doubleElim8Team: PlayoffType = ._10
+    public static let doubleElim4Team: PlayoffType = ._11
+    public static let bo5Finals: PlayoffType = ._6
+    public static let bo3Finals: PlayoffType = ._7
+    public static let custom: PlayoffType = ._8
+}

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/PlayoffTypeHelper.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/PlayoffTypeHelper.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+// Pure match → round mapping for playoff formats. Ported from
+// https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/helpers/playoff_type_helper.py.
+//
+// Note: `EliminationAlliance.status.doubleElimRound` tells us where an
+// *alliance* stands today, not which round a given *match* belongs to —
+// that's why we still need these per-match helpers.
+public enum PlayoffTypeHelper {
+
+    // FIRST's 2023+ 8-team double elimination. Every pre-finals match is
+    // stored as `sf` with set 1..13; finals are BO3 stored as `f` set 1
+    // matches 1..3.
+    public static func doubleElimRound(compLevel: CompLevel, setNumber: Int) -> DoubleElimRound {
+        if compLevel == .f { return .finals }
+        switch setNumber {
+        case ...4: return .round1
+        case ...8: return .round2
+        case ...10: return .round3
+        case ...12: return .round4
+        default: return .round5
+        }
+    }
+
+    // 4-team double elimination (districts w/ divisions). 5 pre-finals `sf`
+    // sets (each match_number 1), then BO3 finals as `f` set 1 matches 1..3.
+    public static func doubleElim4Round(compLevel: CompLevel, setNumber: Int) -> DoubleElimRound {
+        if compLevel == .f { return .finals }
+        switch setNumber {
+        case ...2: return .round1
+        case ...4: return .round2
+        default: return .round3
+        }
+    }
+
+    // Pre-2023 8-team double elimination. Keyed by (level, set) across ef/qf/sf/f.
+    // This is the format where matches of the same comp level split across
+    // the upper and lower brackets.
+    public static func legacyDoubleElimRound(compLevel: CompLevel, setNumber: Int)
+        -> DoubleElimRound
+    {
+        switch (compLevel, setNumber) {
+        case (.ef, let s) where s <= 4: return .round1
+        case (.ef, _): return .round2
+        case (.qf, let s) where s <= 2: return .round2
+        case (.qf, _): return .round3
+        case (.sf, _): return .round4
+        case (.f, 1): return .round5
+        default: return .finals
+        }
+    }
+
+    // Legacy 8-team double elim: which side of the bracket a given match lives in.
+    // In the legacy layout, `f` set 1 is the lower-bracket final; `f` set 2 is the
+    // overall final.
+    public static func legacyDoubleElimBracket(compLevel: CompLevel, setNumber: Int)
+        -> LegacyDoubleElimBracket
+    {
+        switch (compLevel, setNumber) {
+        case (.ef, let s) where s <= 4: return .winner
+        case (.ef, _): return .loser
+        case (.qf, let s) where s <= 2: return .winner
+        case (.qf, _): return .loser
+        case (.sf, 1): return .winner
+        case (.sf, _): return .loser
+        case (.f, 1): return .loser
+        default: return .winner
+        }
+    }
+
+}
+
+public enum LegacyDoubleElimBracket: String, Hashable, Sendable {
+    case winner
+    case loser
+}

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Matches/APIMatch+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Matches/APIMatch+Helpers.swift
@@ -54,6 +54,8 @@ extension Match {
         case .doubleElim8Team, .doubleElim4Team:
             if compLevel == .f { return "Finals \(matchNumber)" }
             return "Match \(setNumber)"
+        case .averageScore8Team:
+            return "\(compLevel.levelShort) \(matchNumber)"
         case .bo3Finals, .bo5Finals:
             return "Finals \(matchNumber)"
         default:

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Matches/APIMatch+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Matches/APIMatch+Helpers.swift
@@ -15,7 +15,7 @@ extension CompLevel {
     public var level: String {
         switch self {
         case .qm: return "Qualification"
-        case .ef: return "Octofinals"
+        case .ef: return "Eighth-Finals"
         case .qf: return "Quarterfinals"
         case .sf: return "Semifinals"
         case .f: return "Finals"
@@ -39,11 +39,26 @@ extension Match {
 
     public var compLevelSortOrder: Int { compLevel.sortOrder }
 
-    public var friendlyName: String {
+    // Round robin prelims and 2023+ double elim pre-finals are both stored
+    // as `sf` (round robin sets match_number 1..15; double elim sets
+    // set_number 1..13 with match_number 1) — so "Semis N-M" is misleading
+    // for those formats. Finals are `f` for both.
+    public func friendlyName(playoffType: PlayoffType?) -> String {
         if compLevel == .qm {
             return "\(compLevel.levelShort) \(matchNumber)"
         }
-        return "\(compLevel.levelShort) \(setNumber)-\(matchNumber)"
+        switch playoffType?.kind {
+        case .roundRobin6Team:
+            if compLevel == .f { return "Finals \(matchNumber)" }
+            return "Match \(matchNumber)"
+        case .doubleElim8Team, .doubleElim4Team:
+            if compLevel == .f { return "Finals \(matchNumber)" }
+            return "Match \(setNumber)"
+        case .bo3Finals, .bo5Finals:
+            return "Finals \(matchNumber)"
+        default:
+            return "\(compLevel.levelShort) \(setNumber)-\(matchNumber)"
+        }
     }
 
     public var redAllianceTeamKeys: [String] { alliances.red.teamKeys }

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Events/PlayoffTypeHelperTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Events/PlayoffTypeHelperTests.swift
@@ -1,0 +1,109 @@
+import Testing
+@testable import TBAAPI
+
+struct PlayoffTypeHelperTests {
+
+    // MARK: - Double Elim 8 (2023+)
+
+    @Test func doubleElim8_firstFourSemisAreRound1() {
+        for set in 1...4 {
+            #expect(PlayoffTypeHelper.doubleElimRound(compLevel: .sf, setNumber: set) == .round1)
+        }
+    }
+
+    @Test func doubleElim8_sets5to8AreRound2() {
+        for set in 5...8 {
+            #expect(PlayoffTypeHelper.doubleElimRound(compLevel: .sf, setNumber: set) == .round2)
+        }
+    }
+
+    @Test func doubleElim8_sets9to10AreRound3() {
+        #expect(PlayoffTypeHelper.doubleElimRound(compLevel: .sf, setNumber: 9) == .round3)
+        #expect(PlayoffTypeHelper.doubleElimRound(compLevel: .sf, setNumber: 10) == .round3)
+    }
+
+    @Test func doubleElim8_sets11to12AreRound4() {
+        #expect(PlayoffTypeHelper.doubleElimRound(compLevel: .sf, setNumber: 11) == .round4)
+        #expect(PlayoffTypeHelper.doubleElimRound(compLevel: .sf, setNumber: 12) == .round4)
+    }
+
+    @Test func doubleElim8_set13IsRound5() {
+        #expect(PlayoffTypeHelper.doubleElimRound(compLevel: .sf, setNumber: 13) == .round5)
+    }
+
+    @Test func doubleElim8_finalsCompLevelAlwaysFinals() {
+        for match in 1...6 {
+            #expect(PlayoffTypeHelper.doubleElimRound(compLevel: .f, setNumber: match) == .finals)
+        }
+    }
+
+    // MARK: - Double Elim 4
+
+    @Test func doubleElim4_firstTwoSetsAreRound1() {
+        #expect(PlayoffTypeHelper.doubleElim4Round(compLevel: .sf, setNumber: 1) == .round1)
+        #expect(PlayoffTypeHelper.doubleElim4Round(compLevel: .sf, setNumber: 2) == .round1)
+    }
+
+    @Test func doubleElim4_sets3to4AreRound2() {
+        #expect(PlayoffTypeHelper.doubleElim4Round(compLevel: .sf, setNumber: 3) == .round2)
+        #expect(PlayoffTypeHelper.doubleElim4Round(compLevel: .sf, setNumber: 4) == .round2)
+    }
+
+    @Test func doubleElim4_set5IsRound3() {
+        #expect(PlayoffTypeHelper.doubleElim4Round(compLevel: .sf, setNumber: 5) == .round3)
+    }
+
+    @Test func doubleElim4_finals() {
+        #expect(PlayoffTypeHelper.doubleElim4Round(compLevel: .f, setNumber: 1) == .finals)
+    }
+
+    // MARK: - Legacy Double Elim 8
+
+    @Test func legacyDE8_efSets1to4AreRound1() {
+        for set in 1...4 {
+            #expect(
+                PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .ef, setNumber: set) == .round1
+            )
+        }
+    }
+
+    @Test func legacyDE8_efSets5to6AreRound2() {
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .ef, setNumber: 5) == .round2)
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .ef, setNumber: 6) == .round2)
+    }
+
+    @Test func legacyDE8_qfSets1to2AreRound2_andSets3to4AreRound3() {
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .qf, setNumber: 1) == .round2)
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .qf, setNumber: 2) == .round2)
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .qf, setNumber: 3) == .round3)
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .qf, setNumber: 4) == .round3)
+    }
+
+    @Test func legacyDE8_sfIsRound4() {
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .sf, setNumber: 1) == .round4)
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .sf, setNumber: 2) == .round4)
+    }
+
+    @Test func legacyDE8_fSet1IsRound5_thenFinals() {
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .f, setNumber: 1) == .round5)
+        #expect(PlayoffTypeHelper.legacyDoubleElimRound(compLevel: .f, setNumber: 2) == .finals)
+    }
+
+    @Test func legacyDE8_bracketSplit() {
+        // ef 1..4 = upper; ef 5..6 = lower
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .ef, setNumber: 1) == .winner)
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .ef, setNumber: 4) == .winner)
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .ef, setNumber: 5) == .loser)
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .ef, setNumber: 6) == .loser)
+        // qf 1..2 = upper; qf 3..4 = lower
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .qf, setNumber: 2) == .winner)
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .qf, setNumber: 3) == .loser)
+        // sf 1 = upper; sf 2 = lower
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .sf, setNumber: 1) == .winner)
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .sf, setNumber: 2) == .loser)
+        // f 1 = lower-bracket final; f 2 = overall final (upper side)
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .f, setNumber: 1) == .loser)
+        #expect(PlayoffTypeHelper.legacyDoubleElimBracket(compLevel: .f, setNumber: 2) == .winner)
+    }
+
+}

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Matches/APIMatch+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Matches/APIMatch+HelpersTests.swift
@@ -89,6 +89,18 @@ struct APIMatchHelpersTests {
         #expect(match.friendlyName(playoffType: .bo5Finals) == "Finals 4")
     }
 
+    @Test func friendlyName_averageScore8Quarters() {
+        // 2015's avg-score format keeps set=1 and runs match_number across
+        // the whole comp_level (e.g. qf1m1..qf1m8).
+        let match = makeMatch(compLevel: .qf, setNumber: 1, matchNumber: 7)
+        #expect(match.friendlyName(playoffType: .averageScore8Team) == "Quarters 7")
+    }
+
+    @Test func friendlyName_averageScore8Finals() {
+        let match = makeMatch(compLevel: .f, setNumber: 1, matchNumber: 2)
+        #expect(match.friendlyName(playoffType: .averageScore8Team) == "Finals 2")
+    }
+
     // MARK: - startTime priority (actual > predicted > scheduled)
 
     @Test func startTime_prefersActual() {

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Matches/APIMatch+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Matches/APIMatch+HelpersTests.swift
@@ -16,7 +16,7 @@ struct APIMatchHelpersTests {
 
     @Test func compLevel_level() {
         #expect(CompLevel.qm.level == "Qualification")
-        #expect(CompLevel.ef.level == "Octofinals")
+        #expect(CompLevel.ef.level == "Eighth-Finals")
         #expect(CompLevel.qf.level == "Quarterfinals")
         #expect(CompLevel.sf.level == "Semifinals")
         #expect(CompLevel.f.level == "Finals")
@@ -46,12 +46,47 @@ struct APIMatchHelpersTests {
 
     @Test func friendlyName_qualification() {
         let match = makeMatch(compLevel: .qm, setNumber: 1, matchNumber: 73)
-        #expect(match.friendlyName == "Quals 73")
+        #expect(match.friendlyName(playoffType: nil) == "Quals 73")
     }
 
     @Test func friendlyName_elimination() {
         let match = makeMatch(compLevel: .ef, setNumber: 2, matchNumber: 73)
-        #expect(match.friendlyName == "Eighths 2-73")
+        #expect(match.friendlyName(playoffType: nil) == "Eighths 2-73")
+    }
+
+    @Test func friendlyName_roundRobinSemifinals() {
+        // RR prelims are stored as `sf` with set 1, match 1..15.
+        let match = makeMatch(compLevel: .sf, setNumber: 1, matchNumber: 9)
+        #expect(match.friendlyName(playoffType: .roundRobin6Team) == "Match 9")
+    }
+
+    @Test func friendlyName_roundRobinFinals() {
+        // RR finals are stored as `f` with set 1, match 1..3 — match number
+        // overlaps with prelim range, so distinguishing on comp_level matters.
+        let match = makeMatch(compLevel: .f, setNumber: 1, matchNumber: 2)
+        #expect(match.friendlyName(playoffType: .roundRobin6Team) == "Finals 2")
+    }
+
+    @Test func friendlyName_doubleElimMatch() {
+        // Modern DE stores each pre-finals match as its own `sf` set with
+        // match_number 1, so the label uses set_number.
+        let match = makeMatch(compLevel: .sf, setNumber: 11, matchNumber: 1)
+        #expect(match.friendlyName(playoffType: .doubleElim8Team) == "Match 11")
+    }
+
+    @Test func friendlyName_doubleElimFinals() {
+        let match = makeMatch(compLevel: .f, setNumber: 1, matchNumber: 2)
+        #expect(match.friendlyName(playoffType: .doubleElim8Team) == "Finals 2")
+    }
+
+    @Test func friendlyName_bo3Finals() {
+        let match = makeMatch(compLevel: .f, setNumber: 1, matchNumber: 2)
+        #expect(match.friendlyName(playoffType: .bo3Finals) == "Finals 2")
+    }
+
+    @Test func friendlyName_bo5Finals() {
+        let match = makeMatch(compLevel: .f, setNumber: 1, matchNumber: 4)
+        #expect(match.friendlyName(playoffType: .bo5Finals) == "Finals 4")
     }
 
     // MARK: - startTime priority (actual > predicted > scheduled)

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -180,6 +180,9 @@
 		92FFE5271E7C9A1F0037E48C /* EventTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FFE5261E7C9A1F0037E48C /* EventTableViewCell.swift */; };
 		A11CF00E00000000000000BB /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A11CF00E00000000000000FF /* AppIcon.icon */; };
 		BA0000000000000000000002 /* EventSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0000000000000000000001 /* EventSection.swift */; };
+		AA00000000000000000AA003 /* MatchSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000AA004 /* MatchSection.swift */; };
+		AA00000000000000000AA007 /* AllianceLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000AA008 /* AllianceLookup.swift */; };
+		AA00000000000000000AA009 /* AllianceBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000AA00A /* AllianceBadgeView.swift */; };
 		D105BC4723E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift in Sources */ = {isa = PBXBuildFile; fileRef = D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */; };
 /* End PBXBuildFile section */
 
@@ -350,6 +353,9 @@
 		92FFE5261E7C9A1F0037E48C /* EventTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTableViewCell.swift; sourceTree = "<group>"; };
 		A11CF00E00000000000000FF /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		BA0000000000000000000001 /* EventSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSection.swift; sourceTree = "<group>"; };
+		AA00000000000000000AA004 /* MatchSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchSection.swift; sourceTree = "<group>"; };
+		AA00000000000000000AA008 /* AllianceLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllianceLookup.swift; sourceTree = "<group>"; };
+		AA00000000000000000AA00A /* AllianceBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllianceBadgeView.swift; sourceTree = "<group>"; };
 		D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2020.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -384,6 +390,7 @@
 				145C57B61ED378E2004955B2 /* MatchTableViewCell.xib */,
 				145C57B41ED377EB004955B2 /* MatchTableViewCell.swift */,
 				1479693F215E9A580075AF4E /* MatchViewModel.swift */,
+				AA00000000000000000AA00A /* AllianceBadgeView.swift */,
 				921F609723CD4DE000FE633B /* Breakdown */,
 			);
 			path = Match;
@@ -822,6 +829,7 @@
 				92FF10F521A61AC2003BC5C4 /* MatchViewController.swift */,
 				92FF10F321A61AC2003BC5C4 /* MatchInfoViewController.swift */,
 				92FF10F621A61AC2003BC5C4 /* MatchBreakdownViewController.swift */,
+				AA00000000000000000AA004 /* MatchSection.swift */,
 			);
 			path = Match;
 			sourceTree = "<group>";
@@ -913,8 +921,17 @@
 			isa = PBXGroup;
 			children = (
 				929AACF32F95A8EA00587DEA /* Event */,
+				AA00000000000000000AA00B /* Match */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		AA00000000000000000AA00B /* Match */ = {
+			isa = PBXGroup;
+			children = (
+				AA00000000000000000AA008 /* AllianceLookup.swift */,
+			);
+			path = Match;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1086,6 +1103,9 @@
 				5EC0D41A2C26041700000004 /* WeekEventsGrouping.swift in Sources */,
 				5EC0D41A2C26041700000006 /* EventsListViewController.swift in Sources */,
 				BA0000000000000000000002 /* EventSection.swift in Sources */,
+				AA00000000000000000AA003 /* MatchSection.swift in Sources */,
+				AA00000000000000000AA007 /* AllianceLookup.swift in Sources */,
+				AA00000000000000000AA009 /* AllianceBadgeView.swift in Sources */,
 				92A5E5DD21A22D550025CC85 /* Int16+Suffix.swift in Sources */,
 				514C2EF52F8F0D5F00C674A9 /* MatchBreakdownConfigurator2026.swift in Sources */,
 				92FF110E21A61AF6003BC5C4 /* EventInsightsViewController.swift in Sources */,

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -66,10 +66,17 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
             eventKey: state.key,
             dependencies: dependencies
         )
-        matchesViewController = MatchesViewController(
-            eventKey: state.key,
-            dependencies: dependencies
-        )
+        if let event = state.event {
+            matchesViewController = MatchesViewController(
+                event: event,
+                dependencies: dependencies
+            )
+        } else {
+            matchesViewController = MatchesViewController(
+                eventKey: state.key,
+                dependencies: dependencies
+            )
+        }
 
         let navTitle = state.event?.friendlyNameWithYear ?? state.key
         super.init(

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -8,6 +8,8 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     private var state: MatchState
     private let teamKey: String?
 
+    private var event: Event?
+
     // MARK: - UI
 
     private let teamsLabel: UILabel = {
@@ -140,7 +142,12 @@ class MatchInfoViewController: TBAViewController, Refreshable {
 
         var baseTeamKeys: [String] = []
         if let teamKey { baseTeamKeys.append(teamKey) }
-        let viewModel = MatchViewModel(match: match, baseTeamKeys: baseTeamKeys)
+        let viewModel: MatchViewModel =
+            if let event {
+                MatchViewModel(match: match, event: event, baseTeamKeys: baseTeamKeys)
+            } else {
+                MatchViewModel(withoutEventContextFor: match, baseTeamKeys: baseTeamKeys)
+            }
         matchSummaryView.viewModel = viewModel
 
         scoreTitleLabel.text = viewModel.hasScores ? "Score" : "Time"
@@ -184,7 +191,18 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            self.state = .match(try await self.api.match(key: self.state.key))
+            // Task handles instead of `async let` — see MatchViewController
+            // for the Swift 6.1 allocator bug this sidesteps.
+            let matchHandle = Task { try? await self.api.match(key: self.state.key) }
+            let eventHandle = Task {
+                try? await self.api.event(key: MatchKey.eventKey(from: self.state.key))
+            }
+            if let match = await matchHandle.value {
+                self.state = .match(match)
+            }
+            if let event = await eventHandle.value {
+                self.event = event
+            }
             self.updateInterface()
         }
     }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchSection.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchSection.swift
@@ -1,0 +1,94 @@
+import Foundation
+import TBAAPI
+
+enum MatchSection: Hashable {
+    case qualification
+    case compLevel(CompLevel)
+    case doubleElimRound(DoubleElimRound)
+    case legacyDoubleElim(LegacyDoubleElimBracket, CompLevel)
+    case roundRobinSemifinals
+    case roundRobinFinals
+
+    var title: String {
+        switch self {
+        case .qualification:
+            return "Qualifications"
+        case .compLevel(let level):
+            return level.level
+        case .doubleElimRound(let round):
+            return round.title
+        case .legacyDoubleElim(let bracket, let level):
+            return "\(bracket.title) — \(level.levelShort)"
+        case .roundRobinSemifinals:
+            return "Round Robin Semifinals"
+        case .roundRobinFinals:
+            return "Finals"
+        }
+    }
+
+    // The trailing sub-order keeps multi-part sections (legacy DE
+    // winner/loser across comp levels) ordered within their bucket.
+    var sortOrder: (Int, Int) {
+        switch self {
+        case .qualification:
+            return (0, 0)
+        case .compLevel(let level):
+            return (10, level.sortOrder)
+        case .doubleElimRound(let round):
+            return (20, round.sortOrder)
+        case .legacyDoubleElim(let bracket, let level):
+            return (30 + bracket.sortOrder, level.sortOrder)
+        case .roundRobinSemifinals:
+            return (40, 0)
+        case .roundRobinFinals:
+            return (50, 0)
+        }
+    }
+}
+
+extension MatchSection: Comparable {
+    static func < (lhs: MatchSection, rhs: MatchSection) -> Bool {
+        lhs.sortOrder < rhs.sortOrder
+    }
+}
+
+extension MatchSection {
+
+    static func section(for match: Match, playoffType: PlayoffType?) -> MatchSection {
+        if match.compLevel == .qm { return .qualification }
+
+        guard let playoffType else {
+            return .compLevel(match.compLevel)
+        }
+
+        switch playoffType.kind {
+        case .doubleElim8Team:
+            return .doubleElimRound(
+                PlayoffTypeHelper.doubleElimRound(
+                    compLevel: match.compLevel,
+                    setNumber: match.setNumber
+                )
+            )
+        case .doubleElim4Team:
+            return .doubleElimRound(
+                PlayoffTypeHelper.doubleElim4Round(
+                    compLevel: match.compLevel,
+                    setNumber: match.setNumber
+                )
+            )
+        case .legacyDoubleElim8Team:
+            let bracket = PlayoffTypeHelper.legacyDoubleElimBracket(
+                compLevel: match.compLevel,
+                setNumber: match.setNumber
+            )
+            return .legacyDoubleElim(bracket, match.compLevel)
+        case .roundRobin6Team:
+            // Prelim match_numbers (1..15) overlap with finals match_numbers
+            // (1..3), so we split on comp_level instead.
+            return match.compLevel == .f ? .roundRobinFinals : .roundRobinSemifinals
+        case .bracket2Team, .bracket4Team, .bracket8Team, .bracket16Team,
+            .averageScore8Team, .bo3Finals, .bo5Finals, .custom:
+            return .compLevel(match.compLevel)
+        }
+    }
+}

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -72,7 +72,7 @@ class MatchViewController: MyTBAContainerViewController {
             )
         }
 
-        let navTitle = state.match?.friendlyName ?? state.key
+        let navTitle = state.match?.friendlyName(playoffType: nil) ?? state.key
         super.init(
             viewControllers: [infoViewController, breakdownViewController],
             navigationTitle: navTitle,
@@ -114,11 +114,14 @@ class MatchViewController: MyTBAContainerViewController {
                 try? await self.dependencies.api.event(key: MatchKey.eventKey(from: self.state.key))
             }
 
-            if let match = await matchHandle.value {
+            let match = await matchHandle.value
+            let event = await eventHandle.value
+
+            if let match {
                 self.state = .match(match)
-                self.navigationTitle = match.friendlyName
+                self.navigationTitle = match.friendlyName(playoffType: event?.playoffTypeEnum)
             }
-            if let event = await eventHandle.value {
+            if let event {
                 self.navigationSubtitle = "@ \(event.friendlyNameWithYear)"
             }
         }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -13,13 +13,14 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     weak var delegate: MatchesViewControllerDelegate?
     var query: MatchQueryOptions = MatchQueryOptions.defaultQuery()
 
-    private let eventKey: String
+    private var state: EventState
     private let teamKey: String?
 
-    private var dataSource: TableViewDataSource<String, Match>!
+    private var dataSource: TableViewDataSource<MatchSection, Match>!
 
     private var allMatches: [Match] = []
     private var favoriteTeamKeys: [String] = []
+    private var allianceLookup: AllianceLookup?
 
     lazy var matchQueryBarButtonItem: UIBarButtonItem = {
         return UIBarButtonItem(
@@ -35,8 +36,18 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Init
 
-    init(eventKey: String, teamKey: String? = nil, dependencies: Dependencies) {
-        self.eventKey = eventKey
+    convenience init(event: Event, teamKey: String? = nil, dependencies: Dependencies) {
+        self.init(state: .event(event), teamKey: teamKey, dependencies: dependencies)
+    }
+
+    // For callers that only have the event key (e.g. TeamAtEventViewController).
+    // refresh() upgrades state to `.event` so playoff-aware sectioning kicks in.
+    convenience init(eventKey: String, teamKey: String? = nil, dependencies: Dependencies) {
+        self.init(state: .key(eventKey), teamKey: teamKey, dependencies: dependencies)
+    }
+
+    private init(state: EventState, teamKey: String?, dependencies: Dependencies) {
+        self.state = state
         self.teamKey = teamKey
 
         super.init(dependencies: dependencies)
@@ -71,7 +82,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: Table View Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<String, Match>(tableView: tableView) {
+        dataSource = TableViewDataSource<MatchSection, Match>(tableView: tableView) {
             [weak self] tableView, indexPath, match in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
 
@@ -84,7 +95,19 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
             {
                 baseTeamKeys.formUnion(favoriteTeamKeys)
             }
-            cell.viewModel = MatchViewModel(match: match, baseTeamKeys: Array(baseTeamKeys))
+            if let event = self?.state.event {
+                cell.viewModel = MatchViewModel(
+                    match: match,
+                    event: event,
+                    allianceLookup: self?.allianceLookup,
+                    baseTeamKeys: Array(baseTeamKeys)
+                )
+            } else {
+                cell.viewModel = MatchViewModel(
+                    withoutEventContextFor: match,
+                    baseTeamKeys: Array(baseTeamKeys)
+                )
+            }
             cell.accessibilityIdentifier = "match.\(match.key)"
             return cell
         }
@@ -99,19 +122,15 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
         )
         let sorted = filtered.sorted(ascending: !query.sort.reverse)
 
-        var snapshot = NSDiffableDataSourceSnapshot<String, Match>()
-        // Group by comp-level string so sections mirror the old FRC behavior.
-        var sectionOrder: [String] = []
-        var grouped: [String: [Match]] = [:]
+        var snapshot = NSDiffableDataSourceSnapshot<MatchSection, Match>()
+        var grouped: [MatchSection: [Match]] = [:]
+        let playoffType = state.event?.playoffTypeEnum
         for match in sorted {
-            let key = match.compLevelString
-            if grouped[key] == nil {
-                sectionOrder.append(key)
-                grouped[key] = []
-            }
-            grouped[key]?.append(match)
+            let section = MatchSection.section(for: match, playoffType: playoffType)
+            grouped[section, default: []].append(match)
         }
-        for section in sectionOrder {
+        let sortedSections = grouped.keys.sorted(by: query.sort.reverse ? (>) : (<))
+        for section in sortedSections {
             snapshot.appendSections([section])
             snapshot.appendItems(grouped[section] ?? [], toSection: section)
         }
@@ -121,11 +140,9 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: TableViewDataSourceDelegate
 
     override func title(forSection section: Int) -> String? {
-        guard let firstMatch = dataSource.itemIdentifier(for: IndexPath(row: 0, section: section))
-        else {
-            return "Matches"
-        }
-        return "\(firstMatch.compLevel.level) Matches"
+        let sectionIDs = dataSource.snapshot().sectionIdentifiers
+        guard section >= 0, section < sectionIDs.count else { return nil }
+        return sectionIDs[section].title
     }
 
     // MARK: UITableView Delegate
@@ -167,7 +184,21 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            self.allMatches = try await self.dependencies.api.eventMatches(key: self.eventKey)
+            let key = self.state.key
+            async let matchesTask = self.dependencies.api.eventMatches(key: key)
+            async let alliancesTask: [EliminationAlliance]?? = {
+                try? await self.dependencies.api.eventAlliances(key: key)
+            }()
+            async let eventTask: Event? = {
+                try? await self.dependencies.api.event(key: key)
+            }()
+            self.allMatches = try await matchesTask
+            if let alliancesResult = await alliancesTask {
+                self.allianceLookup = alliancesResult.map(AllianceLookup.init)
+            }
+            if let event = await eventTask {
+                self.state = .event(event)
+            }
             self.applyMatches(self.allMatches)
         }
     }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -146,7 +146,11 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
                     let cell =
                         tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
                     if let match = self.matchesCache[key] {
-                        cell.viewModel = MatchViewModel(match: match)
+                        if let event = self.eventsCache[MatchKey.eventKey(from: key)] {
+                            cell.viewModel = MatchViewModel(match: match, event: event)
+                        } else {
+                            cell.viewModel = MatchViewModel(withoutEventContextFor: match)
+                        }
                     }
                     return cell
                 }
@@ -245,6 +249,15 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
 
     private func fetchMissingItems() async {
         let items = currentItems
+        // Match rows render playoff-aware labels from their owning Event, so
+        // each .match item implies an event fetch too.
+        let matchImpliedEventKeys = Set(
+            items.compactMap { item -> String? in
+                guard case .match(let key) = item else { return nil }
+                let eventKey = MatchKey.eventKey(from: key)
+                return eventsCache[eventKey] == nil ? eventKey : nil
+            }
+        )
         await withTaskGroup(of: Void.self) { group in
             for item in items {
                 switch item {
@@ -270,6 +283,14 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
                         }
                     }
                 default: break
+                }
+            }
+            for eventKey in matchImpliedEventKeys {
+                group.addTask { [weak self] in
+                    guard let self = self else { return }
+                    if let event = try? await self.dependencies.api.event(key: eventKey) {
+                        await MainActor.run { self.eventsCache[eventKey] = event }
+                    }
                 }
             }
         }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -136,7 +136,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
                         at: indexPath
                     )
                 case .match(let match, let baseTeamKey):
-                    return Self.cellForMatch(
+                    return self.cellForMatch(
                         match,
                         baseTeamKey: baseTeamKey,
                         in: tableView,
@@ -331,17 +331,26 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
         return cell
     }
 
-    private static func cellForMatch(
+    private func cellForMatch(
         _ match: Match,
         baseTeamKey: String?,
         in tableView: UITableView,
         at indexPath: IndexPath
     ) -> MatchTableViewCell {
         let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
-        cell.viewModel = MatchViewModel(
-            match: match,
-            baseTeamKeys: baseTeamKey.map { [$0] } ?? []
-        )
+        let baseTeamKeys = baseTeamKey.map { [$0] } ?? []
+        if let event {
+            cell.viewModel = MatchViewModel(
+                match: match,
+                event: event,
+                baseTeamKeys: baseTeamKeys
+            )
+        } else {
+            cell.viewModel = MatchViewModel(
+                withoutEventContextFor: match,
+                baseTeamKeys: baseTeamKeys
+            )
+        }
         return cell
     }
 
@@ -404,9 +413,9 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
                 )
             }
 
-            self.team = await teamHandle.value
-            self.event = await eventHandle.value
-            self.eventStatus = await statusHandle.value
+            if let team = await teamHandle.value { self.team = team }
+            if let event = await eventHandle.value { self.event = event }
+            if let status = await statusHandle.value { self.eventStatus = status }
 
             let nextHandle = Task { () -> Match? in
                 guard let key = self.eventStatus?.nextMatchKey else { return nil }
@@ -416,8 +425,17 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
                 guard let key = self.eventStatus?.lastMatchKey else { return nil }
                 return try? await self.dependencies.api.match(key: key)
             }
-            self.nextMatch = await nextHandle.value
-            self.lastMatch = await lastHandle.value
+            // Split "status says no key" (clear) from "fetch errored" (preserve).
+            if self.eventStatus?.nextMatchKey == nil {
+                self.nextMatch = nil
+            } else if let match = await nextHandle.value {
+                self.nextMatch = match
+            }
+            if self.eventStatus?.lastMatchKey == nil {
+                self.lastMatch = nil
+            } else if let match = await lastHandle.value {
+                self.lastMatch = match
+            }
 
             self.rebuildSnapshot()
         }

--- a/the-blue-alliance-ios/ViewElements/Match/AllianceBadgeView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/AllianceBadgeView.swift
@@ -1,0 +1,68 @@
+import UIKit
+
+final class AllianceBadgeView: UIView {
+
+    enum Side {
+        case red
+        case blue
+
+        var background: UIColor {
+            switch self {
+            case .red: return UIColor.redAllianceBackgroundColor
+            case .blue: return UIColor.blueAllianceBackgroundColor
+            }
+        }
+    }
+
+    private let label = UILabel()
+    private let pill = UIView()
+
+    init(number: Int, name: String?, side: Side) {
+        super.init(frame: .zero)
+        setupViews()
+        configure(number: number, name: name, side: side)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupViews() {
+        translatesAutoresizingMaskIntoConstraints = false
+        isAccessibilityElement = true
+
+        label.font = .boldSystemFont(ofSize: 11)
+        label.textColor = .label
+        label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        pill.layer.cornerRadius = 6
+        pill.translatesAutoresizingMaskIntoConstraints = false
+        pill.addSubview(label)
+
+        addSubview(pill)
+        NSLayoutConstraint.activate([
+            pill.topAnchor.constraint(equalTo: topAnchor),
+            pill.bottomAnchor.constraint(equalTo: bottomAnchor),
+            pill.leadingAnchor.constraint(equalTo: leadingAnchor),
+            pill.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            label.topAnchor.constraint(equalTo: pill.topAnchor, constant: 2),
+            label.bottomAnchor.constraint(equalTo: pill.bottomAnchor, constant: -2),
+            label.leadingAnchor.constraint(equalTo: pill.leadingAnchor, constant: 5),
+            label.trailingAnchor.constraint(equalTo: pill.trailingAnchor, constant: -5),
+        ])
+    }
+
+    func configure(number: Int, name: String?, side: Side) {
+        pill.backgroundColor = side.background
+        label.text = "A\(number)"
+        if let name, !name.isEmpty {
+            accessibilityLabel = name
+        } else {
+            accessibilityLabel = "Alliance \(number)"
+        }
+    }
+}

--- a/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
@@ -56,6 +56,13 @@ class MatchSummaryView: UIView {
 
     @IBOutlet weak var timeLabel: UILabel!
 
+    private var redAllianceLabel: UILabel!
+    private var blueAllianceLabel: UILabel!
+    private var redLeftVStack: UIStackView!
+    private var blueLeftVStack: UIStackView!
+    private var redScoreWidth: NSLayoutConstraint?
+    private var blueScoreWidth: NSLayoutConstraint?
+
     // MARK: - Init
 
     init(teamsTappable: Bool = false) {
@@ -81,7 +88,87 @@ class MatchSummaryView: UIView {
         summaryView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         self.addSubview(summaryView)
 
+        installAllianceLabels()
         styleInterface()
+    }
+
+    // Restructures each colored container into HStack[ VStack[ allianceLabel,
+    // teamHStack ], scoreView ] — replacing the xib's flat layout so the score
+    // can span the full container height while the alliance label sits over
+    // the team row.
+    private func installAllianceLabels() {
+        for (container, teamHStack, scoreView, isRed) in [
+            (redContainerView!, redStackView!, redScoreView!, true),
+            (blueContainerView!, blueStackView!, blueScoreView!, false),
+        ] {
+            container.constraints
+                .filter { $0.firstItem === teamHStack || $0.secondItem === teamHStack }
+                .forEach { $0.isActive = false }
+            teamHStack.removeFromSuperview()
+            scoreView.removeFromSuperview()
+
+            let allianceLabel = UILabel()
+            allianceLabel.font = .boldSystemFont(ofSize: 11)
+            allianceLabel.textColor = .label
+            allianceLabel.numberOfLines = 1
+            allianceLabel.lineBreakMode = .byTruncatingTail
+            allianceLabel.adjustsFontForContentSizeCategory = true
+            allianceLabel.isHidden = true
+
+            let leftVStack = UIStackView(arrangedSubviews: [allianceLabel, teamHStack])
+            leftVStack.axis = .vertical
+            leftVStack.alignment = .fill
+            leftVStack.distribution = .fill
+            leftVStack.spacing = 2
+            leftVStack.isLayoutMarginsRelativeArrangement = true
+            leftVStack.directionalLayoutMargins = .init(
+                top: 0,
+                leading: 8,
+                bottom: 0,
+                trailing: 0
+            )
+
+            let rootHStack = UIStackView(arrangedSubviews: [leftVStack, scoreView])
+            rootHStack.axis = .horizontal
+            rootHStack.alignment = .fill
+            rootHStack.distribution = .fill
+            rootHStack.translatesAutoresizingMaskIntoConstraints = false
+
+            container.addSubview(rootHStack)
+            NSLayoutConstraint.activate([
+                rootHStack.topAnchor.constraint(equalTo: container.topAnchor),
+                rootHStack.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+                rootHStack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+                rootHStack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            ])
+
+            if isRed {
+                redAllianceLabel = allianceLabel
+                redLeftVStack = leftVStack
+            } else {
+                blueAllianceLabel = allianceLabel
+                blueLeftVStack = leftVStack
+            }
+        }
+    }
+
+    // Anchors the score view's width to the first team column so columns stay
+    // equal regardless of whether the inline pill bumps the team stack from 3
+    // to 4 entries. Re-installed after every configureView since the
+    // arrangedSubviews array is rebuilt.
+    private func updateScoreColumnWidth(
+        scoreView: UIView,
+        teamStack: UIStackView,
+        existing: inout NSLayoutConstraint?
+    ) {
+        existing?.isActive = false
+        guard let firstColumn = teamStack.arrangedSubviews.first else {
+            existing = nil
+            return
+        }
+        let constraint = scoreView.widthAnchor.constraint(equalTo: firstColumn.widthAnchor)
+        constraint.isActive = true
+        existing = constraint
     }
 
     private func styleInterface() {
@@ -109,9 +196,6 @@ class MatchSummaryView: UIView {
     private func removeTeams() {
         for stackView in [redStackView, blueStackView] as [UIStackView] {
             for view in stackView.arrangedSubviews {
-                if [redScoreView, blueScoreView].contains(view) {
-                    continue
-                }
                 stackView.removeArrangedSubview(view)
                 view.removeFromSuperview()
             }
@@ -132,27 +216,55 @@ class MatchSummaryView: UIView {
             return
         }
 
-        matchNumberLabel.text = viewModel.matchName
-        playIconImageView.isHidden = viewModel.hasVideos
+        matchNumberLabel.text = stackedMatchName(viewModel.matchName)
+        playIconImageView.isHidden = !viewModel.hasVideos
 
         removeTeams()
         removeRPs()
 
         let baseTeamKeys = viewModel.baseTeamKeys
-        for (alliance, stackView) in [
-            (viewModel.redAlliance, redStackView!), (viewModel.blueAlliance, blueStackView!),
-        ] {
+        let alliancePairs:
+            [(
+                alliance: [String], stackView: UIStackView, badge: AllianceLookup.Entry?,
+                topLabel: UILabel, leftVStack: UIStackView, side: AllianceBadgeView.Side
+            )] = [
+                (
+                    viewModel.redAlliance, redStackView!, viewModel.redAllianceBadge,
+                    redAllianceLabel, redLeftVStack, .red
+                ),
+                (
+                    viewModel.blueAlliance, blueStackView!, viewModel.blueAllianceBadge,
+                    blueAllianceLabel, blueLeftVStack, .blue
+                ),
+            ]
+        for (alliance, stackView, badge, topLabel, leftVStack, side) in alliancePairs {
+            applyAllianceIdentifier(
+                badge,
+                to: topLabel,
+                leftVStack: leftVStack,
+                stackView: stackView,
+                side: side
+            )
             for teamKey in alliance {
                 let dq = viewModel.dqs.contains(teamKey)
-                // if teams are tappable, load the team #s as buttons to link to the team page
                 let label =
                     teamsTappable
                     ? teamButton(for: teamKey, baseTeamKeys: baseTeamKeys, dq: dq)
                     : teamLabel(for: teamKey, baseTeamKeys: baseTeamKeys, dq: dq)
-                // Insert each new stack view at the index just before the score view
-                stackView.insertArrangedSubview(label, at: stackView.arrangedSubviews.count - 1)
+                stackView.addArrangedSubview(label)
             }
         }
+
+        updateScoreColumnWidth(
+            scoreView: redScoreView,
+            teamStack: redStackView,
+            existing: &redScoreWidth
+        )
+        updateScoreColumnWidth(
+            scoreView: blueScoreView,
+            teamStack: blueStackView,
+            existing: &blueScoreWidth
+        )
 
         // Add red RP to view
         addRPToView(stackView: redRPStackView, rpCount: viewModel.redRPCount)
@@ -183,6 +295,48 @@ class MatchSummaryView: UIView {
             blueContainerView.layer.borderWidth = 2.0
             blueScoreLabel.font = winnerFont
         }
+    }
+
+    // Wraps "Semis 1-1" → "Semis\n1-1" so wider playoff numbers don't shrink to
+    // fit. Single-digit numbers stay inline; they fit comfortably as one line.
+    private func stackedMatchName(_ name: String) -> String {
+        guard let spaceIndex = name.lastIndex(of: " ") else { return name }
+        let trailing = name[name.index(after: spaceIndex)...]
+        guard trailing.count >= 2 else { return name }
+        return name.replacingCharacters(in: spaceIndex...spaceIndex, with: "\n")
+    }
+
+    private func applyAllianceIdentifier(
+        _ entry: AllianceLookup.Entry?,
+        to label: UILabel,
+        leftVStack: UIStackView,
+        stackView: UIStackView,
+        side: AllianceBadgeView.Side
+    ) {
+        guard let entry else {
+            label.text = nil
+            label.isHidden = true
+            setAllianceLabelMargins(showing: false, on: leftVStack)
+            return
+        }
+
+        // EITHER the top-row label OR the inline pill carries the identity, never both.
+        if let name = entry.customName {
+            label.text = name.uppercased()
+            label.isHidden = false
+            setAllianceLabelMargins(showing: true, on: leftVStack)
+        } else {
+            label.text = nil
+            label.isHidden = true
+            setAllianceLabelMargins(showing: false, on: leftVStack)
+            let badge = AllianceBadgeView(number: entry.number, name: entry.name, side: side)
+            stackView.insertArrangedSubview(badge, at: 0)
+        }
+    }
+
+    private func setAllianceLabelMargins(showing: Bool, on stack: UIStackView) {
+        let v: CGFloat = showing ? 4 : 0
+        stack.directionalLayoutMargins = .init(top: v, leading: 8, bottom: v, trailing: 0)
     }
 
     private func addRPToView(stackView: UIStackView, rpCount: Int) {

--- a/the-blue-alliance-ios/ViewElements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchViewModel.swift
@@ -25,6 +25,10 @@ struct MatchViewModel {
 
     let baseTeamKeys: [String]
 
+    // Non-nil for playoff rows when the event has alliances available.
+    let redAllianceBadge: AllianceLookup.Entry?
+    let blueAllianceBadge: AllianceLookup.Entry?
+
     var hasScores: Bool {
         return blueScore != nil && redScore != nil
     }
@@ -40,9 +44,41 @@ struct MatchViewModel {
         return rpCount
     }
 
-    init(match: Match, baseTeamKeys: [String] = []) {
-        matchName = match.friendlyName
-        hasVideos = match.videos.isEmpty
+    init(
+        match: Match,
+        event: Event,
+        allianceLookup: AllianceLookup? = nil,
+        baseTeamKeys: [String] = []
+    ) {
+        self.init(
+            match: match,
+            playoffType: event.playoffTypeEnum,
+            allianceLookup: allianceLookup,
+            baseTeamKeys: baseTeamKeys
+        )
+    }
+
+    // Named so it can't be reached for by accident — primary init is preferred.
+    init(
+        withoutEventContextFor match: Match,
+        baseTeamKeys: [String] = []
+    ) {
+        self.init(
+            match: match,
+            playoffType: nil,
+            allianceLookup: nil,
+            baseTeamKeys: baseTeamKeys
+        )
+    }
+
+    private init(
+        match: Match,
+        playoffType: PlayoffType?,
+        allianceLookup: AllianceLookup?,
+        baseTeamKeys: [String]
+    ) {
+        matchName = match.friendlyName(playoffType: playoffType)
+        hasVideos = !match.videos.isEmpty
 
         redAlliance = match.redAllianceTeamKeys
         redScore = match.alliances.red.score < 0 ? nil : match.alliances.red.score
@@ -60,6 +96,15 @@ struct MatchViewModel {
         blueAllianceWon = hasWinnersAndLosers && match.winningAllianceString == "blue"
 
         self.baseTeamKeys = baseTeamKeys
+
+        // Only playoff rows have alliance membership to render.
+        if match.compLevel != .qm, let lookup = allianceLookup, !lookup.isEmpty {
+            self.redAllianceBadge = lookup.entry(forTeamKeys: match.redAllianceTeamKeys)
+            self.blueAllianceBadge = lookup.entry(forTeamKeys: match.blueAllianceTeamKeys)
+        } else {
+            self.redAllianceBadge = nil
+            self.blueAllianceBadge = nil
+        }
 
         let redBreakdown = match.breakdownDict?["red"] as? [String: Any]
         let blueBreakdown = match.breakdownDict?["blue"] as? [String: Any]

--- a/the-blue-alliance-ios/ViewModels/Event/EventSection.swift
+++ b/the-blue-alliance-ios/ViewModels/Event/EventSection.swift
@@ -1,10 +1,6 @@
 import Foundation
 import TBAAPI
 
-// Grouping + ordering model for the Week Events screen. sortOrder is
-// derived from the TBA `event_type` integer so we don't carry arbitrary
-// bucket offsets, and unknown event types fall through gracefully to
-// their raw integer position with whatever label the API sent.
 public struct EventSection: Hashable, Comparable {
     public let sortOrder: Int
     public let subOrder: Int
@@ -18,10 +14,8 @@ public struct EventSection: Hashable, Comparable {
 }
 
 extension APIEventType {
-    // Section ordering in the Week view. Mostly the TBA rawValue, with two
-    // sentinels whose rawValue doesn't match display intent:
-    //   • preseason (100) renders first
-    //   • unlabeled (-1) renders last
+    // Mostly the TBA rawValue; preseason (100) and unlabeled (-1) are pushed
+    // to the ends so they don't render in the middle of the chronological flow.
     var displayOrder: Int {
         switch self {
         case .preseason: return -1
@@ -34,9 +28,7 @@ extension APIEventType {
 extension Event {
     var section: EventSection {
         guard let type = eventTypeEnum else {
-            // New TBA event_type we haven't shipped a case for. Sort by the
-            // raw integer so it slots between known types, and use the
-            // API-provided string as the title so it's at least self-describing.
+            // Forward-compat for new TBA event_types we haven't shipped a case for.
             let label = eventTypeString.isEmpty ? "Unknown Events" : "\(eventTypeString) Events"
             return .init(sortOrder: eventType.rawValue, subOrder: 0, title: label)
         }
@@ -53,8 +45,7 @@ extension Event {
                 title: "\(districtSectionName) District Events"
             )
         case .districtChampionship, .districtChampionshipDivision:
-            // Parent + divisions share one section per district, keyed off the
-            // parent's displayOrder so both types land on the same sortOrder.
+            // DCMP parent + its divisions share one section per district.
             return .init(
                 sortOrder: APIEventType.districtChampionship.displayOrder,
                 subOrder: 0,
@@ -82,8 +73,6 @@ extension Event {
         }
     }
 
-    // Display name for a district-scoped section; falls back to the uppercased
-    // abbreviation (e.g. FIM) if the API didn't send a populated displayName.
     private var districtSectionName: String {
         guard let district else { return "District" }
         return district.displayName.isEmpty
@@ -95,10 +84,7 @@ extension Event {
         return "Championship"
     }
 
-    // Default ordering for event lists within a single year: by section,
-    // then by event_type (so DCMP parent 2 sorts before division 5), then
-    // by start date, then by key. Callers that mix years should compare
-    // year first and fall back to this.
+    // Within-year ordering. Callers that mix years should compare year first.
     public static func sectionAscending(_ a: Event, _ b: Event) -> Bool {
         if a.section != b.section { return a.section < b.section }
         if a.eventType != b.eventType { return a.eventType.rawValue < b.eventType.rawValue }

--- a/the-blue-alliance-ios/ViewModels/Match/AllianceLookup.swift
+++ b/the-blue-alliance-ios/ViewModels/Match/AllianceLookup.swift
@@ -1,0 +1,48 @@
+import Foundation
+import TBAAPI
+
+struct AllianceLookup {
+
+    struct Entry: Hashable {
+        let number: Int
+        let name: String?
+
+        // nil when the API returned the default `"Alliance N"` placeholder
+        // rather than a sponsor/division name like "DTE Energy" or "Archimedes".
+        var customName: String? {
+            guard let name, !name.isEmpty,
+                name.caseInsensitiveCompare("Alliance \(number)") != .orderedSame
+            else { return nil }
+            return name
+        }
+
+        var hasCustomName: Bool { customName != nil }
+    }
+
+    // One Entry per teamKey: a team can only be on one alliance at a time
+    // (FRC rules), so picks and backup._in across alliances never collide.
+    private let byTeamKey: [String: Entry]
+
+    init(alliances: [EliminationAlliance]) {
+        var map: [String: Entry] = [:]
+        for (index, alliance) in alliances.enumerated() {
+            let entry = Entry(number: index + 1, name: alliance.name)
+            for teamKey in alliance.picks {
+                map[teamKey] = entry
+            }
+            if let backup = alliance.backup, !backup._in.isEmpty {
+                map[backup._in] = entry
+            }
+        }
+        self.byTeamKey = map
+    }
+
+    func entry(forTeamKeys keys: [String]) -> Entry? {
+        for key in keys {
+            if let entry = byTeamKey[key] { return entry }
+        }
+        return nil
+    }
+
+    var isEmpty: Bool { byTeamKey.isEmpty }
+}


### PR DESCRIPTION
Closes #947

## Summary
- Bump the vendored OpenAPI spec to pick up the new `PlayoffType` and `Double_Elim_Round` enums from the TBA API, and add named static accessors on the generated `PlayoffType` so call sites read `event.playoffType == .doubleElim8Team` instead of `._10`.
- Group the Matches tab by **per-round** sections for modern double-elim events (Round 1–5 / Finals), **winner/loser** bracket sections for legacy DE, **round-robin** rounds for RR events, and fall back to comp-level sections for bracket formats.
- Playoff-typed match labels: `"Match N"` for double-elim / round-robin (instead of the misleading `"Semis 13-1"`); `"Finals N"` for finals across all formats including round-robin.
- Alliance identifier on each playoff row: when the event has a custom alliance name (sponsor like `DTE ENERGY`, division like `ARCHIMEDES`), it renders above the team row inside the colored container; otherwise falls back to a small `A#` pill in the team stack. Either-or, never both.
- `MatchViewController` seeds its title + child VCs synchronously when pushed from a list, so the score shows immediately on navigation instead of waiting on the refresh fetch round-trip.
- `MatchViewModel` now requires an `Event` on its primary init, with an explicit `init(withoutEventContextFor:)` for callers that don't have one (myTBA cold-load, MatchesViewController before the event resolves) so playoff-aware labeling can't silently degrade by accident.
- MyTBA list fetches the owning Event for every cached `match` row so playoff-aware labels render there too.
- Refresh paths (`MatchesViewController`, `TeamSummaryViewController`) preserve previously-cached data on fetch errors; only a successful fetch returning nil clears state. Previously a failed `event_alliances` round-trip would wipe the cached `AllianceLookup`.
- Collateral from the spec bump: `Event.eventType`, `Event.playoffType`, `Award.awardType`, `EliminationAlliance.status.doubleElimRound` etc. are now strongly-typed enums; `.rawValue` added at the few existing call sites that were comparing raw ints.
- 19 new unit tests for `PlayoffTypeHelper` plus round-robin / double-elim friendlyName cases in `Packages/TBAAPI/Tests/TBAAPITests/`.

Out of scope (tracked for follow-up PRs):
- Collapsible sections — agreed to do this alongside a UICollectionView migration of the matches list.

## Test plan
- [ ] **Double Elim 8** (e.g. `2024arc`): Matches tab shows `Round 1` / `Round 2` / `Round 3` / `Round 4` / `Round 5` / `Finals` sections. Rows read `Match 1`…`Match 13`, `Finals 1`, `Finals 2`. Each row shows the alliance name above the teams (e.g. `ARCHIMEDES`).
- [ ] **Double Elim 4** (any 2024+ district championship with divisions): `Round 1` / `Round 2` / `Round 3` / `Finals`.
- [ ] **Legacy Double Elim 8** (`2017wiwi`): `Upper Bracket — …` / `Lower Bracket — …` splits.
- [ ] **Round Robin** (`2019cmptx`): `Round Robin Semifinals` / `Finals` sections; rows labeled `Match 1`…`Match 15` then `Finals 1`–`3`.
- [ ] **Bracket 8 / 16** (any 2019–2022 regional or 2022 worlds division): `Quarterfinals` / `Semifinals` / `Finals` (and `Eighth-Finals` for 16-team) sections — bare comp-level headers, no `Matches` suffix.
- [ ] **Alliance identifier**: events with custom alliance names show the name above each playoff row (`DTE ENERGY`, `APTIV`, etc.); events without custom names show the `A#` pill in the team stack instead. Qual rows render no identifier on either side.
- [ ] **Cold-open via URL/notification**: opening an event that lands on the Matches tab before the full `Event` resolves — sections flip from default comp-level grouping to the correct playoff sectioning once `MatchesViewController`'s refresh finishes its async fetch.
- [ ] **Match detail push**: tapping a match from the list → score visible on push (no blank → time → score flash).
- [ ] **myTBA**: bookmarked playoff matches render with playoff-aware labels (e.g. `Match 12`) once the implied event fetch lands on first refresh.
- [ ] **No alliances endpoint**: early-season events (before alliance selection) render playoff matches without identifiers, no crash.
- [ ] **Refresh-error data preservation**: pull-to-refresh on Matches with the alliances endpoint forced to fail (e.g. via Charles) keeps the existing badges visible rather than clearing them.
- [ ] **Rotate to landscape**: team numbers still column-aligned; no constraint breakage.
- [ ] `xcodebuild … build` clean; `swift test` in `Packages/TBAAPI` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)