### PR TITLE
Fix match breakdowns not rendering except shared values outside of 2016

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/openapi.json
+++ b/Packages/TBAAPI/Sources/TBAAPI/openapi.json
@@ -7068,40 +7068,9 @@
           },
           "score_breakdown": {
             "description": "Score breakdown for auto, teleop, etc. points. Varies from year to year. May be null.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2015"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2016"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2017"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2018"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2019"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2020"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2022"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2023"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2024"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2025"
-              },
-              {
-                "$ref": "#/components/schemas/Match_Score_Breakdown_2026"
-              }
+            "type": [
+              "object",
+              "null"
             ]
           },
           "videos": {

--- a/scripts/update-apiv3-spec.py
+++ b/scripts/update-apiv3-spec.py
@@ -117,6 +117,30 @@ def _drop_nullified_required(
     return removed
 
 
+def _flatten_score_breakdown_oneof(spec: dict) -> bool:
+    """Replace Match.score_breakdown's `oneOf` with a free-form nullable object.
+
+    The upstream oneOf lists eleven per-year schemas with no discriminator, so
+    swift-openapi-generator emits a try-each decoder that mis-routes every
+    non-2015 match through the 2016 branch, dropping all year-specific fields
+    (issues #1023 / #1052). The app already consumes the breakdown as raw
+    `[String: Any]`, so we degrade the schema to a free-form object and let
+    `OpenAPIObjectContainer` preserve the payload verbatim.
+    """
+    try:
+        sb = spec["components"]["schemas"]["Match"]["properties"]["score_breakdown"]
+    except (KeyError, TypeError):
+        return False
+    if not isinstance(sb, dict) or "oneOf" not in sb:
+        return False
+    description = sb.get("description")
+    replacement: dict = {"type": ["object", "null"]}
+    if description:
+        replacement = {"description": description, **replacement}
+    spec["components"]["schemas"]["Match"]["properties"]["score_breakdown"] = replacement
+    return True
+
+
 def _find_residual_null_compositions(node: object, path: list[str]) -> list[str]:
     """Return paths where a `oneOf`/`anyOf` still contains a null branch."""
     hits: list[str] = []
@@ -158,6 +182,9 @@ def main() -> int:
         print(f"Dropped {len(required_removals)} now-nullable field(s) from `required`:")
         for r in required_removals:
             print(f"  - {r}")
+
+    if _flatten_score_breakdown_oneof(patched):
+        print("Flattened Match.score_breakdown oneOf to free-form nullable object.")
 
     OUT_PATH.write_text(json.dumps(patched, indent=2) + "\n")
     print(f"Wrote {OUT_PATH}")

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift
@@ -17,7 +17,11 @@ extension MatchBreakdownConfigurator {
     static func breakdownValueSupported(key: String, red: [String: Any], blue: [String: Any])
         -> Bool
     {
-        return red.keys.contains(key) && blue.keys.contains(key)
+        guard let redValue = red[key], let blueValue = blue[key] else { return false }
+        // TBA encodes "this stat doesn't apply to this match" as JSON null, which
+        // `JSONSerialization` surfaces as `NSNull`. Treat those like missing keys
+        // so rows are skipped instead of rendering `<null>`.
+        return !(redValue is NSNull) && !(blueValue is NSNull)
     }
 
     // Values


### PR DESCRIPTION
Swift's OpenAPI generator basically walks all of the `oneOf` options in our spec until we get a valid decode. Since all of our formats follow this `"red"/"blue"` we would succeed on the first possible breakdown. This is why only shared values for other years were rendering - but not their full game spec breakdowns.

I hate patching our OpenAPI spec in this way but - we're going to do it for now to get a bug fix out - and I'll work on a better way to do this in code once we get our other match breakdowns merged.

Fixes https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/1052