### PR TITLE
Fix offseason event titles rendering as "20XX  Offseason"

### DIFF
--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
@@ -32,7 +32,7 @@ extension Event {
 
     var friendlyNameWithYear: String {
         var parts = [String(year)]
-        if let shortName {
+        if let shortName, !shortName.isEmpty {
             parts.append(shortName)
             parts.append(eventTypeString.isEmpty ? "Event" : eventTypeString)
         } else {


### PR DESCRIPTION
## Summary

Fixes offseason event titles like `2024mmr` rendering as `"2024  Offseason"` (no name, double space) instead of `"2024 Minne Mini"`.

TBA returns `short_name: ""` (empty string, not null) for many offseasons. `friendlyNameWithYear`'s `if let shortName` passes on an empty string, so the title was built as `["2024", "", "Offseason"].joined(" ")`. Now guards for non-empty the same way the sibling `safeShortName` helper already does, so these fall through to the event's `name`.

## Test plan

- [ ] Open `2024mmr` (or any offseason with empty `short_name`) and confirm the nav title renders `"2024 Minne Mini"` instead of `"2024  Offseason"`.
- [ ] Open an offseason with a populated `short_name` (e.g. a MAR-affiliated event) and confirm it still renders as `"<year> <Short Name> Offseason"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)