### PR TITLE
Bump OpenAPI spec to v3.13.0; adopt typed enums

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Awards/AwardType+Comparable.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Awards/AwardType+Comparable.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+// The OpenAPI-generated `AwardType` is a named integer enum without
+// `Comparable` conformance — adding it lets callers sort by award type
+// without reaching for `.rawValue`.
+extension AwardType: Comparable {
+    public static func < (lhs: AwardType, rhs: AwardType) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/APIEvent+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/APIEvent+Helpers.swift
@@ -18,7 +18,10 @@ public enum APIEventType: Int, CaseIterable, Sendable {
 extension Event {
 
     public var eventTypeEnum: APIEventType? {
-        APIEventType(rawValue: eventType)
+        // The OpenAPI spec types `eventType` as the generated EventType enum
+        // (we bumped to a spec that adds named integer enums), so we read the
+        // underlying integer via `.rawValue` to feed our hand-rolled APIEventType.
+        APIEventType(rawValue: eventType.rawValue)
     }
 
     public var safeShortName: String {

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/EventType+Comparable.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/EventType+Comparable.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+// The OpenAPI-generated `EventType` is a named integer enum without
+// `Comparable` conformance — adding it lets callers sort by event type
+// without reaching for `.rawValue`.
+extension EventType: Comparable {
+    public static func < (lhs: EventType, rhs: EventType) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
@@ -5,18 +5,22 @@ import Foundation
 // main app target picks them up through `import TBAAPI`.
 public typealias APIStatus = Components.Schemas.APIStatus
 public typealias Award = Components.Schemas.Award
+public typealias AwardType = Components.Schemas.AwardType
 public typealias CompLevel = Components.Schemas.CompLevel
 public typealias District = Components.Schemas.District
 public typealias DistrictRanking = Components.Schemas.DistrictRanking
+public typealias DoubleElimRound = Components.Schemas.DoubleElimRound
 public typealias EliminationAlliance = Components.Schemas.EliminationAlliance
 public typealias Event = Components.Schemas.Event
 public typealias EventDistrictPoints = Components.Schemas.EventDistrictPoints
 public typealias EventInsights = Components.Schemas.EventInsights
 public typealias EventOPRs = Components.Schemas.EventOPRs
 public typealias EventRanking = Components.Schemas.EventRanking
+public typealias EventType = Components.Schemas.EventType
 public typealias Match = Components.Schemas.Match
 public typealias MatchAlliance = Components.Schemas.MatchAlliance
 public typealias Media = Components.Schemas.Media
+public typealias PlayoffType = Components.Schemas.PlayoffType
 public typealias SearchIndex = Components.Schemas.SearchIndex
 public typealias Team = Components.Schemas.Team
 public typealias TeamEventStatus = Components.Schemas.TeamEventStatus

--- a/Packages/TBAAPI/Sources/TBAAPI/openapi.json
+++ b/Packages/TBAAPI/Sources/TBAAPI/openapi.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.12.2",
+    "version": "3.13.0",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.13.0: Introduce named integer enum schemas (AwardType, EventType, PlayoffType) using OpenAPI 3.1.1's annotated-enumeration pattern (`oneOf` of `const` branches with per-branch titles). The `award_type`, `event_type`, and `playoff_type` fields now reference these schemas. Integer values on the wire are unchanged; clients regenerated against the spec get value constraints, and Swagger UI renders the value->name mapping inline. 3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -5018,8 +5018,7 @@
             "description": "The name of the award as provided by FIRST. May vary for the same award type."
           },
           "award_type": {
-            "type": "integer",
-            "description": "Type of award given. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/award_type.py#L8"
+            "$ref": "#/components/schemas/AwardType"
           },
           "event_key": {
             "type": "string",
@@ -5087,6 +5086,247 @@
           "f"
         ],
         "description": "The competition level the match was played at."
+      },
+      "AwardType": {
+        "title": "AwardType",
+        "description": "Type of award given. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/award_type.py for full definitions.",
+        "type": "integer",
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30,
+          31,
+          32,
+          33,
+          34,
+          35,
+          36,
+          37,
+          38,
+          39,
+          40,
+          41,
+          42,
+          43,
+          44,
+          45,
+          46,
+          47,
+          48,
+          49,
+          50,
+          51,
+          52,
+          53,
+          54,
+          55,
+          56,
+          57,
+          58,
+          59,
+          60,
+          61,
+          62,
+          63,
+          64,
+          65,
+          66,
+          67,
+          68,
+          69,
+          70,
+          71,
+          72,
+          73,
+          74,
+          75,
+          76,
+          77,
+          78,
+          79,
+          80,
+          81,
+          82,
+          83
+        ],
+        "x-enum-varnames": [
+          "CHAIRMANS",
+          "WINNER",
+          "FINALIST",
+          "WOODIE_FLOWERS",
+          "DEANS_LIST",
+          "VOLUNTEER",
+          "FOUNDERS",
+          "BART_KAMEN_MEMORIAL",
+          "MAKE_IT_LOUD",
+          "ENGINEERING_INSPIRATION",
+          "ROOKIE_ALL_STAR",
+          "GRACIOUS_PROFESSIONALISM",
+          "COOPERTITION",
+          "JUDGES",
+          "HIGHEST_ROOKIE_SEED",
+          "ROOKIE_INSPIRATION",
+          "INDUSTRIAL_DESIGN",
+          "QUALITY",
+          "SAFETY",
+          "SPORTSMANSHIP",
+          "CREATIVITY",
+          "ENGINEERING_EXCELLENCE",
+          "ENTREPRENEURSHIP",
+          "EXCELLENCE_IN_DESIGN",
+          "EXCELLENCE_IN_DESIGN_CAD",
+          "EXCELLENCE_IN_DESIGN_ANIMATION",
+          "DRIVING_TOMORROWS_TECHNOLOGY",
+          "IMAGERY",
+          "MEDIA_AND_TECHNOLOGY",
+          "INNOVATION_IN_CONTROL",
+          "SPIRIT",
+          "WEBSITE",
+          "VISUALIZATION",
+          "AUTODESK_INVENTOR",
+          "FUTURE_INNOVATOR",
+          "RECOGNITION_OF_EXTRAORDINARY_SERVICE",
+          "OUTSTANDING_CART",
+          "WSU_AIM_HIGHER",
+          "LEADERSHIP_IN_CONTROL",
+          "NUM_1_SEED",
+          "INCREDIBLE_PLAY",
+          "PEOPLES_CHOICE_ANIMATION",
+          "VISUALIZATION_RISING_STAR",
+          "BEST_OFFENSIVE_ROUND",
+          "BEST_PLAY_OF_THE_DAY",
+          "FEATHERWEIGHT_IN_THE_FINALS",
+          "MOST_PHOTOGENIC",
+          "OUTSTANDING_DEFENSE",
+          "POWER_TO_SIMPLIFY",
+          "AGAINST_ALL_ODDS",
+          "RISING_STAR",
+          "CHAIRMANS_HONORABLE_MENTION",
+          "CONTENT_COMMUNICATION_HONORABLE_MENTION",
+          "TECHNICAL_EXECUTION_HONORABLE_MENTION",
+          "REALIZATION",
+          "REALIZATION_HONORABLE_MENTION",
+          "DESIGN_YOUR_FUTURE",
+          "DESIGN_YOUR_FUTURE_HONORABLE_MENTION",
+          "SPECIAL_RECOGNITION_CHARACTER_ANIMATION",
+          "HIGH_SCORE",
+          "TEACHER_PIONEER",
+          "BEST_CRAFTSMANSHIP",
+          "BEST_DEFENSIVE_MATCH",
+          "PLAY_OF_THE_DAY",
+          "PROGRAMMING",
+          "PROFESSIONALISM",
+          "GOLDEN_CORNDOG",
+          "MOST_IMPROVED_TEAM",
+          "WILDCARD",
+          "CHAIRMANS_FINALIST",
+          "OTHER",
+          "AUTONOMOUS",
+          "INNOVATION_CHALLENGE_SEMI_FINALIST",
+          "ROOKIE_GAME_CHANGER",
+          "SKILLS_COMPETITION_WINNER",
+          "SKILLS_COMPETITION_FINALIST",
+          "ROOKIE_DESIGN",
+          "ENGINEERING_DESIGN",
+          "DESIGNERS",
+          "CONCEPT",
+          "GAME_DESIGN_CHALLENGE_WINNER",
+          "GAME_DESIGN_CHALLENGE_FINALIST",
+          "SUSTAINABILITY",
+          "RISING_ALL_STAR"
+        ]
+      },
+      "EventType": {
+        "title": "EventType",
+        "description": "Event Type. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/event_type.py for definitions.",
+        "type": "integer",
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          99,
+          100,
+          -1
+        ],
+        "x-enum-varnames": [
+          "REGIONAL",
+          "DISTRICT",
+          "DISTRICT_CMP",
+          "CMP_DIVISION",
+          "CMP_FINALS",
+          "DISTRICT_CMP_DIVISION",
+          "FOC",
+          "REMOTE",
+          "OFFSEASON",
+          "PRESEASON",
+          "UNLABLED"
+        ]
+      },
+      "PlayoffType": {
+        "title": "PlayoffType",
+        "description": "Playoff bracket format. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/playoff_type.py for definitions.",
+        "type": "integer",
+        "enum": [
+          1,
+          0,
+          2,
+          9,
+          3,
+          4,
+          5,
+          10,
+          11,
+          6,
+          7,
+          8
+        ],
+        "x-enum-varnames": [
+          "BRACKET_16_TEAM",
+          "BRACKET_8_TEAM",
+          "BRACKET_4_TEAM",
+          "BRACKET_2_TEAM",
+          "AVG_SCORE_8_TEAM",
+          "ROUND_ROBIN_6_TEAM",
+          "LEGACY_DOUBLE_ELIM_8_TEAM",
+          "DOUBLE_ELIM_8_TEAM",
+          "DOUBLE_ELIM_4_TEAM",
+          "BO5_FINALS",
+          "BO3_FINALS",
+          "CUSTOM"
+        ]
       },
       "District": {
         "required": [
@@ -5429,7 +5669,6 @@
             "type": "object",
             "required": [
               "level",
-              "playoff_type",
               "status"
             ],
             "properties": {
@@ -5442,12 +5681,8 @@
                 "description": "Average match score during playoffs. Year specific. May be null."
               },
               "playoff_type": {
-                "type": [
-                  "number",
-                  "null"
-                ],
-                "format": "int64",
-                "description": "Playoff type, may be null."
+                "description": "Playoff type, may be null.",
+                "$ref": "#/components/schemas/PlayoffType"
               },
               "level": {
                 "$ref": "#/components/schemas/Comp_Level",
@@ -5675,7 +5910,6 @@
           "webcasts",
           "division_keys",
           "parent_event_key",
-          "playoff_type",
           "playoff_type_string",
           "remap_teams"
         ],
@@ -5694,8 +5928,7 @@
             "description": "Event short code, as provided by FIRST."
           },
           "event_type": {
-            "type": "integer",
-            "description": "Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/event_type.py#L8"
+            "$ref": "#/components/schemas/EventType"
           },
           "district": {
             "$ref": "#/components/schemas/District"
@@ -5854,11 +6087,8 @@
             "description": "The TBA Event key that represents the event's parent. Used to link back to the event from a division event. It is also the inverse relation of `divison_keys`."
           },
           "playoff_type": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "description": "Playoff Type, as defined under `PlayoffType`: https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/playoff_type.py#L37, or null."
+            "description": "Playoff Type, or null.",
+            "$ref": "#/components/schemas/PlayoffType"
           },
           "playoff_type_string": {
             "type": [
@@ -6834,8 +7064,7 @@
             "description": "Event short code, as provided by FIRST."
           },
           "event_type": {
-            "type": "integer",
-            "description": "Event Type, as defined here: https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/event_type.py#L8"
+            "$ref": "#/components/schemas/EventType"
           },
           "district": {
             "$ref": "#/components/schemas/District"

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Events/APIEvent+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Events/APIEvent+HelpersTests.swift
@@ -100,7 +100,10 @@ struct APIEventHelpersTests {
     // MARK: - weekString
 
     @Test func weekString_unknownEventType() {
-        let event = makeEvent(key: "x", year: 2020, eventType: -99)
+        // The OpenAPI EventType enum covers every documented value (-1, 0..7,
+        // 99, 100), but `APIEventType` (our hand-rolled mapping) hasn't shipped
+        // a case for the spec's REMOTE (7) yet. That's our "unknown" path.
+        let event = makeEvent(key: "x", year: 2020, eventType: 7)
         #expect(event.weekString == "Unknown")
     }
 
@@ -388,7 +391,8 @@ struct APIEventHelpersTests {
             key: key,
             name: name,
             eventCode: key.replacingOccurrences(of: "\(year)", with: ""),
-            eventType: eventType,
+            // Spec bump made `eventType` a typed enum; tests still pass raw ints.
+            eventType: Components.Schemas.EventType(rawValue: eventType) ?? ._0,
             city: city,
             stateProv: stateProv,
             country: country,

--- a/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
@@ -45,8 +45,7 @@ class WeekEventsViewController: EventsListViewController {
         let sameYear = events.filter { $0.year == weekEvent.year }
         guard let weekEventType = weekEvent.eventTypeEnum else {
             // Selected week has an unknown event type — group all unknown-type events together.
-            let valid = Set(APIEventType.allCases.map { $0.rawValue })
-            return sameYear.filter { !valid.contains($0.eventType) }
+            return sameYear.filter { $0.eventTypeEnum == nil }
         }
 
         if let week = weekEvent.week {

--- a/the-blue-alliance-ios/ViewModels/Event/EventSection.swift
+++ b/the-blue-alliance-ios/ViewModels/Event/EventSection.swift
@@ -38,7 +38,7 @@ extension Event {
             // raw integer so it slots between known types, and use the
             // API-provided string as the title so it's at least self-describing.
             let label = eventTypeString.isEmpty ? "Unknown Events" : "\(eventTypeString) Events"
-            return .init(sortOrder: eventType, subOrder: 0, title: label)
+            return .init(sortOrder: eventType.rawValue, subOrder: 0, title: label)
         }
 
         switch type {


### PR DESCRIPTION
## Summary
- Refresh `Packages/TBAAPI/Sources/TBAAPI/openapi.json` from prod (`v3.12.2 → v3.13.0`). Upstream introduced named integer enums for `EventType`, `AwardType`, and `PlayoffType`, plus a `DoubleElimRound` string enum.
- After codegen, `Event.eventType`, `Award.awardType`, `Event.playoffType`, and `EliminationAlliance.status.doubleElimRound` are typed Swift enums instead of bare `Int` / `String`. Wire them through:
  - `TypeAliases.swift` adds top-level aliases for the new types.
  - `AwardType+Comparable.swift` and `EventType+Comparable.swift` add `Comparable` conformance so call sites keep using `<` for sorting (no `.rawValue` everywhere).
  - `APIEvent+Helpers.eventTypeEnum` reads `.rawValue` to feed the existing hand-rolled `APIEventType` mapping.
  - `WeekEventsViewController.filter` simplifies the unknown-event-type branch to `eventTypeEnum == nil` — drops the previous `Set(APIEventType.allCases.map { \$0.rawValue })` inversion.
  - `EventSection.section` keeps `.rawValue` only where the integer is genuinely needed as a sort key.
  - `APIEvent+HelpersTests` fixture takes a raw int and converts to the typed enum; the unknown-event-type test uses `.remote (=7)` since that's the one documented case `APIEventType` doesn't handle yet.

## Why this exists as its own PR
This is the prerequisite for the playoff-types feature work in #1049 — extracting it makes #1049 easier to review (#1049 will rebase on top once this lands).

## Test plan
- [ ] iOS build clean: \`xcodebuild -project the-blue-alliance-ios.xcodeproj -scheme \"The Blue Alliance\" -destination \"platform=iOS Simulator,name=iPhone 17 Pro\" build\`
- [ ] TBAAPI tests pass: \`(cd Packages/TBAAPI && swift test)\` — 94 tests, all green
- [ ] \`scripts/swift-format.sh --strict\` exits 0
- [ ] Spot-check the Week Events screen with a multi-event-type year (e.g. 2024) — events list correctly grouped by type; \"Other\" bucket still works for any event with an event_type the app doesn't recognize.
- [ ] Spot-check the Awards tab on any event — awards still sorted by award type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)