### PR TITLE
Route B-team taps to the parent team page (#960)

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
@@ -42,20 +42,15 @@ extension Team: TeamDisplayable {
     }
 }
 
-// A TBA team key — always of the form "frc<number>" or "frc<number><suffix>"
-// (e.g. "frc254", "frc5940B"). Plain `String` for now; the typealias documents
-// intent and lets the helpers below read as operations over team keys.
-public typealias TeamKey = String
-
-public enum TeamKeys {
-    // Strips the `frc` prefix from a team key — "frc254" → "254".
-    public static func trimFRCPrefix(_ key: TeamKey) -> String {
-        String(key.dropFirst(3))
+extension TeamKey {
+    public var trimFRCPrefix: String {
+        String(dropFirst(3))
     }
 
-    // Drops a B-team suffix to get the canonical team key — "frc5940B" → "frc5940".
-    // B teams aren't independent entities in TBA; they alias the parent team.
-    public static func parentKey(_ key: TeamKey) -> TeamKey {
-        TeamKey(key.reversed().drop(while: { !$0.isNumber }).reversed())
+    // B teams (e.g. "frc5940B") aren't independent entities in TBA — they
+    // alias the parent team. Walk from the end and drop non-digits to
+    // recover the canonical key.
+    public var parentKey: TeamKey {
+        TeamKey(reversed().drop(while: { !$0.isNumber }).reversed())
     }
 }

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
@@ -42,18 +42,20 @@ extension Team: TeamDisplayable {
     }
 }
 
-// Strips the `frc` prefix from a team key — "frc254" → "254".
-public enum TeamKey {
-    public static func trimFRCPrefix(_ key: String) -> String {
-        key.hasPrefix("frc") ? String(key.dropFirst(3)) : key
+// A TBA team key — always of the form "frc<number>" or "frc<number><suffix>"
+// (e.g. "frc254", "frc5940B"). Plain `String` for now; the typealias documents
+// intent and lets the helpers below read as operations over team keys.
+public typealias TeamKey = String
+
+public enum TeamKeys {
+    // Strips the `frc` prefix from a team key — "frc254" → "254".
+    public static func trimFRCPrefix(_ key: TeamKey) -> String {
+        String(key.dropFirst(3))
     }
 
     // Drops a B-team suffix to get the canonical team key — "frc5940B" → "frc5940".
     // B teams aren't independent entities in TBA; they alias the parent team.
-    public static func parentKey(_ key: String) -> String {
-        let prefix = key.hasPrefix("frc") ? "frc" : ""
-        let rest = key.dropFirst(prefix.count)
-        let digits = rest.prefix(while: { $0.isNumber })
-        return digits.isEmpty ? key : prefix + digits
+    public static func parentKey(_ key: TeamKey) -> TeamKey {
+        TeamKey(key.reversed().drop(while: { !$0.isNumber }).reversed())
     }
 }

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
@@ -43,12 +43,12 @@ extension Team: TeamDisplayable {
 }
 
 extension TeamKey {
-    public var trimFRCPrefix: String {
+    public var trimPrefix: String {
         String(dropFirst(3))
     }
 
     public var teamNumber: Int? {
-        Int(trimFRCPrefix)
+        Int(trimPrefix)
     }
 
     // B teams (e.g. "frc5940B") aren't independent entities in TBA — they

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
@@ -47,6 +47,10 @@ extension TeamKey {
         String(dropFirst(3))
     }
 
+    public var teamNumber: Int? {
+        Int(trimFRCPrefix)
+    }
+
     // B teams (e.g. "frc5940B") aren't independent entities in TBA — they
     // alias the parent team. Walk from the end and drop non-digits to
     // recover the canonical key.

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
@@ -47,4 +47,13 @@ public enum TeamKey {
     public static func trimFRCPrefix(_ key: String) -> String {
         key.hasPrefix("frc") ? String(key.dropFirst(3)) : key
     }
+
+    // Drops a B-team suffix to get the canonical team key — "frc5940B" → "frc5940".
+    // B teams aren't independent entities in TBA; they alias the parent team.
+    public static func parentKey(_ key: String) -> String {
+        let prefix = key.hasPrefix("frc") ? "frc" : ""
+        let rest = key.dropFirst(prefix.count)
+        let digits = rest.prefix(while: { $0.isNumber })
+        return digits.isEmpty ? key : prefix + digits
+    }
 }

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
@@ -26,3 +26,5 @@ public typealias Team = Components.Schemas.Team
 public typealias TeamEventStatus = Components.Schemas.TeamEventStatus
 public typealias TeamSimple = Components.Schemas.TeamSimple
 public typealias Webcast = Components.Schemas.Webcast
+
+public typealias TeamKey = String

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
@@ -4,40 +4,28 @@ import Testing
 
 struct APITeamHelpersTests {
 
-    // MARK: - TeamKey.trimFRCPrefix
+    // MARK: - TeamKeys.trimFRCPrefix
 
     @Test func trimFRCPrefix_strip() {
-        #expect(TeamKey.trimFRCPrefix("frc2337") == "2337")
+        #expect(TeamKeys.trimFRCPrefix("frc2337") == "2337")
     }
 
     @Test func trimFRCPrefix_stripKeepsSuffix() {
-        #expect(TeamKey.trimFRCPrefix("frc2337b") == "2337b")
+        #expect(TeamKeys.trimFRCPrefix("frc2337b") == "2337b")
     }
 
-    @Test func trimFRCPrefix_noPrefixLeavesAlone() {
-        #expect(TeamKey.trimFRCPrefix("2337") == "2337")
-    }
-
-    // MARK: - TeamKey.parentKey
+    // MARK: - TeamKeys.parentKey
 
     @Test func parentKey_canonicalKeyUnchanged() {
-        #expect(TeamKey.parentKey("frc254") == "frc254")
+        #expect(TeamKeys.parentKey("frc254") == "frc254")
     }
 
     @Test func parentKey_dropsBSuffix() {
-        #expect(TeamKey.parentKey("frc5940B") == "frc5940")
+        #expect(TeamKeys.parentKey("frc5940B") == "frc5940")
     }
 
     @Test func parentKey_dropsLowercaseSuffix() {
-        #expect(TeamKey.parentKey("frc5940b") == "frc5940")
-    }
-
-    @Test func parentKey_handlesUnprefixedKey() {
-        #expect(TeamKey.parentKey("5940B") == "5940")
-    }
-
-    @Test func parentKey_returnsOriginalForNonNumeric() {
-        #expect(TeamKey.parentKey("frc") == "frc")
+        #expect(TeamKeys.parentKey("frc5940b") == "frc5940")
     }
 
     // MARK: - TeamDisplayable (Team)

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
@@ -14,6 +14,16 @@ struct APITeamHelpersTests {
         #expect(("frc2337b" as TeamKey).trimFRCPrefix == "2337b")
     }
 
+    // MARK: - TeamKey.teamNumber
+
+    @Test func teamNumber_parsesDigits() {
+        #expect(("frc254" as TeamKey).teamNumber == 254)
+    }
+
+    @Test func teamNumber_nilForBTeamSuffix() {
+        #expect(("frc5940B" as TeamKey).teamNumber == nil)
+    }
+
     // MARK: - TeamKey.parentKey
 
     @Test func parentKey_canonicalKeyUnchanged() {

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
@@ -4,28 +4,28 @@ import Testing
 
 struct APITeamHelpersTests {
 
-    // MARK: - TeamKeys.trimFRCPrefix
+    // MARK: - TeamKey.trimFRCPrefix
 
     @Test func trimFRCPrefix_strip() {
-        #expect(TeamKeys.trimFRCPrefix("frc2337") == "2337")
+        #expect(("frc2337" as TeamKey).trimFRCPrefix == "2337")
     }
 
     @Test func trimFRCPrefix_stripKeepsSuffix() {
-        #expect(TeamKeys.trimFRCPrefix("frc2337b") == "2337b")
+        #expect(("frc2337b" as TeamKey).trimFRCPrefix == "2337b")
     }
 
-    // MARK: - TeamKeys.parentKey
+    // MARK: - TeamKey.parentKey
 
     @Test func parentKey_canonicalKeyUnchanged() {
-        #expect(TeamKeys.parentKey("frc254") == "frc254")
+        #expect(("frc254" as TeamKey).parentKey == "frc254")
     }
 
     @Test func parentKey_dropsBSuffix() {
-        #expect(TeamKeys.parentKey("frc5940B") == "frc5940")
+        #expect(("frc5940B" as TeamKey).parentKey == "frc5940")
     }
 
     @Test func parentKey_dropsLowercaseSuffix() {
-        #expect(TeamKeys.parentKey("frc5940b") == "frc5940")
+        #expect(("frc5940b" as TeamKey).parentKey == "frc5940")
     }
 
     // MARK: - TeamDisplayable (Team)

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
@@ -4,14 +4,14 @@ import Testing
 
 struct APITeamHelpersTests {
 
-    // MARK: - TeamKey.trimFRCPrefix
+    // MARK: - TeamKey.trimPrefix
 
-    @Test func trimFRCPrefix_strip() {
-        #expect(("frc2337" as TeamKey).trimFRCPrefix == "2337")
+    @Test func trimPrefix_strip() {
+        #expect(("frc2337" as TeamKey).trimPrefix == "2337")
     }
 
-    @Test func trimFRCPrefix_stripKeepsSuffix() {
-        #expect(("frc2337b" as TeamKey).trimFRCPrefix == "2337b")
+    @Test func trimPrefix_stripKeepsSuffix() {
+        #expect(("frc2337b" as TeamKey).trimPrefix == "2337b")
     }
 
     // MARK: - TeamKey.teamNumber

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
@@ -18,6 +18,28 @@ struct APITeamHelpersTests {
         #expect(TeamKey.trimFRCPrefix("2337") == "2337")
     }
 
+    // MARK: - TeamKey.parentKey
+
+    @Test func parentKey_canonicalKeyUnchanged() {
+        #expect(TeamKey.parentKey("frc254") == "frc254")
+    }
+
+    @Test func parentKey_dropsBSuffix() {
+        #expect(TeamKey.parentKey("frc5940B") == "frc5940")
+    }
+
+    @Test func parentKey_dropsLowercaseSuffix() {
+        #expect(TeamKey.parentKey("frc5940b") == "frc5940")
+    }
+
+    @Test func parentKey_handlesUnprefixedKey() {
+        #expect(TeamKey.parentKey("5940B") == "5940")
+    }
+
+    @Test func parentKey_returnsOriginalForNonNumeric() {
+        #expect(TeamKey.parentKey("frc") == "frc")
+    }
+
     // MARK: - TeamDisplayable (Team)
 
     @Test func teamNumberNickname_prependsTeam() {

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -73,7 +73,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
             filtered = rankings
         } else {
             filtered = rankings.filter { ranking in
-                let number = ranking.teamKey.trimFRCPrefix.lowercased()
+                let number = ranking.teamKey.trimPrefix.lowercased()
                 return number.contains(query) || ranking.teamKey.lowercased().contains(query)
             }
         }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -73,7 +73,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
             filtered = rankings
         } else {
             filtered = rankings.filter { ranking in
-                let number = TeamKey.trimFRCPrefix(ranking.teamKey).lowercased()
+                let number = TeamKeys.trimFRCPrefix(ranking.teamKey).lowercased()
                 return number.contains(query) || ranking.teamKey.lowercased().contains(query)
             }
         }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -73,7 +73,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
             filtered = rankings
         } else {
             filtered = rankings.filter { ranking in
-                let number = TeamKeys.trimFRCPrefix(ranking.teamKey).lowercased()
+                let number = ranking.teamKey.trimFRCPrefix.lowercased()
                 return number.contains(query) || ranking.teamKey.lowercased().contains(query)
             }
         }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -32,7 +32,7 @@ class TeamAtDistrictViewController: ContainerViewController {
             dependencies: dependencies
         )
 
-        let teamNumber = TeamKey.trimFRCPrefix(ranking.teamKey)
+        let teamNumber = TeamKeys.trimFRCPrefix(ranking.teamKey)
         super.init(
             viewControllers: [summaryViewController, breakdownViewController],
             navigationTitle: "Team \(teamNumber)",

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -32,7 +32,7 @@ class TeamAtDistrictViewController: ContainerViewController {
             dependencies: dependencies
         )
 
-        let teamNumber = ranking.teamKey.trimFRCPrefix
+        let teamNumber = ranking.teamKey.trimPrefix
         super.init(
             viewControllers: [summaryViewController, breakdownViewController],
             navigationTitle: "Team \(teamNumber)",

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -32,7 +32,7 @@ class TeamAtDistrictViewController: ContainerViewController {
             dependencies: dependencies
         )
 
-        let teamNumber = TeamKeys.trimFRCPrefix(ranking.teamKey)
+        let teamNumber = ranking.teamKey.trimFRCPrefix
         super.init(
             viewControllers: [summaryViewController, breakdownViewController],
             navigationTitle: "Team \(teamNumber)",

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -140,7 +140,7 @@ extension MatchViewController: MatchSummaryViewDelegate {
         guard let match = state.match, match.allTeamKeys.contains(teamKey) else { return }
         // B teams (e.g. "frc5940B") alias the parent team — route to the
         // canonical team@event so the API lookups don't 404.
-        let canonicalKey = TeamKey.parentKey(teamKey)
+        let canonicalKey = TeamKeys.parentKey(teamKey)
         let year = match.year ?? 0
         let teamAtEventVC = TeamAtEventViewController(
             teamKey: canonicalKey,

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -136,12 +136,14 @@ private struct MatchSubscribable: MyTBASubscribable {
 
 extension MatchViewController: MatchSummaryViewDelegate {
 
-    func teamPressed(teamNumber: Int) {
-        let targetKey = "frc\(teamNumber)"
-        guard let match = state.match, match.allTeamKeys.contains(targetKey) else { return }
+    func teamPressed(teamKey: String) {
+        guard let match = state.match, match.allTeamKeys.contains(teamKey) else { return }
+        // B teams (e.g. "frc5940B") alias the parent team — route to the
+        // canonical team@event so the API lookups don't 404.
+        let canonicalKey = TeamKey.parentKey(teamKey)
         let year = match.year ?? 0
         let teamAtEventVC = TeamAtEventViewController(
-            teamKey: targetKey,
+            teamKey: canonicalKey,
             eventKey: match.eventKey,
             year: year,
             dependencies: dependencies

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -140,7 +140,7 @@ extension MatchViewController: MatchSummaryViewDelegate {
         guard let match = state.match, match.allTeamKeys.contains(teamKey) else { return }
         // B teams (e.g. "frc5940B") alias the parent team — route to the
         // canonical team@event so the API lookups don't 404.
-        let canonicalKey = TeamKeys.parentKey(teamKey)
+        let canonicalKey = teamKey.parentKey
         let year = match.year ?? 0
         let teamAtEventVC = TeamAtEventViewController(
             teamKey: canonicalKey,

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -136,14 +136,11 @@ private struct MatchSubscribable: MyTBASubscribable {
 
 extension MatchViewController: MatchSummaryViewDelegate {
 
-    func teamPressed(teamKey: String) {
+    func teamPressed(teamKey: TeamKey) {
         guard let match = state.match, match.allTeamKeys.contains(teamKey) else { return }
-        // B teams (e.g. "frc5940B") alias the parent team — route to the
-        // canonical team@event so the API lookups don't 404.
-        let canonicalKey = teamKey.parentKey
         let year = match.year ?? 0
         let teamAtEventVC = TeamAtEventViewController(
-            teamKey: canonicalKey,
+            teamKey: teamKey,
             eventKey: match.eventKey,
             year: year,
             dependencies: dependencies

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -136,8 +136,8 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
                         )
                     } else {
                         cell.viewModel = TeamCellViewModel(
-                            teamNumber: key.trimFRCPrefix,
-                            nickname: "Team \(key.trimFRCPrefix)",
+                            teamNumber: key.trimPrefix,
+                            nickname: "Team \(key.trimPrefix)",
                             location: nil
                         )
                     }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -136,8 +136,8 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
                         )
                     } else {
                         cell.viewModel = TeamCellViewModel(
-                            teamNumber: TeamKey.trimFRCPrefix(key),
-                            nickname: "Team \(TeamKey.trimFRCPrefix(key))",
+                            teamNumber: TeamKeys.trimFRCPrefix(key),
+                            nickname: "Team \(TeamKeys.trimFRCPrefix(key))",
                             location: nil
                         )
                     }
@@ -184,11 +184,11 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
             return items.sorted { lhs, rhs in
                 let l =
                     teamsCache[lhs.modelKey].map { $0.teamNumber } ?? Int(
-                        TeamKey.trimFRCPrefix(lhs.modelKey)
+                        TeamKeys.trimFRCPrefix(lhs.modelKey)
                     ) ?? 0
                 let r =
                     teamsCache[rhs.modelKey].map { $0.teamNumber } ?? Int(
-                        TeamKey.trimFRCPrefix(rhs.modelKey)
+                        TeamKeys.trimFRCPrefix(rhs.modelKey)
                     ) ?? 0
                 return l < r
             }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -182,14 +182,8 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
             }
         case .team:
             return items.sorted { lhs, rhs in
-                let l =
-                    teamsCache[lhs.modelKey].map { $0.teamNumber } ?? Int(
-                        lhs.modelKey.trimFRCPrefix
-                    ) ?? 0
-                let r =
-                    teamsCache[rhs.modelKey].map { $0.teamNumber } ?? Int(
-                        rhs.modelKey.trimFRCPrefix
-                    ) ?? 0
+                let l = teamsCache[lhs.modelKey]?.teamNumber ?? lhs.modelKey.teamNumber ?? 0
+                let r = teamsCache[rhs.modelKey]?.teamNumber ?? rhs.modelKey.teamNumber ?? 0
                 return l < r
             }
         case .match:

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -136,8 +136,8 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
                         )
                     } else {
                         cell.viewModel = TeamCellViewModel(
-                            teamNumber: TeamKeys.trimFRCPrefix(key),
-                            nickname: "Team \(TeamKeys.trimFRCPrefix(key))",
+                            teamNumber: key.trimFRCPrefix,
+                            nickname: "Team \(key.trimFRCPrefix)",
                             location: nil
                         )
                     }
@@ -184,11 +184,11 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
             return items.sorted { lhs, rhs in
                 let l =
                     teamsCache[lhs.modelKey].map { $0.teamNumber } ?? Int(
-                        TeamKeys.trimFRCPrefix(lhs.modelKey)
+                        lhs.modelKey.trimFRCPrefix
                     ) ?? 0
                 let r =
                     teamsCache[rhs.modelKey].map { $0.teamNumber } ?? Int(
-                        TeamKeys.trimFRCPrefix(rhs.modelKey)
+                        rhs.modelKey.trimFRCPrefix
                     ) ?? 0
                 return l < r
             }

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -129,8 +129,8 @@ class SearchViewController: TBATableViewController {
             let teams = index.teams
                 .filter { matches(team: $0, query: query) }
                 .sorted { lhs, rhs in
-                    let l = Int(lhs.key.trimFRCPrefix) ?? .max
-                    let r = Int(rhs.key.trimFRCPrefix) ?? .max
+                    let l = lhs.key.teamNumber ?? .max
+                    let r = rhs.key.teamNumber ?? .max
                     return l < r
                 }
                 .map { SearchItem.team(key: $0.key, nickname: $0.nickname) }

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -93,7 +93,7 @@ class SearchViewController: TBATableViewController {
                 return cell
             case .team(let key, let nickname):
                 let cell = tableView.dequeueReusableCell(indexPath: indexPath) as TeamTableViewCell
-                let teamNumber = key.trimFRCPrefix
+                let teamNumber = key.trimPrefix
                 cell.viewModel = TeamCellViewModel(
                     teamNumber: teamNumber,
                     nickname: nickname.isEmpty ? "Team \(teamNumber)" : nickname,
@@ -160,7 +160,7 @@ class SearchViewController: TBATableViewController {
     }
 
     private func matches(team: SearchIndex.TeamsPayloadPayload, query: String) -> Bool {
-        let number = team.key.trimFRCPrefix
+        let number = team.key.trimPrefix
         return number.hasPrefix(query) || team.nickname.lowercased().contains(query)
             || team.key.lowercased().contains(query)
     }

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -93,7 +93,7 @@ class SearchViewController: TBATableViewController {
                 return cell
             case .team(let key, let nickname):
                 let cell = tableView.dequeueReusableCell(indexPath: indexPath) as TeamTableViewCell
-                let teamNumber = TeamKey.trimFRCPrefix(key)
+                let teamNumber = TeamKeys.trimFRCPrefix(key)
                 cell.viewModel = TeamCellViewModel(
                     teamNumber: teamNumber,
                     nickname: nickname.isEmpty ? "Team \(teamNumber)" : nickname,
@@ -129,8 +129,8 @@ class SearchViewController: TBATableViewController {
             let teams = index.teams
                 .filter { matches(team: $0, query: query) }
                 .sorted { lhs, rhs in
-                    let l = Int(TeamKey.trimFRCPrefix(lhs.key)) ?? .max
-                    let r = Int(TeamKey.trimFRCPrefix(rhs.key)) ?? .max
+                    let l = Int(TeamKeys.trimFRCPrefix(lhs.key)) ?? .max
+                    let r = Int(TeamKeys.trimFRCPrefix(rhs.key)) ?? .max
                     return l < r
                 }
                 .map { SearchItem.team(key: $0.key, nickname: $0.nickname) }
@@ -160,7 +160,7 @@ class SearchViewController: TBATableViewController {
     }
 
     private func matches(team: SearchIndex.TeamsPayloadPayload, query: String) -> Bool {
-        let number = TeamKey.trimFRCPrefix(team.key)
+        let number = TeamKeys.trimFRCPrefix(team.key)
         return number.hasPrefix(query) || team.nickname.lowercased().contains(query)
             || team.key.lowercased().contains(query)
     }

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -93,7 +93,7 @@ class SearchViewController: TBATableViewController {
                 return cell
             case .team(let key, let nickname):
                 let cell = tableView.dequeueReusableCell(indexPath: indexPath) as TeamTableViewCell
-                let teamNumber = TeamKeys.trimFRCPrefix(key)
+                let teamNumber = key.trimFRCPrefix
                 cell.viewModel = TeamCellViewModel(
                     teamNumber: teamNumber,
                     nickname: nickname.isEmpty ? "Team \(teamNumber)" : nickname,
@@ -129,8 +129,8 @@ class SearchViewController: TBATableViewController {
             let teams = index.teams
                 .filter { matches(team: $0, query: query) }
                 .sorted { lhs, rhs in
-                    let l = Int(TeamKeys.trimFRCPrefix(lhs.key)) ?? .max
-                    let r = Int(TeamKeys.trimFRCPrefix(rhs.key)) ?? .max
+                    let l = Int(lhs.key.trimFRCPrefix) ?? .max
+                    let r = Int(rhs.key.trimFRCPrefix) ?? .max
                     return l < r
                 }
                 .map { SearchItem.team(key: $0.key, nickname: $0.nickname) }
@@ -160,7 +160,7 @@ class SearchViewController: TBATableViewController {
     }
 
     private func matches(team: SearchIndex.TeamsPayloadPayload, query: String) -> Bool {
-        let number = TeamKeys.trimFRCPrefix(team.key)
+        let number = team.key.trimFRCPrefix
         return number.hasPrefix(query) || team.nickname.lowercased().contains(query)
             || team.key.lowercased().contains(query)
     }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -54,7 +54,7 @@ class TeamAtEventViewController: ContainerViewController {
                 statsViewController,
                 awardsViewController,
             ],
-            navigationTitle: "Team \(TeamKey.trimFRCPrefix(teamKey))",
+            navigationTitle: "Team \(TeamKeys.trimFRCPrefix(teamKey))",
             navigationSubtitle: nil,
             segmentedControlTitles: ["Summary", "Matches", "Media", "Stats", "Awards"],
             dependencies: dependencies

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -54,7 +54,7 @@ class TeamAtEventViewController: ContainerViewController {
                 statsViewController,
                 awardsViewController,
             ],
-            navigationTitle: "Team \(TeamKeys.trimFRCPrefix(teamKey))",
+            navigationTitle: "Team \(teamKey.trimFRCPrefix)",
             navigationSubtitle: nil,
             segmentedControlTitles: ["Summary", "Matches", "Media", "Stats", "Awards"],
             dependencies: dependencies

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -18,7 +18,10 @@ class TeamAtEventViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(teamKey: String, eventKey: String, year: Int, dependencies: Dependencies) {
+    init(teamKey: TeamKey, eventKey: String, year: Int, dependencies: Dependencies) {
+        // B teams (e.g. "frc5940B") alias their parent team — there's no
+        // /team/<N>B page, so route every caller to the canonical key.
+        let teamKey = teamKey.parentKey
         self.teamKey = teamKey
         self.eventKey = eventKey
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -54,7 +54,7 @@ class TeamAtEventViewController: ContainerViewController {
                 statsViewController,
                 awardsViewController,
             ],
-            navigationTitle: "Team \(teamKey.trimFRCPrefix)",
+            navigationTitle: "Team \(teamKey.trimPrefix)",
             navigationSubtitle: nil,
             segmentedControlTitles: ["Summary", "Matches", "Media", "Stats", "Awards"],
             dependencies: dependencies

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -67,7 +67,7 @@ class TeamViewController: HeaderContainerViewController {
     private init(state: TeamState, partialNickname: String?, dependencies: Dependencies) {
         self.state = state
 
-        let teamNumber = state.team?.teamNumber ?? Int(TeamKey.trimFRCPrefix(state.key)) ?? 0
+        let teamNumber = state.team?.teamNumber ?? Int(TeamKeys.trimFRCPrefix(state.key)) ?? 0
         let nickname: String? = {
             if let team = state.team, !team.nickname.isEmpty { return team.nickname }
             return partialNickname

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -56,8 +56,14 @@ class TeamViewController: HeaderContainerViewController {
 
     // MARK: Init
 
-    convenience init(teamKey: String, nickname: String? = nil, dependencies: Dependencies) {
-        self.init(state: .key(teamKey), partialNickname: nickname, dependencies: dependencies)
+    convenience init(teamKey: TeamKey, nickname: String? = nil, dependencies: Dependencies) {
+        // B teams (e.g. "frc5940B") alias their parent team — there's no
+        // /team/<N>B page, so route every caller to the canonical key.
+        self.init(
+            state: .key(teamKey.parentKey),
+            partialNickname: nickname,
+            dependencies: dependencies
+        )
     }
 
     convenience init(team: Team, dependencies: Dependencies) {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -67,7 +67,7 @@ class TeamViewController: HeaderContainerViewController {
     private init(state: TeamState, partialNickname: String?, dependencies: Dependencies) {
         self.state = state
 
-        let teamNumber = state.team?.teamNumber ?? Int(state.key.trimFRCPrefix) ?? 0
+        let teamNumber = state.team?.teamNumber ?? state.key.teamNumber ?? 0
         let nickname: String? = {
             if let team = state.team, !team.nickname.isEmpty { return team.nickname }
             return partialNickname

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -67,7 +67,7 @@ class TeamViewController: HeaderContainerViewController {
     private init(state: TeamState, partialNickname: String?, dependencies: Dependencies) {
         self.state = state
 
-        let teamNumber = state.team?.teamNumber ?? Int(TeamKeys.trimFRCPrefix(state.key)) ?? 0
+        let teamNumber = state.team?.teamNumber ?? Int(state.key.trimFRCPrefix) ?? 0
         let nickname: String? = {
             if let team = state.team, !team.nickname.isEmpty { return team.nickname }
             return partialNickname

--- a/the-blue-alliance-ios/ViewElements/Events/EventAllianceTableViewCell.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/EventAllianceTableViewCell.swift
@@ -78,7 +78,7 @@ class EventAllianceTableViewCell: UITableViewCell, Reusable {
 
         // OH PICK BOY http://photos.prnewswire.com/prnvar/20140130/NY56077
         for (index, teamKey) in viewModel.picks.enumerated() {
-            let teamNumber = teamKey.trimFRCPrefix
+            let teamNumber = teamKey.trimPrefix
 
             var label: UILabel
             if index == 0 {

--- a/the-blue-alliance-ios/ViewElements/Events/EventAllianceTableViewCell.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/EventAllianceTableViewCell.swift
@@ -78,7 +78,7 @@ class EventAllianceTableViewCell: UITableViewCell, Reusable {
 
         // OH PICK BOY http://photos.prnewswire.com/prnvar/20140130/NY56077
         for (index, teamKey) in viewModel.picks.enumerated() {
-            let teamNumber = TeamKey.trimFRCPrefix(teamKey)
+            let teamNumber = TeamKeys.trimFRCPrefix(teamKey)
 
             var label: UILabel
             if index == 0 {

--- a/the-blue-alliance-ios/ViewElements/Events/EventAllianceTableViewCell.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/EventAllianceTableViewCell.swift
@@ -78,7 +78,7 @@ class EventAllianceTableViewCell: UITableViewCell, Reusable {
 
         // OH PICK BOY http://photos.prnewswire.com/prnvar/20140130/NY56077
         for (index, teamKey) in viewModel.picks.enumerated() {
-            let teamNumber = TeamKeys.trimFRCPrefix(teamKey)
+            let teamNumber = teamKey.trimFRCPrefix
 
             var label: UILabel
             if index == 0 {

--- a/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
@@ -193,14 +193,14 @@ class MatchSummaryView: UIView {
     }
 
     private func teamLabel(for teamKey: String, baseTeamKeys: [String], dq: Bool) -> UILabel {
-        let text: String = "\(TeamKey.trimFRCPrefix(teamKey))"
+        let text: String = "\(TeamKeys.trimFRCPrefix(teamKey))"
         let isBold: Bool = baseTeamKeys.contains(teamKey)
 
         return label(text: text, isBold: isBold, isStrikethrough: dq)
     }
 
     private func teamButton(for teamKey: String, baseTeamKeys: [String], dq: Bool) -> UIButton {
-        let text: String = "\(TeamKey.trimFRCPrefix(teamKey))"
+        let text: String = "\(TeamKeys.trimFRCPrefix(teamKey))"
         let isBold: Bool = baseTeamKeys.contains(teamKey)
 
         return button(text: text, teamKey: teamKey, isBold: isBold, isStrikethrough: dq)

--- a/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
@@ -193,14 +193,14 @@ class MatchSummaryView: UIView {
     }
 
     private func teamLabel(for teamKey: String, baseTeamKeys: [String], dq: Bool) -> UILabel {
-        let text: String = "\(teamKey.trimFRCPrefix)"
+        let text: String = "\(teamKey.trimPrefix)"
         let isBold: Bool = baseTeamKeys.contains(teamKey)
 
         return label(text: text, isBold: isBold, isStrikethrough: dq)
     }
 
     private func teamButton(for teamKey: String, baseTeamKeys: [String], dq: Bool) -> UIButton {
-        let text: String = "\(teamKey.trimFRCPrefix)"
+        let text: String = "\(teamKey.trimPrefix)"
         let isBold: Bool = baseTeamKeys.contains(teamKey)
 
         return button(text: text, teamKey: teamKey, isBold: isBold, isStrikethrough: dq)

--- a/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
@@ -193,14 +193,14 @@ class MatchSummaryView: UIView {
     }
 
     private func teamLabel(for teamKey: String, baseTeamKeys: [String], dq: Bool) -> UILabel {
-        let text: String = "\(TeamKeys.trimFRCPrefix(teamKey))"
+        let text: String = "\(teamKey.trimFRCPrefix)"
         let isBold: Bool = baseTeamKeys.contains(teamKey)
 
         return label(text: text, isBold: isBold, isStrikethrough: dq)
     }
 
     private func teamButton(for teamKey: String, baseTeamKeys: [String], dq: Bool) -> UIButton {
-        let text: String = "\(TeamKeys.trimFRCPrefix(teamKey))"
+        let text: String = "\(teamKey.trimFRCPrefix)"
         let isBold: Bool = baseTeamKeys.contains(teamKey)
 
         return button(text: text, teamKey: teamKey, isBold: isBold, isStrikethrough: dq)

--- a/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchSummaryView.swift
@@ -3,7 +3,7 @@ import TBAAPI
 import UIKit
 
 protocol MatchSummaryViewDelegate: AnyObject {
-    func teamPressed(teamNumber: Int)
+    func teamPressed(teamKey: String)
 }
 
 class MatchSummaryView: UIView {
@@ -203,17 +203,15 @@ class MatchSummaryView: UIView {
         let text: String = "\(TeamKey.trimFRCPrefix(teamKey))"
         let isBold: Bool = baseTeamKeys.contains(teamKey)
 
-        return button(text: text, isBold: isBold, isStrikethrough: dq)
+        return button(text: text, teamKey: teamKey, isBold: isBold, isStrikethrough: dq)
     }
 
-    private func button(text: String, isBold: Bool, isStrikethrough: Bool = false) -> UIButton {
+    private func button(text: String, teamKey: String, isBold: Bool, isStrikethrough: Bool = false)
+        -> UIButton
+    {
         let button = UIButton(type: .system)
         button.setTitle(text, for: [])
         button.setTitleColor(UIColor.highlightColor, for: .normal)
-
-        if let teamNumber = Int(text) {
-            button.tag = teamNumber
-        }
 
         button.titleLabel?.attributedText = customAttributedString(
             text: text,
@@ -222,9 +220,8 @@ class MatchSummaryView: UIView {
         )
 
         button.addAction(
-            UIAction { [weak self, weak button] _ in
-                guard let button, button.tag != 0 else { return }
-                self?.delegate?.teamPressed(teamNumber: button.tag)
+            UIAction { [weak self] _ in
+                self?.delegate?.teamPressed(teamKey: teamKey)
             },
             for: .touchUpInside
         )


### PR DESCRIPTION
## Summary
- B teams (e.g. `frc5940B`) alias their parent team in TBA — no separate Team entity, no `/team/<N>B` route. The web strips letter suffixes at link time (`|digits` Jinja filter), so 5940B links route to `/team/5940`. iOS had no equivalent: `MatchSummaryView` stashed the team number in `button.tag` via `Int(text)`, which returned `nil` for `"5940B"` and left the tag at `0`, so the tap guard swallowed every B-team press.
- Adds `TeamKey.parentKey("frc5940B") → "frc5940"` (iOS analog of web's `|digits`).
- `MatchSummaryViewDelegate.teamPressed` now passes `teamKey: String` and captures the key directly in the action closure, so B-team taps actually fire.
- `MatchViewController` normalizes the tapped key via `parentKey` before pushing `TeamAtEventViewController`, mirroring web's parent-team routing so the team API lookup doesn't 404.

Fixes #960. The Core Data layer that caused the original "refreshes don't insert" symptom was removed in #978, so the remaining B-team bug was the dead tap in match summary.

## Test plan
- [x] New `TeamKey.parentKey` unit tests: canonical / uppercase B / lowercase b / unprefixed / non-numeric fallback (5 tests). All 19 TBAAPI helper tests pass.
- [x] `scripts/swift-format.sh --strict` clean.
- [x] `xcodebuild -scheme "The Blue Alliance" -destination 'platform=iOS Simulator,name=iPhone 17'` compiles the Swift sources without errors (only the unrelated `Secrets.plist` copy step fails in CI-less checkouts).
- [ ] Manual: open 2023cacc → Matches → tap a match with `frc5940B` in an alliance → tap `5940B` → lands on Team 5940's @Event page.
- [ ] Manual: tapping a canonical team key (e.g. `5940` on red) still navigates as before.