### PR TITLE
Wrap event names in event list cell

### DIFF
--- a/the-blue-alliance-ios/ViewElements/Events/EventTableViewCell.xib
+++ b/the-blue-alliance-ios/ViewElements/Events/EventTableViewCell.xib
@@ -18,7 +18,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uRU-9b-pBx">
                         <rect key="frame" x="16" y="8" width="366.5" height="70"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="751" text="Kettering University District" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MWI-Oa-cyJ">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="751" text="Kettering University District" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MWI-Oa-cyJ">
                                 <rect key="frame" x="0.0" y="0.0" width="366.5" height="52"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>


### PR DESCRIPTION
## Summary
- Long event names were truncated to a single line in Search, MyTBA, and event lists. Set `EventTableViewCell` name label to `numberOfLines=0` with `wordWrap` so the full name is visible. Row height already uses `automaticDimension`, so cells resize naturally.

## Test plan
- [ ] Build & run on iOS simulator
- [ ] Search for an event with a long name (e.g. a district championship) and confirm the name wraps instead of truncating
- [ ] Verify location and date row still renders correctly underneath
- [ ] Confirm wrapping also looks correct in MyTBA favorites and the events list (year/week views)
- [ ] Verify short event names still render in a single line with normal row height

🤖 Generated with [Claude Code](https://claude.com/claude-code)