### PR TITLE
Inline `let fetched =` interims in refresh closures

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -92,10 +92,9 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched =
+            self.allRankings =
                 try await self.dependencies.api.districtRankings(key: self.districtKey) ?? []
-            self.allRankings = fetched
-            self.applyRankings(fetched)
+            self.applyRankings(self.allRankings)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
@@ -80,8 +80,7 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.districtsByYear(self.year)
-            self.apply(fetched)
+            self.apply(try await self.dependencies.api.districtsByYear(self.year))
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
@@ -118,8 +118,8 @@ private class EventAlliancesViewController: TBATableViewController, Refreshable,
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.eventAlliances(key: self.eventKey)
-            self.alliances = fetched ?? []
+            self.alliances =
+                try await self.dependencies.api.eventAlliances(key: self.eventKey) ?? []
             self.tableView.reloadData()
         }
     }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -127,8 +127,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.eventAwards(key: self.eventKey)
-            self.applyAwards(fetched)
+            self.applyAwards(try await self.dependencies.api.eventAwards(key: self.eventKey))
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
@@ -80,12 +80,11 @@ class WeekEventsViewController: EventsListViewController {
     override func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.eventsByYear(self.currentYear)
-            self.allEvents = fetched
+            self.allEvents = try await self.dependencies.api.eventsByYear(self.currentYear)
             if self.weekEvent == nil {
                 self.weekEvent = WeekEventsViewController.initialWeekEvent(
                     for: self.currentYear,
-                    from: fetched
+                    from: self.allEvents
                 )
             } else {
                 self.applyEvents(self.allEvents)

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -167,9 +167,8 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.eventMatches(key: self.eventKey)
-            self.allMatches = fetched
-            self.applyMatches(fetched)
+            self.allMatches = try await self.dependencies.api.eventMatches(key: self.eventKey)
+            self.applyMatches(self.allMatches)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -113,8 +113,7 @@ class SearchViewController: TBATableViewController {
     private func loadIndex() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.getSearchIndex()
-            self.index = fetched
+            self.index = try await self.dependencies.api.getSearchIndex()
             self.updateSnapshot()
         }
     }

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -120,8 +120,7 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.loadTeams()
-            self.applyTeams(fetched)
+            self.applyTeams(try await self.loadTeams())
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #1059 / #1060. Collapses interim `let fetched = ...` locals that exist only to bridge a single async call into the next assignment or method call. No behavior change — purely cosmetic.

Eight sites updated:

| File | Before | After |
|---|---|---|
| `DistrictsViewController` | `let fetched = try await …; self.apply(fetched)` | `self.apply(try await …)` |
| `TeamsListViewController` | `let fetched = try await …; self.applyTeams(fetched)` | `self.applyTeams(try await …)` |
| `EventAwardsViewController` | `let fetched = try await …; self.applyAwards(fetched)` | `self.applyAwards(try await …)` |
| `EventAlliancesViewController` | `let fetched = try await …; self.alliances = fetched ?? []` | `self.alliances = try await … ?? []` |
| `SearchViewController` | `let fetched = try await …; self.index = fetched; self.updateSnapshot()` | `self.index = try await …; self.updateSnapshot()` |
| `DistrictRankingsViewController` | `let fetched = try await … ?? []; self.allRankings = fetched; self.applyRankings(fetched)` | `self.allRankings = try await … ?? []; self.applyRankings(self.allRankings)` |
| `MatchesViewController` | `let fetched = try await …; self.allMatches = fetched; self.applyMatches(fetched)` | `self.allMatches = try await …; self.applyMatches(self.allMatches)` |
| `WeekEventsViewController` | `let fetched = try await …; self.allEvents = fetched; …use fetched…` | `self.allEvents = try await …; …use self.allEvents…` |

### Left alone

- `DistrictBreakdownViewController` and `DistrictTeamSummaryViewController` — `fetched?.first(where: …)` does element lookup against a list; the local is holding the fetched list while picking one element out of it.
- `EventViewController.viewDidLoad` — `if let fetched = try? await …` uses `fetched` three times (`state = .event(fetched)`, `title = fetched.friendlyNameWithYear`, `navigationTitle = fetched.friendlyNameWithYear`); inlining would re-await.

## Test plan

- [ ] Pull-to-refresh on districts list, teams list, matches list, events list, event alliances, event awards, district rankings — all still render fresh data.
- [ ] Open Search — index still loads on first present.
- [ ] Open the Events container on first launch of the year — `initialWeekEvent` still picks the right week.