### PR TITLE
Use GitHub auto-generated release notes for App Store releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -105,10 +105,11 @@ platform :ios do
     preship
     build
 
-    ship_github(is_prerelease: false) # Create GitHub release
+    release_body = generated_release_notes
+    ship_github(is_prerelease: false, description: release_body)
     slack(
       channel: "#app-releases",
-      message: "Shipping iOS #{current_version} to the App Store 🎉\n```\n#{commit_changelog}\n```\nhttps://github.com/the-blue-alliance/the-blue-alliance-ios/releases/tag/#{current_version}",
+      message: "Shipping iOS #{current_version} to the App Store 🎉\n```\n#{release_body}\n```\nhttps://github.com/the-blue-alliance/the-blue-alliance-ios/releases/tag/#{current_version}",
       default_payloads: [],
       username: "release-bot",
       icon_url: "https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-logo/master/ios/tba-icon-60%403x.png",
@@ -128,7 +129,7 @@ platform :ios do
      api_token: ENV["GH_TOKEN"],
      name: current_version,
      tag_name: current_version,
-     description: commit_changelog,
+     description: options[:description],
      is_prerelease: options[:is_prerelease] ? true : false,
      upload_assets: ["The Blue Alliance.ipa"]
    )
@@ -200,6 +201,19 @@ platform :ios do
 
   private_lane :commit_changelog do
     File.read("release_notes/beta.md").strip
+  end
+
+  private_lane :generated_release_notes do
+    notes = github_api(
+      api_token: ENV["GH_TOKEN"],
+      http_method: "POST",
+      path: "/repos/the-blue-alliance/the-blue-alliance-ios/releases/generate-notes",
+      body: {
+        tag_name: current_version,
+        target_commitish: "main"
+      }
+    )
+    notes[:json]["body"]
   end
 
   ## End Internal Lanes for Shipping Lanes ##


### PR DESCRIPTION
## Summary
- v3.3.1's GitHub release reused the stale v3.3.0 beta notes because both the TestFlight `pilot` call and `set_github_release` read from `fastlane/release_notes/beta.md` via `commit_changelog`.
- Split the sources: beta.md stays the "What to Test" source for TestFlight; GitHub releases now fetch a body from GitHub's `POST /repos/{owner}/{repo}/releases/generate-notes` endpoint, yielding the standard `## What's Changed` + PR list + `**Full Changelog**` block.
- New `generated_release_notes` private lane fetches the body once per App Store ship; `app_store` threads it into both `ship_github(description:)` and the `#app-releases` Slack post so the two always match.

## Test plan
- [ ] `bundle exec fastlane lanes` parses the Fastfile without errors (verified locally).
- [ ] On the next App Store ship, confirm the created GitHub release body contains `## What's Changed`, a bullet list of merged PRs, and a `**Full Changelog**: vPREV...vNEW` link.
- [ ] Confirm the `#app-releases` Slack message inlines that same auto-generated body.
- [ ] Confirm TestFlight `beta_ci` still uses `beta.md` for the "What to Test" field (no change in behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)