### PR TITLE
Seed MatchViewController synchronously when pushed from a list

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -191,9 +191,9 @@ extension EventViewController: EventRankingsViewControllerDelegate {
 
 extension EventViewController: MatchesViewControllerDelegate, MatchesViewControllerQueryable {
 
-    func matchSelected(matchKey: String) {
+    func matchSelected(_ match: Match) {
         let matchViewController = MatchViewController(
-            matchKey: matchKey,
+            match: match,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(matchViewController, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -46,6 +46,18 @@ class MatchViewController: MyTBAContainerViewController {
         infoViewController.matchSummaryDelegate = self
     }
 
+    // Preferred path when the caller already has a fully-fetched Match (e.g.
+    // from a matches list). Seeds the title + child VCs synchronously so scores
+    // render immediately on push; the background refresh in viewDidLoad still
+    // runs to pick up fresh data.
+    convenience init(match: Match, teamKey: String? = nil, dependencies: Dependencies) {
+        self.init(matchKey: match.key, teamKey: teamKey, dependencies: dependencies)
+        self.match = match
+        self.navigationTitle = match.friendlyName
+        self.infoViewController.apply(match: match)
+        self.breakdownViewController.apply(match: match)
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -46,10 +46,6 @@ class MatchViewController: MyTBAContainerViewController {
         infoViewController.matchSummaryDelegate = self
     }
 
-    // Preferred path when the caller already has a fully-fetched Match (e.g.
-    // from a matches list). Seeds the title + child VCs synchronously so scores
-    // render immediately on push; the background refresh in viewDidLoad still
-    // runs to pick up fresh data.
     convenience init(match: Match, teamKey: String? = nil, dependencies: Dependencies) {
         self.init(matchKey: match.key, teamKey: teamKey, dependencies: dependencies)
         self.match = match

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -5,7 +5,7 @@ import UIKit
 
 protocol MatchesViewControllerDelegate: AnyObject {
     func showFilter()
-    func matchSelected(matchKey: String)
+    func matchSelected(_ match: Match)
 }
 
 class MatchesViewController: TBATableViewController, Refreshable, Stateful {
@@ -132,7 +132,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let match = dataSource.itemIdentifier(for: indexPath) else { return }
-        delegate?.matchSelected(matchKey: match.key)
+        delegate?.matchSelected(match)
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -130,9 +130,9 @@ class TeamAtEventViewController: ContainerViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    private func pushMatch(matchKey: String) {
+    private func pushMatch(_ match: Match) {
         let matchViewController = MatchViewController(
-            matchKey: matchKey,
+            match: match,
             teamKey: teamKey,
             dependencies: dependencies
         )
@@ -149,8 +149,8 @@ extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewC
         pushTeam(teamKey: teamKey)
     }
 
-    func matchSelected(matchKey: String) {
-        pushMatch(matchKey: matchKey)
+    func matchSelected(_ match: Match) {
+        pushMatch(match)
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 
 protocol TeamSummaryViewControllerDelegate: AnyObject {
     func teamInfoSelected(teamKey: String)
-    func matchSelected(matchKey: String)
+    func matchSelected(_ match: Match)
 }
 
 private enum TeamSummarySection: Int {
@@ -370,7 +370,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
         case .teamInfo:
             delegate?.teamInfoSelected(teamKey: teamKey)
         case .match(let match, _):
-            delegate?.matchSelected(matchKey: match.key)
+            delegate?.matchSelected(match)
         case .pitLocation:
             guard let event,
                 let teamNumber = team?.teamNumber,


### PR DESCRIPTION
## Summary
- Match list cells already hold a fully-fetched `Match` object, but `MatchViewController` re-fetches by key in `viewDidLoad`. That produces a visible \"time only → blank → score\" flash on every push from a list.
- Add a `convenience init(match: Match, ...)` on `MatchViewController` that seeds `navigationTitle`, `infoViewController`, and `breakdownViewController` synchronously from the passed `Match` before the push animation runs. The background refresh in `viewDidLoad` still runs unchanged so live scores update if they change while the detail is open.
- Change `MatchesViewControllerDelegate.matchSelected` and `TeamSummaryViewControllerDelegate.matchSelected` from `(matchKey: String)` to `(_ match: Match)`. Update the implementers in `EventViewController`, `TeamAtEventViewController`, and `TeamSummaryViewController` to push the new init.
- MyTBA's matchKey-only path (subscriptions list) is untouched and continues to use the existing key-based init.

## Test plan
- [ ] Open an event with played playoff matches, tap one from the Matches tab → detail view shows the score immediately on push (no time-only / blank flash).
- [ ] Repeat from a Team@Event matches list and from the Team@Event Summary tab's Next/Last Match rows.
- [ ] Open a MyTBA subscribed match → detail still loads correctly via the matchKey-only init (no Match object available there).
- [ ] Tap an unplayed/upcoming match → time still shows; no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)