### PR TITLE
Refactor CompLevel check in match brekadown config to use API enums. DRY some of the RP-gating logic

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -85,7 +85,7 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
             }
         }
 
-        configureDataSource(state.match?.breakdownDict, state.match?.compLevel.rawValue)
+        configureDataSource(state.match?.breakdownDict, state.match?.compLevel)
     }
 
     // MARK: - Methods
@@ -105,13 +105,15 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
         dataSource.statefulDelegate = self
     }
 
-    func configureDataSource(_ breakdown: [String: Any]?, _ compLevel: String?) {
+    func configureDataSource(
+        _ breakdown: [String: Any]?,
+        _ compLevel: Components.Schemas.CompLevel?
+    ) {
         var snapshot = dataSource.snapshot()
         snapshot.deleteAllItems()
 
         let red = breakdown?["red"] as? [String: Any]
         let blue = breakdown?["blue"] as? [String: Any]
-        let compLevel = compLevel
 
         if let breakdownConfigurator = breakdownConfigurator {
             breakdownConfigurator.configureDataSource(&snapshot, breakdown, red, blue, compLevel)
@@ -131,7 +133,7 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
             self.state = .match(try await self.dependencies.api.match(key: self.state.key))
             self.configureDataSource(
                 self.state.match?.breakdownDict,
-                self.state.match?.compLevel.rawValue
+                self.state.match?.compLevel
             )
         }
     }

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 protocol MatchBreakdownConfigurator {
@@ -7,7 +8,7 @@ protocol MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     )
 }
 
