### PR TITLE
Include event year in search matcher

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -85,10 +85,8 @@ class SearchViewController: TBATableViewController {
             switch item {
             case .event(let key, let name):
                 let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
-                let year = String(key.prefix(4))
-                let displayName = name.isEmpty ? key : "\(year) \(name)"
                 cell.viewModel = EventCellViewModel(
-                    name: displayName,
+                    name: SearchViewController.eventDisplayName(key: key, name: name),
                     location: nil,
                     dateString: nil
                 )
@@ -168,7 +166,15 @@ class SearchViewController: TBATableViewController {
     }
 
     private func matches(event: SearchIndex.EventsPayloadPayload, query: String) -> Bool {
-        event.name.lowercased().contains(query) || event.key.lowercased().contains(query)
+        let display = SearchViewController.eventDisplayName(key: event.key, name: event.name)
+        return display.lowercased().contains(query) || event.key.lowercased().contains(query)
+    }
+
+    // Single source of truth for event row text so the search matcher operates on what the user sees —
+    // event names from the API don't include the year, so without this typing "2026 michigan" wouldn't hit.
+    private static func eventDisplayName(key: String, name: String) -> String {
+        guard !name.isEmpty else { return key }
+        return "\(key.prefix(4)) \(name)"
     }
 
     // MARK: - Table View Delegate


### PR DESCRIPTION
## Summary
- Search results display events as `"{year} {name}"`, but the matcher was still only checking `event.name` and `event.key`. Since API event names don't contain the year, typing the full displayed text (e.g. `2026 michigan`) returned no results.
- Extract a shared `eventDisplayName(key:name:)` helper used by both the cell rendering and `matches(event:query:)` so the search predicate operates on exactly what the user sees.

## Test plan
- [ ] In the search tab, type `2026 michigan` (or any `{year} {name}` substring of a real event) — results should appear.
- [ ] Type just `2026` — all 2026 events still match (via the key fallback).
- [ ] Type just `michigan` — name-only queries still match.
- [ ] Type a team number (e.g. `254`) — team search behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)