### PR TITLE
Adopt EventState / TeamState pattern from MatchState

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -31,10 +31,8 @@ private enum EventInfoItem: Hashable {
 
 class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
 
-    private let eventKey: String
+    private var state: EventState
     private let eventName: String?
-
-    private var event: Event?
 
     private var dataSource: TableViewDataSource<EventInfoSection, EventInfoItem>!
 
@@ -43,16 +41,15 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: - Init
 
     convenience init(eventKey: String, name: String? = nil, dependencies: Dependencies) {
-        self.init(eventKey: eventKey, event: nil, eventName: name, dependencies: dependencies)
+        self.init(state: .key(eventKey), eventName: name, dependencies: dependencies)
     }
 
     convenience init(event: Event, dependencies: Dependencies) {
-        self.init(eventKey: event.key, event: event, eventName: nil, dependencies: dependencies)
+        self.init(state: .event(event), eventName: nil, dependencies: dependencies)
     }
 
-    private init(eventKey: String, event: Event?, eventName: String?, dependencies: Dependencies) {
-        self.eventKey = eventKey
-        self.event = event
+    private init(state: EventState, eventName: String?, dependencies: Dependencies) {
+        self.state = state
         self.eventName = eventName
 
         super.init(style: .grouped, dependencies: dependencies)
@@ -111,11 +108,11 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
                     return cell
                 case .twitter:
                     let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
-                    cell.textLabel?.text = "View \(self.eventKey) on Twitter"
+                    cell.textLabel?.text = "View \(self.state.key) on Twitter"
                     return cell
                 case .youtube:
                     let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
-                    cell.textLabel?.text = "View \(self.eventKey) on YouTube"
+                    cell.textLabel?.text = "View \(self.state.key) on YouTube"
                     return cell
                 case .chiefDelphi:
                     let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
@@ -133,7 +130,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         snapshot.appendSections([.title])
         snapshot.appendItems([.title], toSection: .title)
 
-        if let event {
+        if let event = state.event {
             let webcasts = event.webcasts
                 .sorted { $0.channel > $1.channel }
                 .filter { $0.urlString != nil }
@@ -148,14 +145,14 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         // a single-row ghost during push. districtPoints is event-dependent
         // so it only appears once we know the event has a district.
         var detailItems: [EventInfoItem] = [.alliances, .insights, .awards]
-        if event?.district != nil {
+        if state.event?.district != nil {
             detailItems.insert(.districtPoints, at: 1)
         }
         snapshot.appendSections([.detail])
         snapshot.appendItems(detailItems, toSection: .detail)
 
         var linkItems: [EventInfoItem] = [.twitter, .youtube, .chiefDelphi]
-        if event?.hasWebsite == true {
+        if state.event?.hasWebsite == true {
             linkItems.insert(.website, at: 0)
         }
         snapshot.appendSections([.link])
@@ -170,14 +167,14 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         -> UITableViewCell
     {
         let cell = tableView.dequeueReusableCell(indexPath: indexPath) as InfoTableViewCell
-        if let event {
+        if let event = state.event {
             cell.viewModel = InfoCellViewModel(event: event)
         } else if let eventName, !eventName.isEmpty {
-            let year = String(eventKey.prefix(4))
+            let year = String(state.key.prefix(4))
             let name = year.allSatisfy(\.isNumber) ? "\(year) \(eventName)" : eventName
             cell.viewModel = InfoCellViewModel(nameString: name, subtitleStrings: [])
         } else {
-            cell.viewModel = InfoCellViewModel(nameString: eventKey, subtitleStrings: [])
+            cell.viewModel = InfoCellViewModel(nameString: state.key, subtitleStrings: [])
         }
 
         cell.accessoryType = .none
@@ -216,13 +213,13 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         case .webcast(let webcast):
             urlString = webcast.urlString
         case .website:
-            urlString = event?.website
+            urlString = state.event?.website
         case .twitter:
-            urlString = "https://twitter.com/search?q=%23\(eventKey)"
+            urlString = "https://twitter.com/search?q=%23\(state.key)"
         case .youtube:
-            urlString = "https://www.youtube.com/results?search_query=\(eventKey)"
+            urlString = "https://www.youtube.com/results?search_query=\(state.key)"
         case .chiefDelphi:
-            urlString = "https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A\(eventKey)"
+            urlString = "https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A\(state.key)"
         default:
             break
         }
@@ -234,13 +231,12 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Refreshable
 
-    var isDataSourceEmpty: Bool { event == nil }
+    var isDataSourceEmpty: Bool { state.event == nil }
 
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.api.event(key: self.eventKey)
-            self.event = fetched
+            self.state = .event(try await self.api.event(key: self.state.key))
             self.updateEventInfo()
         }
     }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -3,10 +3,28 @@ import Photos
 import TBAAPI
 import UIKit
 
+enum EventState {
+    case key(String)
+    case event(Event)
+
+    var key: String {
+        switch self {
+        case .key(let key): return key
+        case .event(let event): return event.key
+        }
+    }
+
+    var event: Event? {
+        switch self {
+        case .key: return nil
+        case .event(let event): return event
+        }
+    }
+}
+
 class EventViewController: MyTBAContainerViewController, EventStatusSubscribable {
 
-    private let eventKey: String
-    private var event: Event?
+    private var state: EventState
 
     private(set) var infoViewController: EventInfoViewController
     private(set) var teamsViewController: EventTeamsViewController
@@ -14,46 +32,46 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
     private(set) var matchesViewController: MatchesViewController
 
     override var subscribableModel: MyTBASubscribable {
-        EventSubscribable(modelKey: eventKey)
+        EventSubscribable(modelKey: state.key)
     }
 
     // MARK: - Init
 
     convenience init(eventKey: String, name: String? = nil, dependencies: Dependencies) {
-        self.init(eventKey: eventKey, event: nil, eventName: name, dependencies: dependencies)
+        self.init(state: .key(eventKey), eventName: name, dependencies: dependencies)
     }
 
     convenience init(event: Event, dependencies: Dependencies) {
-        self.init(eventKey: event.key, event: event, eventName: nil, dependencies: dependencies)
+        self.init(state: .event(event), eventName: nil, dependencies: dependencies)
     }
 
-    private init(eventKey: String, event: Event?, eventName: String?, dependencies: Dependencies) {
-        self.eventKey = eventKey
-        self.event = event
+    private init(state: EventState, eventName: String?, dependencies: Dependencies) {
+        self.state = state
 
-        if let event {
-            infoViewController = EventInfoViewController(event: event, dependencies: dependencies)
-        } else {
+        switch state {
+        case .key(let eventKey):
             infoViewController = EventInfoViewController(
                 eventKey: eventKey,
                 name: eventName,
                 dependencies: dependencies
             )
+        case .event(let event):
+            infoViewController = EventInfoViewController(event: event, dependencies: dependencies)
         }
         teamsViewController = EventTeamsViewController(
-            eventKey: eventKey,
+            eventKey: state.key,
             dependencies: dependencies
         )
         rankingsViewController = EventRankingsViewController(
-            eventKey: eventKey,
+            eventKey: state.key,
             dependencies: dependencies
         )
         matchesViewController = MatchesViewController(
-            eventKey: eventKey,
+            eventKey: state.key,
             dependencies: dependencies
         )
 
-        let navTitle = event?.friendlyNameWithYear ?? eventKey
+        let navTitle = state.event?.friendlyNameWithYear ?? state.key
         super.init(
             viewControllers: [
                 infoViewController, teamsViewController, rankingsViewController,
@@ -81,14 +99,14 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if isEventDown(eventKey: eventKey) {
+        if isEventDown(eventKey: state.key) {
             showOfflineEventMessage(shouldShow: true, animated: false)
         }
-        registerForEventStatusChanges(eventKey: eventKey)
+        registerForEventStatusChanges(eventKey: state.key)
 
         Task { @MainActor in
-            if let fetched = try? await api.event(key: eventKey) {
-                event = fetched
+            if let fetched = try? await api.event(key: state.key) {
+                state = .event(fetched)
                 title = fetched.friendlyNameWithYear
                 navigationTitle = fetched.friendlyNameWithYear
             }
@@ -119,7 +137,7 @@ private struct EventSubscribable: MyTBASubscribable {
 extension EventViewController: EventInfoViewControllerDelegate {
 
     func showAlliances() {
-        guard let event else { return }
+        guard let event = state.event else { return }
         let eventAlliancesViewController = EventAlliancesContainerViewController(
             event: event,
             dependencies: dependencies
@@ -128,7 +146,7 @@ extension EventViewController: EventInfoViewControllerDelegate {
     }
 
     func showAwards() {
-        guard let event else { return }
+        guard let event = state.event else { return }
         let eventAwardsViewController = EventAwardsContainerViewController(
             event: event,
             dependencies: dependencies
@@ -137,7 +155,7 @@ extension EventViewController: EventInfoViewControllerDelegate {
     }
 
     func showDistrictPoints() {
-        guard let event else { return }
+        guard let event = state.event else { return }
         let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(
             event: event,
             dependencies: dependencies
@@ -149,7 +167,7 @@ extension EventViewController: EventInfoViewControllerDelegate {
     }
 
     func showInsights() {
-        guard let event else { return }
+        guard let event = state.event else { return }
         let eventInsightsContainerViewController = EventInsightsContainerViewController(
             event: event,
             dependencies: dependencies
@@ -177,10 +195,10 @@ extension EventViewController: EventRankingsViewControllerDelegate {
     }
 
     private func pushTeamAtEvent(teamKey: String) {
-        let year = event?.year ?? Int(eventKey.prefix(4)) ?? 0
+        let year = state.event?.year ?? Int(state.key.prefix(4)) ?? 0
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
-            eventKey: eventKey,
+            eventKey: state.key,
             year: year,
             dependencies: dependencies
         )

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -19,9 +19,7 @@ private enum TeamInfoItem {
 
 class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
 
-    private let teamKey: String
-
-    private var team: Team?
+    private var state: TeamState
 
     private var dataSource: TableViewDataSource<TeamInfoSection, TeamInfoItem>!
 
@@ -30,16 +28,15 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: - Init
 
     convenience init(teamKey: String, dependencies: Dependencies) {
-        self.init(teamKey: teamKey, team: nil, dependencies: dependencies)
+        self.init(state: .key(teamKey), dependencies: dependencies)
     }
 
     convenience init(team: Team, dependencies: Dependencies) {
-        self.init(teamKey: team.key, team: team, dependencies: dependencies)
+        self.init(state: .team(team), dependencies: dependencies)
     }
 
-    private init(teamKey: String, team: Team?, dependencies: Dependencies) {
-        self.teamKey = teamKey
-        self.team = team
+    private init(state: TeamState, dependencies: Dependencies) {
+        self.state = state
 
         super.init(style: .grouped, dependencies: dependencies)
     }
@@ -82,11 +79,11 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
                     return cell
                 case .twitter:
                     let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
-                    cell.textLabel?.text = "View \(self.teamKey) on Twitter"
+                    cell.textLabel?.text = "View \(self.state.key) on Twitter"
                     return cell
                 case .youtube:
                     let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
-                    cell.textLabel?.text = "View \(self.teamKey) on YouTube"
+                    cell.textLabel?.text = "View \(self.state.key) on YouTube"
                     return cell
                 case .chiefDelphi:
                     let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
@@ -101,7 +98,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
         var snapshot = dataSource.snapshot()
         snapshot.deleteAllItems()
 
-        guard let team else {
+        guard let team = state.team else {
             dataSource.applySnapshotUsingReloadData(snapshot)
             return
         }
@@ -145,7 +142,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
         let cell =
             tableView.dequeueReusableCell(indexPath: indexPath) as ReverseSubtitleTableViewCell
         cell.titleLabel?.text = "Location"
-        cell.subtitleLabel?.text = team?.locationString
+        cell.subtitleLabel?.text = state.team?.locationString
         cell.accessoryType = .none
         cell.selectionStyle = .none
         return cell
@@ -157,7 +154,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
         let cell =
             tableView.dequeueReusableCell(indexPath: indexPath) as ReverseSubtitleTableViewCell
         cell.titleLabel?.text = "Rookie Year"
-        cell.subtitleLabel?.text = team?.rookieYear.map(String.init) ?? ""
+        cell.subtitleLabel?.text = state.team?.rookieYear.map(String.init) ?? ""
         cell.accessoryType = .none
         cell.selectionStyle = .none
         return cell
@@ -168,7 +165,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
     {
         let cell = tableView.dequeueReusableCell(indexPath: indexPath) as BasicTableViewCell
 
-        cell.textLabel?.text = team?.name
+        cell.textLabel?.text = state.team?.name
         cell.textLabel?.textColor = UIColor.secondaryLabel
 
         if sponsorsExpanded {
@@ -205,13 +202,13 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
             sponsorsExpanded = true
             reloadSponsors()
         case .website:
-            urlString = team?.website
+            urlString = state.team?.website
         case .twitter:
-            urlString = "https://twitter.com/search?q=%23\(teamKey)"
+            urlString = "https://twitter.com/search?q=%23\(state.key)"
         case .youtube:
-            urlString = "https://www.youtube.com/results?search_query=\(teamKey)"
+            urlString = "https://www.youtube.com/results?search_query=\(state.key)"
         case .chiefDelphi:
-            urlString = "https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A\(teamKey)"
+            urlString = "https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A\(state.key)"
         default:
             break
         }
@@ -223,13 +220,12 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Refreshable
 
-    var isDataSourceEmpty: Bool { team == nil }
+    var isDataSourceEmpty: Bool { state.team == nil }
 
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.api.team(key: self.teamKey)
-            self.team = fetched
+            self.state = .team(try await self.api.team(key: self.state.key))
             self.updateTeamInfo()
         }
     }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -4,11 +4,28 @@ import Photos
 import TBAAPI
 import UIKit
 
+enum TeamState {
+    case key(String)
+    case team(Team)
+
+    var key: String {
+        switch self {
+        case .key(let key): return key
+        case .team(let team): return team.key
+        }
+    }
+
+    var team: Team? {
+        switch self {
+        case .key: return nil
+        case .team(let team): return team
+        }
+    }
+}
+
 class TeamViewController: HeaderContainerViewController {
 
-    private let teamKey: String
-
-    private var team: Team?
+    private var state: TeamState
     private var yearsParticipated: [Int] = []
     private var avatarImage: UIImage?
 
@@ -23,7 +40,7 @@ class TeamViewController: HeaderContainerViewController {
     private(set) var mediaViewController: TeamMediaCollectionViewController
 
     override var subscribableModel: MyTBASubscribable {
-        TeamSubscribable(modelKey: teamKey)
+        TeamSubscribable(modelKey: state.key)
     }
 
     private var year: Int? {
@@ -40,29 +57,22 @@ class TeamViewController: HeaderContainerViewController {
     // MARK: Init
 
     convenience init(teamKey: String, nickname: String? = nil, dependencies: Dependencies) {
-        self.init(
-            teamKey: teamKey,
-            team: nil,
-            partialNickname: nickname,
-            dependencies: dependencies
-        )
+        self.init(state: .key(teamKey), partialNickname: nickname, dependencies: dependencies)
     }
 
     convenience init(team: Team, dependencies: Dependencies) {
-        self.init(teamKey: team.key, team: team, partialNickname: nil, dependencies: dependencies)
+        self.init(state: .team(team), partialNickname: nil, dependencies: dependencies)
     }
 
-    private init(teamKey: String, team: Team?, partialNickname: String?, dependencies: Dependencies)
-    {
-        self.teamKey = teamKey
-        self.team = team
+    private init(state: TeamState, partialNickname: String?, dependencies: Dependencies) {
+        self.state = state
 
-        let teamNumber = team?.teamNumber ?? Int(TeamKey.trimFRCPrefix(teamKey)) ?? 0
+        let teamNumber = state.team?.teamNumber ?? Int(TeamKey.trimFRCPrefix(state.key)) ?? 0
         let nickname: String? = {
-            if let team, !team.nickname.isEmpty { return team.nickname }
+            if let team = state.team, !team.nickname.isEmpty { return team.nickname }
             return partialNickname
         }()
-        let teamNumberNickname = team?.teamNumberNickname ?? "Team \(teamNumber)"
+        let teamNumberNickname = state.team?.teamNumberNickname ?? "Team \(teamNumber)"
 
         self.teamHeaderView = TeamHeaderView(
             TeamHeaderViewModel(
@@ -74,21 +84,22 @@ class TeamViewController: HeaderContainerViewController {
             )
         )
 
-        if let team {
-            infoViewController = TeamInfoViewController(team: team, dependencies: dependencies)
-        } else {
+        switch state {
+        case .key(let teamKey):
             infoViewController = TeamInfoViewController(
                 teamKey: teamKey,
                 dependencies: dependencies
             )
+        case .team(let team):
+            infoViewController = TeamInfoViewController(team: team, dependencies: dependencies)
         }
         eventsViewController = TeamEventsViewController(
-            teamKey: teamKey,
+            teamKey: state.key,
             year: nil,
             dependencies: dependencies
         )
         mediaViewController = TeamMediaCollectionViewController(
-            teamKey: teamKey,
+            teamKey: state.key,
             year: Calendar.current.component(.year, from: Date()),
             dependencies: dependencies
         )
@@ -133,20 +144,17 @@ class TeamViewController: HeaderContainerViewController {
             // here even with reverse-order awaits (#995 didn't fully fix it).
             // Task handles heap-allocate and sidestep the allocator entirely.
             // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
-            let teamHandle = Task { try? await self.dependencies.api.team(key: self.teamKey) }
+            let teamHandle = Task { try? await self.dependencies.api.team(key: self.state.key) }
             let yearsHandle = Task {
-                try? await self.dependencies.api.teamYearsParticipated(key: self.teamKey)
+                try? await self.dependencies.api.teamYearsParticipated(key: self.state.key)
             }
 
-            let team = await teamHandle.value
-            let years = await yearsHandle.value
-
-            if let team {
-                self.team = team
+            if let team = await teamHandle.value {
+                self.state = .team(team)
                 self.navigationTitle = team.teamNumberNickname
                 updateInterface()
             }
-            if let years {
+            if let years = await yearsHandle.value {
                 self.yearsParticipated = years.sorted().reversed()
                 if year == nil {
                     year = Self.latestYear(
@@ -169,7 +177,7 @@ class TeamViewController: HeaderContainerViewController {
     }
 
     private func updateInterface() {
-        if let team {
+        if let team = state.team {
             teamHeaderView.viewModel = TeamHeaderViewModel(
                 teamNumber: team.teamNumber,
                 avatar: avatarImage,
@@ -185,7 +193,7 @@ class TeamViewController: HeaderContainerViewController {
         Task { @MainActor in
             guard
                 let media = try? await dependencies.api.teamMediaByYear(
-                    teamKey: teamKey,
+                    teamKey: state.key,
                     year: year
                 )
             else { return }
@@ -254,7 +262,7 @@ extension TeamViewController: EventsListViewControllerDelegate {
 
     func eventSelected(_ event: Event) {
         let teamAtEventViewController = TeamAtEventViewController(
-            teamKey: teamKey,
+            teamKey: state.key,
             eventKey: event.key,
             year: event.year,
             dependencies: dependencies


### PR DESCRIPTION
## Summary

Follow-up to #1059. Applies the init-time `State` enum pattern from the Match VCs to the Event and Team VC families.

- New `EventState` enum at file scope in `EventViewController.swift`; new `TeamState` enum at file scope in `TeamViewController.swift`. Children in each family (`EventInfoViewController`, `TeamInfoViewController`) share the parent's definition rather than redeclaring.
- Each VC's `(eventKey: String, event: Event?)` / `(teamKey: String, team: Team?)` property pair collapses into one `private var state`. Single source of truth — the key and the model can no longer drift, and there's no path to reach for `eventKey`/`teamKey` when the full model is already in hand.
- Convenience inits (`init(eventKey:name:)` / `init(event:)` / `init(teamKey:nickname:)` / `init(team:)`) funnel into one private designated init taking `state:`. Same shape as `MatchViewController` after #1059.
- `refresh()` updates state in a single assignment: `self.state = .event(try await self.api.event(key: state.key))` — no interim `fetched` local.
- `eventName` (the search-result title hint on `EventInfoViewController`) and `partialNickname` (the search-result header hint on `TeamViewController`) remain as separate properties. They're not "what model do we have" — they're orthogonal display fallbacks used only until the real model loads.
- `TeamAtEventViewController` and `TeamSummaryViewController` are intentionally untouched: they don't hold a single seeded model and don't expose an `apply()`-style API, so the pattern doesn't apply.

## Test plan

- [ ] Push an event from the events list (full-`Event` path). Title renders immediately as `friendlyNameWithYear`; refresh on each segment continues to work.
- [ ] Push an event from MyTBA notifications (key-only path). Title shows the event key, then upgrades to `friendlyNameWithYear` once the fetch resolves.
- [ ] Push an event from search results (key + verbose name path). Title cell shows the partial name with year prefix until the full event loads.
- [ ] Tap **Alliances**, **Awards**, **District Points**, **Insights** from the event info VC — each push only fires once the full event has loaded (`guard let event = state.event`).
- [ ] Push a team from the teams list (full-`Team` path). Header renders nickname/teamNumber immediately; year picker, events, media all populate.
- [ ] Push a team from MyTBA notifications (key-only path). Header shows "Team N" then upgrades to nickname after fetch.
- [ ] Push a team from search (key + nickname path). Header shows the search nickname until the full team loads.
- [ ] Pull-to-refresh on `TeamInfoViewController` and `EventInfoViewController` — sponsors / detail rows still rebuild correctly.