@@ -172,6 +173,25 @@ extension MatchBreakdownConfigurator {
             blue: [String(format: formatString, blueString)],
             type: type,
             offset: offset
+        )
+    }
+
+    // Ranking Points are awarded only in qualification matches; this helper
+    // returns nil for any other comp level so the row is dropped by `compactMap`.
+    static func rankingPointsRow(
+        key: String,
+        formatString: String = "%@",
+        compLevel: Components.Schemas.CompLevel?,
+        red: [String: Any]?,
+        blue: [String: Any]?
+    ) -> BreakdownRow? {
+        guard compLevel == .qm else { return nil }
+        return row(
+            title: "Ranking Points",
+            key: key,
+            formatString: formatString,
+            red: red,
+            blue: blue
         )
     }
 

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2015.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2015.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 struct MatchBreakdownConfigurator2015: MatchBreakdownConfigurator {
@@ -8,7 +9,7 @@ struct MatchBreakdownConfigurator2015: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
         var rows: [BreakdownRow?] = []
 

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2016.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2016.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 struct MatchBreakdownConfigurator2016: MatchBreakdownConfigurator {
@@ -8,7 +9,7 @@ struct MatchBreakdownConfigurator2016: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
         var rows: [BreakdownRow?] = []
 
@@ -124,9 +125,9 @@ struct MatchBreakdownConfigurator2016: MatchBreakdownConfigurator {
             row(title: "Total Score", key: "totalPoints", red: red, blue: blue, type: .total)
         )
         // RP
-        if let compLevel, compLevel == "qm" {
-            rows.append(row(title: "Ranking Points", key: "tba_rpEarned", red: red, blue: blue))
-        }
+        rows.append(
+            rankingPointsRow(key: "tba_rpEarned", compLevel: compLevel, red: red, blue: blue)
+        )
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })
         if !validRows.isEmpty {

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2017.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2017.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 struct MatchBreakdownConfigurator2017: MatchBreakdownConfigurator {
@@ -8,7 +9,7 @@ struct MatchBreakdownConfigurator2017: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
         var rows: [BreakdownRow?] = []
 
@@ -159,9 +160,9 @@ struct MatchBreakdownConfigurator2017: MatchBreakdownConfigurator {
             row(title: "Total Score", key: "totalPoints", red: red, blue: blue, type: .total)
         )
         // RP
-        if let compLevel, compLevel == "qm" {
-            rows.append(row(title: "Ranking Points", key: "tba_rpEarned", red: red, blue: blue))
-        }
+        rows.append(
+            rankingPointsRow(key: "tba_rpEarned", compLevel: compLevel, red: red, blue: blue)
+        )
 
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2018.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2018.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 struct MatchBreakdownConfigurator2018: MatchBreakdownConfigurator {
@@ -8,7 +9,7 @@ struct MatchBreakdownConfigurator2018: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
         var rows: [BreakdownRow?] = []
 
@@ -183,9 +184,7 @@ struct MatchBreakdownConfigurator2018: MatchBreakdownConfigurator {
             row(title: "Total Score", key: "totalPoints", red: red, blue: blue, type: .total)
         )
         // RP
-        if let compLevel, compLevel == "qm" {
-            rows.append(row(title: "Ranking Points", key: "rp", red: red, blue: blue))
-        }
+        rows.append(rankingPointsRow(key: "rp", compLevel: compLevel, red: red, blue: blue))
 
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2019.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2019.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 private class BreakdownStyle2019 {
@@ -14,7 +15,7 @@ struct MatchBreakdownConfigurator2019: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
         var rows: [BreakdownRow?] = []
 
@@ -92,9 +93,7 @@ struct MatchBreakdownConfigurator2019: MatchBreakdownConfigurator {
             row(title: "Total Score", key: "totalPoints", red: red, blue: blue, type: .total)
         )
         // RP
-        if let compLevel, compLevel == "qm" {
-            rows.append(row(title: "Ranking Points", key: "rp", red: red, blue: blue))
-        }
+        rows.append(rankingPointsRow(key: "rp", compLevel: compLevel, red: red, blue: blue))
 
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2020.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2020.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 private class BreakdownStyle2020 {
@@ -14,7 +15,7 @@ struct MatchBreakdownConfigurator2020: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
 
         var rows: [BreakdownRow?] = []
@@ -94,17 +95,15 @@ struct MatchBreakdownConfigurator2020: MatchBreakdownConfigurator {
         )
 
         // RP
-        if let compLevel, compLevel == "qm" {
-            rows.append(
-                row(
-                    title: "Ranking Points",
-                    key: "rp",
-                    formatString: "+%@ RP",
-                    red: red,
-                    blue: blue
-                )
+        rows.append(
+            rankingPointsRow(
+                key: "rp",
+                formatString: "+%@ RP",
+                compLevel: compLevel,
+                red: red,
+                blue: blue
             )
-        }
+        )
 
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })
@@ -352,7 +351,7 @@ struct MatchBreakdownConfigurator2020: MatchBreakdownConfigurator {
         title: String,
         red: [String: Any]?,
         blue: [String: Any]?,
-        compLevel: String?
+        compLevel: Components.Schemas.CompLevel?
     )
         -> BreakdownRow?
     {
@@ -374,7 +373,7 @@ struct MatchBreakdownConfigurator2020: MatchBreakdownConfigurator {
 
         let elements = [redActivation, blueActivation].map { (stage) -> String in
             if stage[0] == 1 {
-                if let compLevel, compLevel == "qm" {
+                if compLevel == .qm {
                     return "3 (+1 RP)"
                 }
                 return "3"

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2022.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2022.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 private class BreakdownStyle2022 {
@@ -19,7 +20,7 @@ struct MatchBreakdownConfigurator2022: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
 
         var rows: [BreakdownRow?] = []
@@ -81,17 +82,15 @@ struct MatchBreakdownConfigurator2022: MatchBreakdownConfigurator {
         )
 
         // RP
-        if let compLevel, compLevel == "qm" {
-            rows.append(
-                row(
-                    title: "Ranking Points",
-                    key: "rp",
-                    formatString: "+%@ RP",
-                    red: red,
-                    blue: blue
-                )
+        rows.append(
+            rankingPointsRow(
+                key: "rp",
+                formatString: "+%@ RP",
+                compLevel: compLevel,
+                red: red,
+                blue: blue
             )
-        }
+        )
 
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2024.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2024.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 private class BreakdownStyle2024 {
@@ -22,7 +23,7 @@ struct MatchBreakdownConfigurator2024: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
 
         var rows: [BreakdownRow?] = []
@@ -115,17 +116,15 @@ struct MatchBreakdownConfigurator2024: MatchBreakdownConfigurator {
         )
 
         // RP
-        if let compLevel, compLevel == "qm" {
-            rows.append(
-                row(
-                    title: "Ranking Points",
-                    key: "rp",
-                    formatString: "+%@ RP",
-                    red: red,
-                    blue: blue
-                )
+        rows.append(
+            rankingPointsRow(
+                key: "rp",
+                formatString: "+%@ RP",
+                compLevel: compLevel,
+                red: red,
+                blue: blue
             )
-        }
+        )
 
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2026.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2026.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import UIKit
 
 struct MatchBreakdownConfigurator2026: MatchBreakdownConfigurator {
@@ -8,7 +9,7 @@ struct MatchBreakdownConfigurator2026: MatchBreakdownConfigurator {
         _ breakdown: [String: Any]?,
         _ red: [String: Any]?,
         _ blue: [String: Any]?,
-        _ compLevel: String?
+        _ compLevel: Components.Schemas.CompLevel?
     ) {
 
         var rows: [BreakdownRow?] = []
@@ -144,17 +145,15 @@ struct MatchBreakdownConfigurator2026: MatchBreakdownConfigurator {
         rows.append(
             row(title: "Total Score", key: "totalPoints", red: red, blue: blue, type: .total)
         )
-        if let compLevel, compLevel == "qm" {
-            rows.append(
-                row(
-                    title: "Ranking Points",
-                    key: "rp",
-                    formatString: "+%@ RP",
-                    red: red,
-                    blue: blue
-                )
+        rows.append(
+            rankingPointsRow(
+                key: "rp",
+                formatString: "+%@ RP",
+                compLevel: compLevel,
+                red: red,
+                blue: blue
             )
-        }
+        )
 
         // Clean up any empty rows
         let validRows = rows.compactMap({ $0 })


### PR DESCRIPTION
Small tweaks from https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/1051 just to make use of our API types. DRY's the RP-gating logic by moving it into the base `MatchBreakdownConfigurator`