### PR TITLE
Fix match-detail crash when pushed from a list; replace apply() with MatchState seeding

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -27,18 +27,25 @@ struct BreakdownRow: Hashable {
 
 class MatchBreakdownViewController: TBATableViewController, Refreshable, Stateful {
 
-    private let matchKey: String
+    private var state: MatchState
     private let year: Int
     private let breakdownConfigurator: MatchBreakdownConfigurator.Type?
-
-    private var match: Match?
 
     private var dataSource: TableViewDataSource<String?, BreakdownRow>!
 
     // MARK: - Init
 
-    init(matchKey: String, year: Int, dependencies: Dependencies) {
-        self.matchKey = matchKey
+    convenience init(matchKey: String, year: Int, dependencies: Dependencies) {
+        self.init(state: .key(matchKey), year: year, dependencies: dependencies)
+    }
+
+    convenience init(match: Match, dependencies: Dependencies) {
+        let year = match.year ?? MatchKey.year(from: match.key) ?? 0
+        self.init(state: .match(match), year: year, dependencies: dependencies)
+    }
+
+    private init(state: MatchState, year: Int, dependencies: Dependencies) {
+        self.state = state
         self.year = year
 
         switch year {
@@ -77,6 +84,8 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
                 self.disableRefreshing()
             }
         }
+
+        configureDataSource(state.match?.breakdownDict)
     }
 
     // MARK: - Methods
@@ -94,11 +103,6 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
         }
         dataSource.delegate = self
         dataSource.statefulDelegate = self
-    }
-
-    func apply(match: Match) {
-        self.match = match
-        configureDataSource(match.breakdownDict)
     }
 
     func configureDataSource(_ breakdown: [String: Any]?) {
@@ -123,8 +127,8 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
         guard breakdownConfigurator != nil else { return }
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.match(key: self.matchKey)
-            self.apply(match: fetched)
+            self.state = .match(try await self.dependencies.api.match(key: self.state.key))
+            self.configureDataSource(self.state.match?.breakdownDict)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -5,10 +5,8 @@ import UIKit
 
 class MatchInfoViewController: TBAViewController, Refreshable {
 
-    private let matchKey: String
+    private var state: MatchState
     private let teamKey: String?
-
-    private var match: Match?
 
     // MARK: - UI
 
@@ -77,8 +75,16 @@ class MatchInfoViewController: TBAViewController, Refreshable {
 
     // MARK: Init
 
-    init(matchKey: String, teamKey: String? = nil, dependencies: Dependencies) {
-        self.matchKey = matchKey
+    convenience init(matchKey: String, teamKey: String? = nil, dependencies: Dependencies) {
+        self.init(state: .key(matchKey), teamKey: teamKey, dependencies: dependencies)
+    }
+
+    convenience init(match: Match, teamKey: String? = nil, dependencies: Dependencies) {
+        self.init(state: .match(match), teamKey: teamKey, dependencies: dependencies)
+    }
+
+    private init(state: MatchState, teamKey: String?, dependencies: Dependencies) {
+        self.state = state
         self.teamKey = teamKey
 
         super.init(dependencies: dependencies)
@@ -94,6 +100,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
         super.viewDidLoad()
 
         styleInterface()
+        updateInterface()
     }
 
     // MARK: Interface Methods
@@ -122,18 +129,13 @@ class MatchInfoViewController: TBAViewController, Refreshable {
         view.backgroundColor = .systemBackground
     }
 
-    func apply(match: Match) {
-        self.match = match
-        updateInterface()
-    }
-
     func updateInterface() {
         updateMatchSummaryView()
         updateMatchVideos()
     }
 
     func updateMatchSummaryView() {
-        guard let match else { return }
+        guard let match = state.match else { return }
         matchSummaryView.resetView()
 
         var baseTeamKeys: [String] = []
@@ -150,7 +152,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
             view.removeFromSuperview()
         }
 
-        guard let match else { return }
+        guard let match = state.match else { return }
         for video in match.videos {
             let playerView = Self.playerView(for: video)
             videoStackView.addArrangedSubview(playerView)
@@ -176,14 +178,14 @@ class MatchInfoViewController: TBAViewController, Refreshable {
 
     var isDataSourceEmpty: Bool {
         // Match hasn't loaded yet, or it has loaded but has no videos.
-        (match?.videos.count ?? 0) == 0
+        (state.match?.videos.count ?? 0) == 0
     }
 
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.api.match(key: self.matchKey)
-            self.apply(match: fetched)
+            self.state = .match(try await self.api.match(key: self.state.key))
+            self.updateInterface()
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -3,55 +3,85 @@ import Photos
 import TBAAPI
 import UIKit
 
+enum MatchState {
+    case key(String)
+    case match(Match)
+
+    var key: String {
+        switch self {
+        case .key(let key): return key
+        case .match(let match): return match.key
+        }
+    }
+
+    var match: Match? {
+        switch self {
+        case .key: return nil
+        case .match(let match): return match
+        }
+    }
+}
+
 class MatchViewController: MyTBAContainerViewController {
 
-    private let matchKey: String
+    private var state: MatchState
     private let teamKey: String?
-
-    private var match: Match?
 
     private(set) var infoViewController: MatchInfoViewController
     private let breakdownViewController: MatchBreakdownViewController
 
     override var subscribableModel: MyTBASubscribable {
-        MatchSubscribable(modelKey: matchKey)
+        MatchSubscribable(modelKey: state.key)
     }
 
     // MARK: Init
 
-    init(matchKey: String, teamKey: String? = nil, dependencies: Dependencies) {
-        self.matchKey = matchKey
+    convenience init(matchKey: String, teamKey: String? = nil, dependencies: Dependencies) {
+        self.init(state: .key(matchKey), teamKey: teamKey, dependencies: dependencies)
+    }
+
+    convenience init(match: Match, teamKey: String? = nil, dependencies: Dependencies) {
+        self.init(state: .match(match), teamKey: teamKey, dependencies: dependencies)
+    }
+
+    private init(state: MatchState, teamKey: String?, dependencies: Dependencies) {
+        self.state = state
         self.teamKey = teamKey
 
-        infoViewController = MatchInfoViewController(
-            matchKey: matchKey,
-            teamKey: teamKey,
-            dependencies: dependencies
-        )
-        breakdownViewController = MatchBreakdownViewController(
-            matchKey: matchKey,
-            year: MatchKey.year(from: matchKey) ?? 0,
-            dependencies: dependencies
-        )
+        switch state {
+        case .key(let matchKey):
+            infoViewController = MatchInfoViewController(
+                matchKey: matchKey,
+                teamKey: teamKey,
+                dependencies: dependencies
+            )
+            breakdownViewController = MatchBreakdownViewController(
+                matchKey: matchKey,
+                year: MatchKey.year(from: matchKey) ?? 0,
+                dependencies: dependencies
+            )
+        case .match(let match):
+            infoViewController = MatchInfoViewController(
+                match: match,
+                teamKey: teamKey,
+                dependencies: dependencies
+            )
+            breakdownViewController = MatchBreakdownViewController(
+                match: match,
+                dependencies: dependencies
+            )
+        }
 
+        let navTitle = state.match?.friendlyName ?? state.key
         super.init(
             viewControllers: [infoViewController, breakdownViewController],
-            navigationTitle: "Match",
+            navigationTitle: navTitle,
             navigationSubtitle: nil,
             segmentedControlTitles: ["Info", "Breakdown"],
-
             dependencies: dependencies
         )
 
         infoViewController.matchSummaryDelegate = self
-    }
-
-    convenience init(match: Match, teamKey: String? = nil, dependencies: Dependencies) {
-        self.init(matchKey: match.key, teamKey: teamKey, dependencies: dependencies)
-        self.match = match
-        self.navigationTitle = match.friendlyName
-        self.infoViewController.apply(match: match)
-        self.breakdownViewController.apply(match: match)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -73,21 +103,16 @@ class MatchViewController: MyTBAContainerViewController {
             // here even with reverse-order awaits (#995 didn't fully fix it).
             // Task handles heap-allocate and sidestep the allocator entirely.
             // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
-            let matchHandle = Task { try? await self.dependencies.api.match(key: self.matchKey) }
+            let matchHandle = Task { try? await self.dependencies.api.match(key: self.state.key) }
             let eventHandle = Task {
-                try? await self.dependencies.api.event(key: MatchKey.eventKey(from: self.matchKey))
+                try? await self.dependencies.api.event(key: MatchKey.eventKey(from: self.state.key))
             }
 
-            let match = await matchHandle.value
-            let event = await eventHandle.value
-
-            if let match {
-                self.match = match
+            if let match = await matchHandle.value {
+                self.state = .match(match)
                 self.navigationTitle = match.friendlyName
-                self.infoViewController.apply(match: match)
-                self.breakdownViewController.apply(match: match)
             }
-            if let event {
+            if let event = await eventHandle.value {
                 self.navigationSubtitle = "@ \(event.friendlyNameWithYear)"
             }
         }
@@ -107,7 +132,7 @@ extension MatchViewController: MatchSummaryViewDelegate {
 
     func teamPressed(teamNumber: Int) {
         let targetKey = "frc\(teamNumber)"
-        guard let match, match.allTeamKeys.contains(targetKey) else { return }
+        guard let match = state.match, match.allTeamKeys.contains(targetKey) else { return }
         let year = match.year ?? 0
         let teamAtEventVC = TeamAtEventViewController(
             teamKey: targetKey,


### PR DESCRIPTION
## Summary

Fixes a fatal crash on every match selection: `MatchBreakdownViewController.swift:105: Unexpectedly found nil while implicitly unwrapping an Optional value`.

**Root cause.** PR #1054 added `MatchViewController.init(match:)` to seed scores synchronously and avoid the "time → blank → score" flash. That convenience init called `breakdownViewController.apply(match:)` during init — before `viewDidLoad()` had run `setupDataSource()`. The implicitly-unwrapped `dataSource!` was nil, so `dataSource.snapshot()` crashed. `MatchInfoViewController.apply(match:)` didn't crash because all its subviews are programmatic property-level inits, but the underlying API shape — push state into the child after construction — is still wrong.

**Fix.** Removed `apply(match:)` from both child VCs and adopted the init-time seeding pattern from #987 (`EventInfoViewController`):

- New `MatchState` enum at file scope in `MatchViewController.swift`, shared with both children:
  ```swift
  enum MatchState {
      case key(String)
      case match(Match)
  }
  ```
- Each VC stores `private var state: MatchState` (replacing the `matchKey: String` + `match: Match?` pair). Single source of truth — impossible for the key and the match to drift, impossible to reach for `matchKey` when we already have the full `Match`.
- `init(matchKey:)` and `init(match:)` are convenience inits that funnel into one private designated init taking `state:`.
- `viewDidLoad` consumes `state` directly (no `if let match { apply(match: match) }` dance).
- `refresh()` updates state in one assignment: `self.state = .match(try await api.match(key: state.key))` — no interim `let fetched`.
- `MatchViewController` collapses its two inits into convenience inits funneling into one private designated init. The synchronous-seeding goal of #1054 is preserved because the seed now travels through init rather than a post-hoc `apply()` call.
- Nav title defaults to `state.key` when only a key is available, then upgrades to `match.friendlyName` once `loadMatchAndEvent` resolves — same shape as `EventViewController` does for events.

## Test plan

- [ ] Tap a match from any matches list (event detail, team@event). VC pushes without crashing; the score renders immediately (no blank flash).
- [ ] Tap a match from MyTBA notifications (key-only path). VC pushes with the match key as the nav title, then upgrades to `friendlyName` once the fetch resolves.
- [ ] Switch to the Breakdown segment. Table renders the breakdown for the seeded match; pull-to-refresh updates from the API.
- [ ] Switch to the Info segment. Score / videos render from the seeded match; pull-to-refresh updates.
- [ ] Tap a team in the match summary — `teamPressed` still pushes the team@event VC.
- [ ] Verify nav subtitle (`@ <event name>`) populates after push.