### PR TITLE
Restore team nicknames on Event Rankings

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Client/TBAAPI+Events.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Client/TBAAPI+Events.swift
@@ -50,6 +50,22 @@ extension TBAAPI {
         }
     }
 
+    public func eventTeamsSimple(key eventKey: String) async throws -> [TeamSimple] {
+        let response = try await client.getEventTeamsSimple(path: .init(eventKey: eventKey))
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json
+        case .notModified:
+            throw TBAAPIError.notModified
+        case .unauthorized:
+            throw TBAAPIError.unauthorized
+        case .notFound:
+            throw TBAAPIError.notFound
+        case .undocumented(let statusCode, _):
+            throw TBAAPIError.unexpectedStatus(statusCode)
+        }
+    }
+
     public func eventRankings(key eventKey: String) async throws -> EventRanking {
         let response = try await client.getEventRankings(path: .init(eventKey: eventKey))
         switch response {

--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
@@ -29,6 +29,7 @@ public protocol TBAAPIProtocol {
     func eventsByYear(_ year: Int) async throws -> [Event]
     func event(key eventKey: String) async throws -> Event
     func eventTeams(key eventKey: String) async throws -> [Team]
+    func eventTeamsSimple(key eventKey: String) async throws -> [TeamSimple]
     func eventRankings(key eventKey: String) async throws -> EventRanking
     func eventAlliances(key eventKey: String) async throws -> [EliminationAlliance]?
     func eventAwards(key eventKey: String) async throws -> [Award]

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
@@ -16,6 +16,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
     private var rankings: [EventRanking.RankingsPayloadPayload] = []
     private var extraStatsInfo: [EventRanking.ExtraStatsInfoPayloadPayload] = []
     private var sortOrderInfo: [EventRanking.SortOrderInfoPayloadPayload] = []
+    private var teamsByKey: [String: TeamSimple] = [:]
 
     // MARK: - Init
 
@@ -54,7 +55,12 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
             [weak self] tableView, indexPath, ranking in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as RankingTableViewCell
             let detail = self?.rankingInfoString(for: ranking)
-            cell.viewModel = RankingCellViewModel(apiRanking: ranking, detailText: detail)
+            let team = self?.teamsByKey[ranking.teamKey]
+            cell.viewModel = RankingCellViewModel(
+                apiRanking: ranking,
+                detailText: detail,
+                team: team
+            )
             return cell
         }
         dataSource.statefulDelegate = self
@@ -113,7 +119,25 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let response = try await self.dependencies.api.eventRankings(key: self.eventKey)
+            // Unstructured Task handles instead of `async let`: Swift 6.1's
+            // async-let stack allocator trips swift_task_dealloc's LIFO check
+            // here even with reverse-order awaits (#995 didn't fully fix it).
+            // Task handles heap-allocate and sidestep the allocator entirely.
+            // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
+            let rankingsHandle = Task {
+                try await self.dependencies.api.eventRankings(key: self.eventKey)
+            }
+            let teamsHandle = Task {
+                try? await self.dependencies.api.eventTeamsSimple(key: self.eventKey)
+            }
+
+            // Persist teams before awaiting rankings so a rankings failure
+            // doesn't discard a successful teams response — the next refresh
+            // that succeeds on rankings will render using this team map.
+            let teams = await teamsHandle.value ?? []
+            self.teamsByKey = Dictionary(uniqueKeysWithValues: teams.map { ($0.key, $0) })
+
+            let response = try await rankingsHandle.value
             self.applyRanking(response)
         }
     }

--- a/the-blue-alliance-ios/ViewElements/Events/RankingCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/RankingCellViewModel.swift
@@ -35,10 +35,14 @@ struct RankingCellViewModel {
         self.wltText = nil
     }
 
-    init(apiRanking ranking: EventRanking.RankingsPayloadPayload, detailText: String?) {
+    init(
+        apiRanking ranking: EventRanking.RankingsPayloadPayload,
+        detailText: String?,
+        team: TeamSimple? = nil
+    ) {
         self.rankText = "Rank \(ranking.rank)"
         self.teamNumber = Self.teamNumber(from: ranking.teamKey)
-        self.teamName = "Team \(self.teamNumber ?? ranking.teamKey)"
+        self.teamName = team?.displayNickname ?? "Team \(self.teamNumber ?? ranking.teamKey)"
         self.detailText = detailText
         self.wltText = {
             if let qualAverage = ranking.qualAverage {


### PR DESCRIPTION
## Summary

- Event Rankings lost team nicknames after the TBAAPI / remove-TBAData migration — every row rendered as "Team 27" because `eventRankings(key:)` only returns `teamKey`, and the old TBAData nickname join was gone.
- `EventRankingsViewController.refresh()` now co-fetches `eventTeamsSimple(key:)` alongside rankings using unstructured `Task {}` handles (Swift 6.1 async-let allocator bug, #996 — matches the `TeamSummaryViewController` precedent). Teams are persisted to `teamsByKey` before awaiting rankings, so a rankings failure doesn't discard a successful teams response; the next successful rankings refresh renders with the already-loaded team map.
- `RankingCellViewModel` gained an optional `team: TeamSimple?` parameter and uses `team.displayNickname` when present, falling back to the existing "Team N" string otherwise.
- Added `eventTeamsSimple(key:)` to `TBAAPI` and `TBAAPIProtocol` (thin wrapper around the generated `getEventTeamsSimple` operation).

Failure behavior matches requested semantics:
- Rankings ✓ + Teams ✓ → nicknames render.
- Rankings ✓ + Teams ✗ → "Team N" fallback renders.
- Rankings ✗ → no render (existing `runRefresh` silent-swallow); teams, if successfully fetched, stay in memory for the next refresh.

No app-level cache added — URL loading system's `.useProtocolCachePolicy` handles HTTP caching.

## Test plan

- [ ] Build & run on simulator; open a 2026 event with rankings (e.g. `2026mimsc`) and confirm rows show real nicknames, not "Team 27".
- [ ] Pull-to-refresh; confirm nicknames remain.
- [ ] Airplane-mode regression after a successful load: rankings + teams should render from HTTP cache; on genuine teams failure, rows fall back to "Team N" without crashing.
- [ ] Verify no regressions on District Rankings / OPR cells (those view-model inits are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)