### PR TITLE
Restore event names on Team@District Summary + Breakdown

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
@@ -7,6 +7,7 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Stat
     private let teamKey: String
     private let districtKey: String
     private var ranking: DistrictRanking
+    private var eventsByKey: [String: Event] = [:]
 
     // MARK: - Init
 
@@ -80,7 +81,8 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Stat
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int)
         -> String?
     {
-        eventPoints[section].eventKey
+        let eventKey = eventPoints[section].eventKey
+        return eventsByKey[eventKey]?.safeShortName ?? eventKey
     }
 
     // MARK: - Refreshable
@@ -90,11 +92,26 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Stat
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey)
+            // Unstructured Task handles instead of `async let`: Swift 6.1's
+            // async-let stack allocator trips swift_task_dealloc's LIFO check
+            // here even with reverse-order awaits (#995 didn't fully fix it).
+            // Task handles heap-allocate and sidestep the allocator entirely.
+            // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
+            let rankingsHandle = Task {
+                try await self.dependencies.api.districtRankings(key: self.districtKey)
+            }
+            let eventsHandle = Task {
+                try? await self.dependencies.api.districtEvents(key: self.districtKey)
+            }
+
+            let events = await eventsHandle.value ?? []
+            self.eventsByKey = Dictionary(uniqueKeysWithValues: events.map { ($0.key, $0) })
+
+            let fetched = try await rankingsHandle.value
             if let updated = fetched?.first(where: { $0.teamKey == self.teamKey }) {
                 self.ranking = updated
-                self.tableView.reloadData()
             }
+            self.tableView.reloadData()
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
@@ -11,6 +11,7 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable, St
     private let teamKey: String
     private let districtKey: String
     private var ranking: DistrictRanking
+    private var eventsByKey: [String: Event] = [:]
 
     weak var delegate: DistrictTeamSummaryViewControllerDelegate?
 
@@ -54,7 +55,7 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable, St
             tableView.dequeueReusableCell(indexPath: indexPath) as ReverseSubtitleTableViewCell
         if isEventPointsRow(row: indexPath.row) {
             let points = eventPoints[indexPath.row - 1]
-            cell.titleLabel.text = points.eventKey
+            cell.titleLabel.text = eventsByKey[points.eventKey]?.safeShortName ?? points.eventKey
             cell.subtitleLabel.text = "\(points.total) Points"
             cell.selectionStyle = .default
             cell.accessoryType = .disclosureIndicator
@@ -91,11 +92,29 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable, St
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            let fetched = try await self.dependencies.api.districtRankings(key: self.districtKey)
+            // Unstructured Task handles instead of `async let`: Swift 6.1's
+            // async-let stack allocator trips swift_task_dealloc's LIFO check
+            // here even with reverse-order awaits (#995 didn't fully fix it).
+            // Task handles heap-allocate and sidestep the allocator entirely.
+            // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
+            let rankingsHandle = Task {
+                try await self.dependencies.api.districtRankings(key: self.districtKey)
+            }
+            let eventsHandle = Task {
+                try? await self.dependencies.api.districtEvents(key: self.districtKey)
+            }
+
+            // Persist events before awaiting rankings so a rankings failure
+            // doesn't discard a successful events response — the next refresh
+            // that succeeds on rankings will render using this event map.
+            let events = await eventsHandle.value ?? []
+            self.eventsByKey = Dictionary(uniqueKeysWithValues: events.map { ($0.key, $0) })
+
+            let fetched = try await rankingsHandle.value
             if let updated = fetched?.first(where: { $0.teamKey == self.teamKey }) {
                 self.ranking = updated
-                self.tableView.reloadData()
             }
+            self.tableView.reloadData()
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1079. Same TBAData-migration drop as #1063 / #1067 — the two Team@District tabs render `DistrictRanking.eventPoints[].eventKey` directly, so:
- **Summary** (`DistrictTeamSummaryViewController`): per-event rows showed raw keys (e.g. "2026mibat") instead of event names.
- **Breakdown** (`DistrictBreakdownViewController`): section headers (sibling tab on the same screen) had the same regression.

Each VC now owns an `eventsByKey: [String: Event]` cache and co-fetches `districtRankings(key:)` + `districtEvents(key:)` on refresh using the unstructured `Task {}`-handle pattern from #1063/#1067 (Swift 6.1 async-let allocator bug, #996). Events are persisted before awaiting rankings so a rankings failure doesn't discard a successful events response. Cells render `eventsByKey[key]?.safeShortName ?? key`, so failure to load events falls back cleanly to the key string.

Cache lives with the VC and is replaced wholesale on each refresh — no eviction; dies when the user navigates away.

Audit note: I grepped all label/header bindings against `eventKey`/`teamKey`/`districtKey`/`matchKey` in `ViewControllers/` and `ViewElements/`. The only key-as-display sites left from the TBAData drop were these two — everything else either renders through a model that's already loaded or uses an intentional short form (Team N for match alliance buttons, MyTBA cell fallbacks).

## Test plan

- [ ] Open Team @ District (e.g. tap into a team from a 2026 district rankings page) and confirm the **Summary** tab's per-event rows show real event names (e.g. "Battle Creek"), not "2026mibat".
- [ ] Switch to the **Breakdown** tab on the same screen and confirm section headers show event names too.
- [ ] Pull-to-refresh on each tab; names remain.
- [ ] Tapping an event row on Summary still navigates into Team @ Event correctly.
- [ ] Offline regression after a successful load: rows / headers should render from HTTP cache; on a genuine events failure, both tabs fall back to the eventKey string without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)