### PR TITLE
Add Team # sort option to Event Team Stats

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -16,6 +16,7 @@ enum EventTeamStatFilter: String, Comparable, CaseIterable {
     case opr = "OPR"
     case dpr = "DPR"
     case ccwm = "CCWM"
+    case teamNumber = "Team #"
 }
 
 struct TeamStatRow: Hashable {
@@ -127,6 +128,13 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
         case .opr: sorted = unsorted.sorted { $0.opr > $1.opr }
         case .dpr: sorted = unsorted.sorted { $0.dpr > $1.dpr }
         case .ccwm: sorted = unsorted.sorted { $0.ccwm > $1.ccwm }
+        case .teamNumber:
+            sorted = unsorted.sorted { lhs, rhs in
+                let lNum = lhs.teamKey.parentKey.teamNumber ?? 0
+                let rNum = rhs.teamKey.parentKey.teamNumber ?? 0
+                if lNum != rNum { return lNum < rNum }
+                return lhs.teamKey < rhs.teamKey
+            }
         }
         self.rows = sorted
 


### PR DESCRIPTION
## Summary
- Adds a `Team #` sort option to the Event Team Stats screen, restoring the team-number sort that was removed during the TeamKey refactor.
- Sorts ascending by parent team number so B-teams group with their parent (e.g. `frc5940` then `frc5940B`), with the raw key as a tiebreaker.

Closes #279

## Test plan
- [ ] Open an event's Stats tab, tap the filter button, pick `Team #`, and confirm rows are ordered by ascending team number.
- [ ] On an event that includes a B-team (e.g. 5940/5940B), confirm the B-team sorts immediately after its parent.
- [ ] Switch back to OPR/DPR/CCWM and confirm those sorts still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)