### PR TITLE
Simplify myTBA view. Only show fully loaded models - no placeholders. Add UI for showing unloaded models

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Client/TBAAPI+Events.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Client/TBAAPI+Events.swift
@@ -18,7 +18,7 @@ extension TBAAPI {
         }
     }
 
-    public func event(key eventKey: String) async throws -> Event {
+    public func event(key eventKey: EventKey) async throws -> Event {
         let response = try await client.getEvent(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -34,7 +34,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventTeams(key eventKey: String) async throws -> [Team] {
+    public func eventTeams(key eventKey: EventKey) async throws -> [Team] {
         let response = try await client.getEventTeams(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -50,7 +50,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventTeamsSimple(key eventKey: String) async throws -> [TeamSimple] {
+    public func eventTeamsSimple(key eventKey: EventKey) async throws -> [TeamSimple] {
         let response = try await client.getEventTeamsSimple(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -66,7 +66,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventRankings(key eventKey: String) async throws -> EventRanking {
+    public func eventRankings(key eventKey: EventKey) async throws -> EventRanking {
         let response = try await client.getEventRankings(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -82,7 +82,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventAlliances(key eventKey: String) async throws -> [EliminationAlliance]? {
+    public func eventAlliances(key eventKey: EventKey) async throws -> [EliminationAlliance]? {
         let response = try await client.getEventAlliances(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -98,7 +98,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventAwards(key eventKey: String) async throws -> [Award] {
+    public func eventAwards(key eventKey: EventKey) async throws -> [Award] {
         let response = try await client.getEventAwards(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -114,7 +114,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventDistrictPoints(key eventKey: String) async throws -> EventDistrictPoints {
+    public func eventDistrictPoints(key eventKey: EventKey) async throws -> EventDistrictPoints {
         let response = try await client.getEventDistrictPoints(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -130,7 +130,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventInsights(key eventKey: String) async throws -> EventInsights {
+    public func eventInsights(key eventKey: EventKey) async throws -> EventInsights {
         let response = try await client.getEventInsights(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -146,7 +146,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventMatches(key eventKey: String) async throws -> [Match] {
+    public func eventMatches(key eventKey: EventKey) async throws -> [Match] {
         let response = try await client.getEventMatches(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -178,7 +178,7 @@ extension TBAAPI {
         }
     }
 
-    public func eventOPRs(key eventKey: String) async throws -> EventOPRs {
+    public func eventOPRs(key eventKey: EventKey) async throws -> EventOPRs {
         let response = try await client.getEventOPRs(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Client/TBAAPI+Teams.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Client/TBAAPI+Teams.swift
@@ -46,7 +46,7 @@ extension TBAAPI {
         return all
     }
 
-    public func team(key teamKey: String) async throws -> Team {
+    public func team(key teamKey: TeamKey) async throws -> Team {
         let response = try await client.getTeam(path: .init(teamKey: teamKey))
         switch response {
         case .ok(let ok):
@@ -62,7 +62,7 @@ extension TBAAPI {
         }
     }
 
-    public func teamYearsParticipated(key teamKey: String) async throws -> [Int] {
+    public func teamYearsParticipated(key teamKey: TeamKey) async throws -> [Int] {
         let response = try await client.getTeamYearsParticipated(path: .init(teamKey: teamKey))
         switch response {
         case .ok(let ok):
@@ -78,7 +78,7 @@ extension TBAAPI {
         }
     }
 
-    public func teamEventsByYear(key teamKey: String, year: Int) async throws -> [Event] {
+    public func teamEventsByYear(key teamKey: TeamKey, year: Int) async throws -> [Event] {
         let response = try await client.getTeamEventsByYear(
             path: .init(teamKey: teamKey, year: year)
         )
@@ -96,7 +96,7 @@ extension TBAAPI {
         }
     }
 
-    public func teamEventMatches(teamKey: String, eventKey: String) async throws -> [Match] {
+    public func teamEventMatches(teamKey: TeamKey, eventKey: EventKey) async throws -> [Match] {
         let response = try await client.getTeamEventMatches(
             path: .init(teamKey: teamKey, eventKey: eventKey)
         )
@@ -114,7 +114,7 @@ extension TBAAPI {
         }
     }
 
-    public func teamEventAwards(teamKey: String, eventKey: String) async throws -> [Award] {
+    public func teamEventAwards(teamKey: TeamKey, eventKey: EventKey) async throws -> [Award] {
         let response = try await client.getTeamEventAwards(
             path: .init(teamKey: teamKey, eventKey: eventKey)
         )
@@ -132,7 +132,9 @@ extension TBAAPI {
         }
     }
 
-    public func teamEventStatus(teamKey: String, eventKey: String) async throws -> TeamEventStatus {
+    public func teamEventStatus(teamKey: TeamKey, eventKey: EventKey) async throws
+        -> TeamEventStatus
+    {
         let response = try await client.getTeamEventStatus(
             path: .init(teamKey: teamKey, eventKey: eventKey)
         )
@@ -150,7 +152,8 @@ extension TBAAPI {
         }
     }
 
-    public func eventTeamsStatuses(key eventKey: String) async throws -> [String: TeamEventStatus] {
+    public func eventTeamsStatuses(key eventKey: EventKey) async throws -> [String: TeamEventStatus]
+    {
         let response = try await client.getEventTeamsStatuses(
             path: .init(eventKey: eventKey)
         )
@@ -168,7 +171,7 @@ extension TBAAPI {
         }
     }
 
-    public func teamMediaByYear(teamKey: String, year: Int) async throws -> [Media] {
+    public func teamMediaByYear(teamKey: TeamKey, year: Int) async throws -> [Media] {
         let response = try await client.getTeamMediaByYear(
             path: .init(teamKey: teamKey, year: year)
         )

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/EventKey+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/EventKey+Helpers.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension EventKey {
+    // Year prefix of an event key (`2024nyro` → 2024). nil for malformed keys.
+    public var year: Int? {
+        Int(prefix(4))
+    }
+
+    // Event code stripped of its 4-digit year prefix (`2024nyro` → `nyro`).
+    public var eventCode: String {
+        String(dropFirst(4))
+    }
+}

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
@@ -27,4 +27,5 @@ public typealias TeamEventStatus = Components.Schemas.TeamEventStatus
 public typealias TeamSimple = Components.Schemas.TeamSimple
 public typealias Webcast = Components.Schemas.Webcast
 
+public typealias EventKey = String
 public typealias TeamKey = String

--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
@@ -15,29 +15,29 @@ public protocol TBAAPIProtocol {
     // Teams
     func allTeams() async throws -> [Team]
     func allTeamsSimple() async throws -> [TeamSimple]
-    func team(key teamKey: String) async throws -> Team
-    func teamYearsParticipated(key teamKey: String) async throws -> [Int]
-    func teamEventsByYear(key teamKey: String, year: Int) async throws -> [Event]
-    func teamEventMatches(teamKey: String, eventKey: String) async throws -> [Match]
-    func teamEventAwards(teamKey: String, eventKey: String) async throws -> [Award]
-    func teamEventStatus(teamKey: String, eventKey: String) async throws -> TeamEventStatus
-    func teamMediaByYear(teamKey: String, year: Int) async throws -> [Media]
+    func team(key teamKey: TeamKey) async throws -> Team
+    func teamYearsParticipated(key teamKey: TeamKey) async throws -> [Int]
+    func teamEventsByYear(key teamKey: TeamKey, year: Int) async throws -> [Event]
+    func teamEventMatches(teamKey: TeamKey, eventKey: EventKey) async throws -> [Match]
+    func teamEventAwards(teamKey: TeamKey, eventKey: EventKey) async throws -> [Award]
+    func teamEventStatus(teamKey: TeamKey, eventKey: EventKey) async throws -> TeamEventStatus
+    func teamMediaByYear(teamKey: TeamKey, year: Int) async throws -> [Media]
 
-    func eventTeamsStatuses(key eventKey: String) async throws -> [String: TeamEventStatus]
+    func eventTeamsStatuses(key eventKey: EventKey) async throws -> [String: TeamEventStatus]
 
     // Events
     func eventsByYear(_ year: Int) async throws -> [Event]
-    func event(key eventKey: String) async throws -> Event
-    func eventTeams(key eventKey: String) async throws -> [Team]
-    func eventTeamsSimple(key eventKey: String) async throws -> [TeamSimple]
-    func eventRankings(key eventKey: String) async throws -> EventRanking
-    func eventAlliances(key eventKey: String) async throws -> [EliminationAlliance]?
-    func eventAwards(key eventKey: String) async throws -> [Award]
-    func eventDistrictPoints(key eventKey: String) async throws -> EventDistrictPoints
-    func eventInsights(key eventKey: String) async throws -> EventInsights
-    func eventMatches(key eventKey: String) async throws -> [Match]
+    func event(key eventKey: EventKey) async throws -> Event
+    func eventTeams(key eventKey: EventKey) async throws -> [Team]
+    func eventTeamsSimple(key eventKey: EventKey) async throws -> [TeamSimple]
+    func eventRankings(key eventKey: EventKey) async throws -> EventRanking
+    func eventAlliances(key eventKey: EventKey) async throws -> [EliminationAlliance]?
+    func eventAwards(key eventKey: EventKey) async throws -> [Award]
+    func eventDistrictPoints(key eventKey: EventKey) async throws -> EventDistrictPoints
+    func eventInsights(key eventKey: EventKey) async throws -> EventInsights
+    func eventMatches(key eventKey: EventKey) async throws -> [Match]
     func match(key matchKey: String) async throws -> Match
-    func eventOPRs(key eventKey: String) async throws -> EventOPRs
+    func eventOPRs(key eventKey: EventKey) async throws -> EventOPRs
 
     // Districts
     func districtsByYear(_ year: Int) async throws -> [District]

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Events/EventKey+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Events/EventKey+HelpersTests.swift
@@ -1,0 +1,27 @@
+import Testing
+
+@testable import TBAAPI
+
+struct EventKeyHelpersTests {
+
+    // MARK: - EventKey.year
+
+    @Test func year_parsesYearPrefix() {
+        #expect(("2024nyro" as EventKey).year == 2024)
+    }
+
+    @Test func year_nilForMalformedKey() {
+        #expect(("abcd" as EventKey).year == nil)
+        #expect(("" as EventKey).year == nil)
+    }
+
+    // MARK: - EventKey.eventCode
+
+    @Test func eventCode_dropsYearPrefix() {
+        #expect(("2024nyro" as EventKey).eventCode == "nyro")
+    }
+
+    @Test func eventCode_handlesEmptyAfterYear() {
+        #expect(("2024" as EventKey).eventCode == "")
+    }
+}

--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -53,7 +53,7 @@ extension Refreshable {
     }
 
     func updateRefresh() {
-        OperationQueue.main.addOperation {
+        DispatchQueue.main.async {
             if self.isRefreshing {
                 self.hideNoData()
 

--- a/the-blue-alliance-ios/Protocols/SearchContainer.swift
+++ b/the-blue-alliance-ios/Protocols/SearchContainer.swift
@@ -54,7 +54,7 @@ protocol SearchContainerDelegate {
 
 extension SearchContainerDelegate where Self: ContainerViewController {
 
-    func eventSelected(eventKey: String, name: String?) {
+    func eventSelected(eventKey: EventKey, name: String?) {
         let eventViewController = EventViewController(
             eventKey: eventKey,
             name: name,

--- a/the-blue-alliance-ios/Services/StatusService.swift
+++ b/the-blue-alliance-ios/Services/StatusService.swift
@@ -55,7 +55,7 @@ protocol StatusServiceProtocol: AnyObject {
 
     func registerForStatusChanges(_ subscriber: StatusSubscribable)
     func registerForFMSStatusChanges(_ subscriber: FMSStatusSubscribable)
-    func registerForEventStatusChanges(_ subscriber: EventStatusSubscribable, eventKey: String)
+    func registerForEventStatusChanges(_ subscriber: EventStatusSubscribable, eventKey: EventKey)
 
     func registerRetryable(initiallyRetry: Bool)
     func unregisterRetryable()
@@ -145,7 +145,7 @@ public class StatusService: NSObject, StatusServiceProtocol {
         fmsStatusSubscribers.add(subscriber as AnyObject)
     }
 
-    func registerForEventStatusChanges(_ subscriber: EventStatusSubscribable, eventKey: String) {
+    func registerForEventStatusChanges(_ subscriber: EventStatusSubscribable, eventKey: EventKey) {
         let subscribers =
             eventStatusSubscribers.object(forKey: eventKey as NSString)
             ?? NSHashTable<AnyObject>.weakObjects()
@@ -153,7 +153,7 @@ public class StatusService: NSObject, StatusServiceProtocol {
         eventStatusSubscribers.setObject(subscribers, forKey: eventKey as NSString)
     }
 
-    private func updateEventSubscribers(eventKey: String, isEventOffline: Bool) {
+    private func updateEventSubscribers(eventKey: EventKey, isEventOffline: Bool) {
         guard let subscribersTable = eventStatusSubscribers.object(forKey: eventKey as NSString)
         else {
             return
@@ -214,11 +214,11 @@ protocol EventStatusSubscribable: AnyObject {
 
 extension EventStatusSubscribable {
 
-    func registerForEventStatusChanges(eventKey: String) {
+    func registerForEventStatusChanges(eventKey: EventKey) {
         statusService.registerForEventStatusChanges(self, eventKey: eventKey)
     }
 
-    func isEventDown(eventKey: String) -> Bool {
+    func isEventDown(eventKey: EventKey) -> Bool {
         return statusService.status.downEventKeys.contains(eventKey)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
@@ -3,7 +3,7 @@ import TBAAPI
 import UIKit
 
 protocol DistrictTeamSummaryViewControllerDelegate: AnyObject {
-    func eventPointsSelected(eventKey: String)
+    func eventPointsSelected(eventKey: EventKey)
 }
 
 class DistrictTeamSummaryViewController: TBATableViewController, Refreshable, Stateful {

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -76,8 +76,8 @@ class TeamAtDistrictViewController: ContainerViewController {
 
 extension TeamAtDistrictViewController: DistrictTeamSummaryViewControllerDelegate {
 
-    func eventPointsSelected(eventKey: String) {
-        let year = Int(eventKey.prefix(4)) ?? self.year
+    func eventPointsSelected(eventKey: EventKey) {
+        let year = eventKey.year ?? self.year
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: eventKey,

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
@@ -64,14 +64,14 @@ protocol EventAlliancesViewControllerDelegate: AnyObject {
 
 private class EventAlliancesViewController: TBATableViewController, Refreshable, Stateful {
 
-    private let eventKey: String
+    private let eventKey: EventKey
     private var alliances: [EliminationAlliance] = []
 
     weak var delegate: EventAlliancesViewControllerDelegate?
 
     // MARK: - Init
 
-    init(eventKey: String, dependencies: Dependencies) {
+    init(eventKey: EventKey, dependencies: Dependencies) {
         self.eventKey = eventKey
         super.init(dependencies: dependencies)
     }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -65,7 +65,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
 
     weak var delegate: EventAwardsViewControllerDelegate?
 
-    private let eventKey: String
+    private let eventKey: EventKey
     private let teamKey: String?
 
     private var dataSource: TableViewDataSource<String, Award>!
@@ -74,7 +74,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Init
 
-    init(eventKey: String, teamKey: String? = nil, dependencies: Dependencies) {
+    init(eventKey: EventKey, teamKey: String? = nil, dependencies: Dependencies) {
         self.eventKey = eventKey
         self.teamKey = teamKey
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
@@ -69,7 +69,7 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
 
     weak var delegate: EventDistrictPointsViewControllerDelegate?
 
-    private let eventKey: String
+    private let eventKey: EventKey
 
     private var dataSource: TableViewDataSource<String, TeamDistrictPointsRow>!
     private var rows: [TeamDistrictPointsRow] = []
@@ -77,7 +77,7 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
 
     // MARK: - Init
 
-    init(eventKey: String, dependencies: Dependencies) {
+    init(eventKey: EventKey, dependencies: Dependencies) {
         self.eventKey = eventKey
         super.init(dependencies: dependencies)
     }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -40,7 +40,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Init
 
-    convenience init(eventKey: String, name: String? = nil, dependencies: Dependencies) {
+    convenience init(eventKey: EventKey, name: String? = nil, dependencies: Dependencies) {
         self.init(state: .key(eventKey), eventName: name, dependencies: dependencies)
     }
 
@@ -170,8 +170,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         if let event = state.event {
             cell.viewModel = InfoCellViewModel(event: event)
         } else if let eventName, !eventName.isEmpty {
-            let year = String(state.key.prefix(4))
-            let name = year.allSatisfy(\.isNumber) ? "\(year) \(eventName)" : eventName
+            let name = state.key.year.map { "\($0) \(eventName)" } ?? eventName
             cell.viewModel = InfoCellViewModel(nameString: name, subtitleStrings: [])
         } else {
             cell.viewModel = InfoCellViewModel(nameString: state.key, subtitleStrings: [])

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
@@ -10,7 +10,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
 
     weak var delegate: EventRankingsViewControllerDelegate?
 
-    private let eventKey: String
+    private let eventKey: EventKey
 
     private var dataSource: TableViewDataSource<String, EventRanking.RankingsPayloadPayload>!
     private var rankings: [EventRanking.RankingsPayloadPayload] = []
@@ -20,7 +20,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
 
     // MARK: - Init
 
-    init(eventKey: String, dependencies: Dependencies) {
+    init(eventKey: EventKey, dependencies: Dependencies) {
         self.eventKey = eventKey
         super.init(dependencies: dependencies)
     }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift
@@ -3,13 +3,13 @@ import TBAAPI
 
 class EventTeamsViewController: TeamsListViewController<Team> {
 
-    let eventKey: String
+    let eventKey: EventKey
 
     private var pitLocations: [String: String] = [:]
 
     // MARK: Init
 
-    init(eventKey: String, dependencies: Dependencies) {
+    init(eventKey: EventKey, dependencies: Dependencies) {
         self.eventKey = eventKey
 
         super.init(showSearch: false, dependencies: dependencies)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -37,7 +37,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 
     // MARK: - Init
 
-    convenience init(eventKey: String, name: String? = nil, dependencies: Dependencies) {
+    convenience init(eventKey: EventKey, name: String? = nil, dependencies: Dependencies) {
         self.init(state: .key(eventKey), eventName: name, dependencies: dependencies)
     }
 
@@ -208,7 +208,7 @@ extension EventViewController: EventRankingsViewControllerDelegate {
     }
 
     private func pushTeamAtEvent(teamKey: String) {
-        let year = state.event?.year ?? Int(state.key.prefix(4)) ?? 0
+        let year = state.event?.year ?? state.key.year ?? 0
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: state.key,

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
@@ -15,13 +15,13 @@ struct InsightRow: Hashable {
 
 class EventInsightsViewController: TBATableViewController, Refreshable, Stateful {
 
-    private let eventKey: String
+    private let eventKey: EventKey
     private let year: Int
     private let eventStatsConfigurator: EventInsightsConfigurator.Type?
 
     private var dataSource: TableViewDataSource<String, InsightRow>!
 
-    init(eventKey: String, year: Int, dependencies: Dependencies) {
+    init(eventKey: EventKey, year: Int, dependencies: Dependencies) {
         self.eventKey = eventKey
         self.year = year
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -30,7 +30,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
 
     weak var delegate: EventTeamStatsSelectionDelegate?
 
-    private let eventKey: String
+    private let eventKey: EventKey
 
     private var dataSource: TableViewDataSource<String, TeamStatRow>!
     private var rows: [TeamStatRow] = []
@@ -57,7 +57,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
 
     // MARK: - Init
 
-    init(eventKey: String, dependencies: Dependencies) {
+    init(eventKey: EventKey, dependencies: Dependencies) {
         self.eventKey = eventKey
 
         super.init(dependencies: dependencies)

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -42,7 +42,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
 
     // For callers that only have the event key (e.g. TeamAtEventViewController).
     // refresh() upgrades state to `.event` so playoff-aware sectioning kicks in.
-    convenience init(eventKey: String, teamKey: String? = nil, dependencies: Dependencies) {
+    convenience init(eventKey: EventKey, teamKey: String? = nil, dependencies: Dependencies) {
         self.init(state: .key(eventKey), teamKey: teamKey, dependencies: dependencies)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -1,27 +1,17 @@
 import Foundation
 import MyTBAKit
+import PureLayout
 import TBAAPI
 import UIKit
 
 public enum MyTBASection: Int {
     case event
     case team
-    case match
-
-    static func section(for modelType: MyTBAModelType) -> MyTBASection? {
-        switch modelType {
-        case .event: return .event
-        case .team: return .team
-        case .match: return .match
-        default: return nil
-        }
-    }
 
     var headerTitle: String {
         switch self {
         case .event: return "Events"
         case .team: return "Teams"
-        case .match: return "Matches"
         }
     }
 }
@@ -29,25 +19,30 @@ public enum MyTBASection: Int {
 protocol MyTBATableViewControllerDelegate: AnyObject {
     func eventSelected(eventKey: String)
     func teamSelected(teamKey: String)
-    func matchSelected(matchKey: String)
 }
 
 enum MyTBAItem: Hashable {
     case event(key: String)
     case team(key: String)
-    case match(key: String)
+
+    init?(modelType: MyTBAModelType, key: String) {
+        switch modelType {
+        case .event: self = .event(key: key)
+        case .team: self = .team(key: key)
+        default: return nil
+        }
+    }
 
     var section: MyTBASection {
         switch self {
         case .event: return .event
         case .team: return .team
-        case .match: return .match
         }
     }
 
     var modelKey: String {
         switch self {
-        case .event(let key), .team(let key), .match(let key):
+        case .event(let key), .team(let key):
             return key
         }
     }
@@ -55,32 +50,137 @@ enum MyTBAItem: Hashable {
 
 // Abstract base. Two concrete subclasses below bind to FavoritesStore or
 // SubscriptionsStore, then pass their entries through the common rendering
-// pipeline (per-type caches populated lazily from TBAAPI).
-class MyTBATableViewController: TBATableViewController, NotificationObservable {
+// pipeline. Owns the loaded-model cache, failure tracking, and the pinned
+// failure banner that sits above the table.
+class MyTBATableViewController: UIViewController, NotificationObservable,
+    TableViewDataSourceDelegate, DataController, Navigatable
+{
 
+    let dependencies: Dependencies
     weak var delegate: MyTBATableViewControllerDelegate?
 
+    var api: any TBAAPIProtocol { dependencies.api }
+    var myTBA: any MyTBAProtocol { dependencies.myTBA }
+    var myTBAStores: MyTBAStores { dependencies.myTBAStores }
+    var statusService: any StatusServiceProtocol { dependencies.statusService }
+    var urlOpener: any URLOpener { dependencies.urlOpener }
+
+    // MARK: - Refreshable
+
+    var currentRefreshTask: Task<Void, Never>?
+
+    // MARK: - Stateful
+
+    var noDataViewController: NoDataViewController = NoDataViewController()
+
+    // MARK: - Navigatable
+
+    var additionalRightBarButtonItems: [UIBarButtonItem] {
+        return []
+    }
+
+    // MARK: - Views
+
+    private(set) var tableView: UITableView!
+    private var failureBannerView: FailureBannerView!
+    private var failureBannerContainer: UIView!
+    private var failureBannerHeightConstraint: NSLayoutConstraint!
     private var dataSource: TableViewDataSource<MyTBASection, MyTBAItem>!
 
-    private var eventsCache: [String: Event] = [:]
-    private var teamsCache: [String: Team] = [:]
-    private var matchesCache: [String: Match] = [:]
+    // MARK: - State
 
-    // MARK: View Lifecycle
+    private enum LoadedModel {
+        case event(Event)
+        case team(Team)
+    }
+    private var loadedModels: [MyTBAItem: LoadedModel] = [:]
+    private var failedKeys: Set<MyTBAItem> = []
+    /// When true, failed items render inline as key-only placeholder cells and
+    /// the banner stays hidden until the next refresh repopulates `failedKeys`.
+    private var inlineFailedKeys: Bool = false
+
+    // MARK: - Init
+
+    init(dependencies: Dependencies) {
+        self.dependencies = dependencies
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.backgroundColor = UIColor.systemGroupedBackground
+
+        failureBannerView = FailureBannerView()
+        failureBannerView.addAction(
+            UIAction { [weak self] _ in self?.bannerTapped() },
+            for: .touchUpInside
+        )
+        failureBannerView.translatesAutoresizingMaskIntoConstraints = false
+
+        // Clipping wrapper so the banner can slide up behind the segmented
+        // control instead of being scrunched. Banner is pinned to the wrapper's
+        // bottom; animating the wrapper's height 0 ↔ bannerHeight produces the
+        // slide effect without resizing the banner content itself.
+        failureBannerContainer = UIView()
+        failureBannerContainer.clipsToBounds = true
+        failureBannerContainer.translatesAutoresizingMaskIntoConstraints = false
+        failureBannerContainer.addSubview(failureBannerView)
+        NSLayoutConstraint.activate([
+            failureBannerView.leadingAnchor.constraint(
+                equalTo: failureBannerContainer.leadingAnchor
+            ),
+            failureBannerView.trailingAnchor.constraint(
+                equalTo: failureBannerContainer.trailingAnchor
+            ),
+            failureBannerView.bottomAnchor.constraint(
+                equalTo: failureBannerContainer.bottomAnchor
+            ),
+        ])
+        failureBannerHeightConstraint = failureBannerContainer.heightAnchor.constraint(
+            equalToConstant: 0
+        )
+        failureBannerHeightConstraint.isActive = true
+
+        tableView = UITableView(frame: .zero, style: .plain)
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 64.0
+        tableView.backgroundColor = UIColor.systemGroupedBackground
+        tableView.tableFooterView = UIView(frame: .zero)
+        tableView.delegate = self
+        tableView.registerReusableCell(BasicTableViewCell.self)
         tableView.registerReusableCell(EventTableViewCell.self)
         tableView.registerReusableCell(TeamTableViewCell.self)
-        tableView.registerReusableCell(MatchTableViewCell.self)
+
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = 0
+            tableView.contentInsetAdjustmentBehavior = .never
+        }
+
+        let stack = UIStackView(arrangedSubviews: [failureBannerContainer, tableView])
+        stack.axis = .vertical
+        view.addSubview(stack)
+        stack.autoPinEdge(toSuperviewSafeArea: .top)
+        stack.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .top)
 
         setupDataSource()
         tableView.dataSource = dataSource
 
         registerForStoreChanges()
-
         rebuildSnapshot()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let selected = tableView.indexPathForSelectedRow {
+            tableView.deselectRow(at: selected, animated: animated)
+        }
     }
 
     // MARK: Subclass Hooks
@@ -100,147 +200,163 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
         fatalError("Subclasses must override registerForStoreChanges()")
     }
 
-    // MARK: Data Source
+    // MARK: - Refreshable default
+
+    func refresh() {
+        guard myTBA.isAuthenticated else { return }
+        refreshFromRemote()
+    }
+
+    // MARK: - Data Source
 
     private func setupDataSource() {
         dataSource = TableViewDataSource<MyTBASection, MyTBAItem>(
             tableView: tableView,
             cellProvider: { [weak self] tableView, indexPath, item in
                 guard let self = self else { return UITableViewCell() }
-                switch item {
-                case .event(let key):
-                    let cell =
-                        tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
-                    if let event = self.eventsCache[key] {
-                        cell.viewModel = EventCellViewModel(
-                            name: event.safeShortName,
-                            location: event.locationString,
-                            dateString: event.dateString
-                        )
-                    } else {
-                        cell.viewModel = EventCellViewModel(
-                            name: key,
-                            location: nil,
-                            dateString: nil
-                        )
-                    }
-                    return cell
-                case .team(let key):
-                    let cell =
-                        tableView.dequeueReusableCell(indexPath: indexPath) as TeamTableViewCell
-                    if let team = self.teamsCache[key] {
-                        cell.viewModel = TeamCellViewModel(
-                            teamNumber: "\(team.teamNumber)",
-                            nickname: team.displayNickname,
-                            location: team.locationString
-                        )
-                    } else {
-                        cell.viewModel = TeamCellViewModel(
-                            teamNumber: key.trimPrefix,
-                            nickname: "Team \(key.trimPrefix)",
-                            location: nil
-                        )
-                    }
-                    return cell
-                case .match(let key):
-                    let cell =
-                        tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
-                    if let match = self.matchesCache[key] {
-                        if let event = self.eventsCache[MatchKey.eventKey(from: key)] {
-                            cell.viewModel = MatchViewModel(match: match, event: event)
-                        } else {
-                            cell.viewModel = MatchViewModel(withoutEventContextFor: match)
-                        }
-                    }
-                    return cell
+                if let model = self.loadedModels[item] {
+                    return self.makeCell(for: model, in: tableView, at: indexPath)
                 }
+                if self.inlineFailedKeys, self.failedKeys.contains(item) {
+                    return self.makePlaceholderCell(for: item, in: tableView, at: indexPath)
+                }
+                return UITableViewCell()
             }
         )
         dataSource.delegate = self
     }
 
+    private func makeCell(
+        for model: LoadedModel,
+        in tableView: UITableView,
+        at indexPath: IndexPath
+    ) -> UITableViewCell {
+        switch model {
+        case .event(let event):
+            let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
+            cell.viewModel = EventCellViewModel(
+                name: event.safeShortName,
+                location: event.locationString,
+                dateString: event.dateString
+            )
+            return cell
+        case .team(let team):
+            let cell = tableView.dequeueReusableCell(indexPath: indexPath) as TeamTableViewCell
+            cell.viewModel = TeamCellViewModel(
+                teamNumber: "\(team.teamNumber)",
+                nickname: team.displayNickname,
+                location: team.locationString
+            )
+            return cell
+        }
+    }
+
+    private func makePlaceholderCell(
+        for item: MyTBAItem,
+        in tableView: UITableView,
+        at indexPath: IndexPath
+    ) -> UITableViewCell {
+        switch item {
+        case .event(let key):
+            let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
+            cell.viewModel = EventCellViewModel(name: key, location: nil, dateString: nil)
+            return cell
+        case .team(let key):
+            let cell = tableView.dequeueReusableCell(indexPath: indexPath) as TeamTableViewCell
+            cell.viewModel = TeamCellViewModel(
+                teamNumber: key.trimPrefix,
+                nickname: "Team \(key.trimPrefix)",
+                location: nil
+            )
+            return cell
+        }
+    }
+
     private func rebuildSnapshot() {
+        let validItems = Set(currentItems)
+        loadedModels = loadedModels.filter { validItems.contains($0.key) }
+        failedKeys.formIntersection(validItems)
+
         var snapshot = NSDiffableDataSourceSnapshot<MyTBASection, MyTBAItem>()
-        let items = currentItems
-        let grouped = Dictionary(grouping: items, by: { $0.section })
-        for section in [MyTBASection.event, .team, .match] {
+        let visible = currentItems.filter { item in
+            if loadedModels[item] != nil { return true }
+            if inlineFailedKeys, failedKeys.contains(item) { return true }
+            return false
+        }
+        let grouped = Dictionary(grouping: visible, by: { $0.section })
+        for section in [MyTBASection.event, .team] {
             guard let sectionItems = grouped[section], !sectionItems.isEmpty else { continue }
             let sorted = sortItems(sectionItems, in: section)
             snapshot.appendSections([section])
             snapshot.appendItems(sorted, toSection: section)
         }
         dataSource.applySnapshotUsingReloadData(snapshot)
+
+        updateFailureBanner()
     }
 
     private func sortItems(_ items: [MyTBAItem], in section: MyTBASection) -> [MyTBAItem] {
         switch section {
         case .event:
             return items.sorted { lhs, rhs in
-                let lEvent = eventsCache[lhs.modelKey]
-                let rEvent = eventsCache[rhs.modelKey]
-                let lYear = lEvent.flatMap { Int($0.key.prefix(4)) } ?? 0
-                let rYear = rEvent.flatMap { Int($0.key.prefix(4)) } ?? 0
+                guard case .event(let l) = loadedModels[lhs],
+                    case .event(let r) = loadedModels[rhs]
+                else {
+                    return lhs.modelKey < rhs.modelKey
+                }
+                let lYear = Int(l.key.prefix(4)) ?? 0
+                let rYear = Int(r.key.prefix(4)) ?? 0
                 if lYear != rYear { return lYear > rYear }
-                if let l = lEvent, let r = rEvent { return Event.sectionAscending(l, r) }
-                return lhs.modelKey < rhs.modelKey
+                return Event.sectionAscending(l, r)
             }
         case .team:
             return items.sorted { lhs, rhs in
-                let l = teamsCache[lhs.modelKey]?.teamNumber ?? lhs.modelKey.teamNumber ?? 0
-                let r = teamsCache[rhs.modelKey]?.teamNumber ?? rhs.modelKey.teamNumber ?? 0
-                return l < r
-            }
-        case .match:
-            return items.sorted { lhs, rhs in
-                if let l = matchesCache[lhs.modelKey], let r = matchesCache[rhs.modelKey] {
-                    if l.compLevelSortOrder != r.compLevelSortOrder {
-                        return l.compLevelSortOrder < r.compLevelSortOrder
-                    }
-                    if l.setNumber != r.setNumber { return l.setNumber < r.setNumber }
-                    return l.matchNumber < r.matchNumber
+                guard case .team(let l) = loadedModels[lhs],
+                    case .team(let r) = loadedModels[rhs]
+                else {
+                    return lhs.modelKey < rhs.modelKey
                 }
-                return lhs.modelKey < rhs.modelKey
+                return l.teamNumber < r.teamNumber
             }
         }
     }
 
-    // MARK: TableViewDataSourceDelegate
+    // MARK: - TableViewDataSourceDelegate
 
-    override func title(forSection sectionIndex: Int) -> String? {
+    func title(forSection sectionIndex: Int) -> String? {
         let sections = dataSource.snapshot().sectionIdentifiers
         guard sectionIndex < sections.count else { return nil }
         return sections[sectionIndex].headerTitle
     }
 
-    // MARK: UITableView Delegate
-
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
-        switch item {
-        case .event(let key): delegate?.eventSelected(eventKey: key)
-        case .team(let key): delegate?.teamSelected(teamKey: key)
-        case .match(let key): delegate?.matchSelected(matchKey: key)
-        }
-    }
-
-    // MARK: Stateful wiring
+    // MARK: - Stateful wiring
 
     /// Concrete subclasses call this from `viewDidLoad` (after `super`) to
-    /// hook the no-data view into the data source. Declared on the base but
-    /// walked via an Obj-C cast so the base doesn't have to conform.
+    /// hook the no-data view into the data source. Walked via an Obj-C cast so
+    /// the base doesn't have to conform.
     func attachStatefulDelegate() {
         dataSource.statefulDelegate = self as? (Refreshable & Stateful)
     }
 
-    // MARK: Refresh
+    // MARK: - Refresh
 
     func storeDidChange() {
         rebuildSnapshot()
+        // Locally added favorites/subscriptions need their backing models loaded
+        // even when the user hasn't pulled to refresh.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.fetchMissingItems()
+            self.rebuildSnapshot()
+        }
     }
 
     func refreshFromRemote() {
         (self as? Refreshable)?.runRefresh { [weak self] in
             guard let self else { return }
+            self.failedKeys.removeAll()
+            self.inlineFailedKeys = false
+            self.updateFailureBanner()
             try await self.performRemoteRefresh()
             await self.fetchMissingItems()
             self.rebuildSnapshot()
@@ -249,50 +365,166 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
 
     private func fetchMissingItems() async {
         let items = currentItems
-        // Match rows render playoff-aware labels from their owning Event, so
-        // each .match item implies an event fetch too.
-        let matchImpliedEventKeys = Set(
-            items.compactMap { item -> String? in
-                guard case .match(let key) = item else { return nil }
-                let eventKey = MatchKey.eventKey(from: key)
-                return eventsCache[eventKey] == nil ? eventKey : nil
-            }
-        )
         await withTaskGroup(of: Void.self) { group in
-            for item in items {
-                switch item {
-                case .event(let key) where eventsCache[key] == nil:
-                    group.addTask { [weak self] in
-                        guard let self = self else { return }
-                        if let event = try? await self.dependencies.api.event(key: key) {
-                            await MainActor.run { self.eventsCache[key] = event }
-                        }
-                    }
-                case .team(let key) where teamsCache[key] == nil:
-                    group.addTask { [weak self] in
-                        guard let self = self else { return }
-                        if let team = try? await self.dependencies.api.team(key: key) {
-                            await MainActor.run { self.teamsCache[key] = team }
-                        }
-                    }
-                case .match(let key) where matchesCache[key] == nil:
-                    group.addTask { [weak self] in
-                        guard let self = self else { return }
-                        if let match = try? await self.dependencies.api.match(key: key) {
-                            await MainActor.run { self.matchesCache[key] = match }
-                        }
-                    }
-                default: break
-                }
-            }
-            for eventKey in matchImpliedEventKeys {
+            for item in items where loadedModels[item] == nil {
                 group.addTask { [weak self] in
                     guard let self = self else { return }
-                    if let event = try? await self.dependencies.api.event(key: eventKey) {
-                        await MainActor.run { self.eventsCache[eventKey] = event }
+                    do {
+                        let model = try await self.loadModel(for: item)
+                        await MainActor.run {
+                            self.loadedModels[item] = model
+                            self.failedKeys.remove(item)
+                            self.rebuildSnapshot()
+                        }
+                    } catch is CancellationError {
+                        // Refresh was cancelled; leave state untouched.
+                    } catch {
+                        await MainActor.run {
+                            self.failedKeys.insert(item)
+                            self.updateFailureBanner()
+                        }
                     }
                 }
             }
+        }
+    }
+
+    private func loadModel(for item: MyTBAItem) async throws -> LoadedModel {
+        switch item {
+        case .event(let key):
+            return .event(try await dependencies.api.event(key: key))
+        case .team(let key):
+            return .team(try await dependencies.api.team(key: key))
+        }
+    }
+
+    // MARK: - Failure Banner
+
+    private func updateFailureBanner() {
+        let events = failedKeys.filter { $0.section == .event }.count
+        let teams = failedKeys.filter { $0.section == .team }.count
+        let text = inlineFailedKeys ? nil : Self.failureBannerText(events: events, teams: teams)
+        if let text { failureBannerView.text = text }
+
+        let target: CGFloat
+        if text != nil {
+            let fitting = failureBannerView.systemLayoutSizeFitting(
+                CGSize(
+                    width: view.bounds.width,
+                    height: UIView.layoutFittingCompressedSize.height
+                ),
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .fittingSizeLevel
+            )
+            target = fitting.height
+        } else {
+            target = 0
+        }
+
+        guard failureBannerHeightConstraint.constant != target else { return }
+        failureBannerHeightConstraint.constant = target
+        UIView.animate(
+            withDuration: 0.25,
+            delay: 0,
+            options: [.beginFromCurrentState, .curveEaseInOut],
+            animations: {
+                self.view.layoutIfNeeded()
+            }
+        )
+    }
+
+    static func failureBannerText(events: Int, teams: Int) -> String? {
+        let parts: [String] = [
+            (events > 0 ? "\(events) \(events == 1 ? "event" : "events")" : nil),
+            (teams > 0 ? "\(teams) \(teams == 1 ? "team" : "teams")" : nil),
+        ].compactMap { $0 }
+        guard !parts.isEmpty else { return nil }
+        return "Failed to load \(parts.joined(separator: ", "))"
+    }
+
+    private func bannerTapped() {
+        guard !failedKeys.isEmpty else { return }
+        inlineFailedKeys = true
+        rebuildSnapshot()
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension MyTBATableViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+        switch item {
+        case .event(let key): delegate?.eventSelected(eventKey: key)
+        case .team(let key): delegate?.teamSelected(teamKey: key)
+        }
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        willDisplayHeaderView view: UIView,
+        forSection section: Int
+    ) {
+        if type(of: view) == UITableViewHeaderFooterView.self,
+            let view = view as? UITableViewHeaderFooterView
+        {
+            view.textLabel?.textColor = UIColor.white
+            view.textLabel?.font = UIFont.preferredFont(forTextStyle: .subheadline)
+
+            let headerView = UIView()
+            headerView.backgroundColor = UIColor.tableViewHeaderColor
+            view.backgroundView = headerView
+        }
+    }
+}
+
+// MARK: - Refreshable / Stateful
+
+extension Refreshable where Self: MyTBATableViewController {
+
+    var refreshControl: UIRefreshControl? {
+        get { tableView.refreshControl }
+        set { tableView.refreshControl = newValue }
+    }
+
+    var refreshView: UIScrollView { tableView }
+
+    func hideNoData() {
+        // Default no-op; the Stateful override handles the real case.
+    }
+
+    func noDataReload() {
+        // Default no-op; the Stateful override handles the real case.
+    }
+}
+
+extension Stateful where Self: MyTBATableViewController {
+
+    func addNoDataView(_ noDataView: UIView) {
+        DispatchQueue.main.async {
+            self.tableView.backgroundView = noDataView
+        }
+    }
+
+    func removeNoDataView(_ noDataView: UIView) {
+        DispatchQueue.main.async {
+            self.tableView.backgroundView = nil
+        }
+    }
+}
+
+extension Refreshable where Self: MyTBATableViewController & Stateful {
+
+    func hideNoData() {
+        removeNoDataView()
+    }
+
+    func noDataReload() {
+        if isDataSourceEmpty {
+            showNoDataView()
+        } else {
+            removeNoDataView()
         }
     }
 }
@@ -309,7 +541,9 @@ class MyTBAFavoritesViewController: MyTBATableViewController, Refreshable, State
     }
 
     override var currentItems: [MyTBAItem] {
-        favoritesStore.favorites.compactMap { Self.item(for: $0.modelType, key: $0.modelKey) }
+        favoritesStore.favorites.compactMap {
+            MyTBAItem(modelType: $0.modelType, key: $0.modelKey)
+        }
     }
 
     override func registerForStoreChanges() {
@@ -323,11 +557,6 @@ class MyTBAFavoritesViewController: MyTBATableViewController, Refreshable, State
         await MainActor.run { favoritesStore.replaceAll(with: favorites) }
     }
 
-    func refresh() {
-        guard myTBA.isAuthenticated else { return }
-        refreshFromRemote()
-    }
-
     // MARK: - Refreshable
 
     var isDataSourceEmpty: Bool { myTBA.isAuthenticated && favoritesStore.favorites.isEmpty }
@@ -335,15 +564,6 @@ class MyTBAFavoritesViewController: MyTBATableViewController, Refreshable, State
     // MARK: - Stateful
 
     var noDataText: String? { "No favorites" }
-
-    private static func item(for type: MyTBAModelType, key: String) -> MyTBAItem? {
-        switch type {
-        case .event: return .event(key: key)
-        case .team: return .team(key: key)
-        case .match: return .match(key: key)
-        default: return nil
-        }
-    }
 }
 
 // MARK: - Subscriptions
@@ -359,7 +579,7 @@ class MyTBASubscriptionsViewController: MyTBATableViewController, Refreshable, S
 
     override var currentItems: [MyTBAItem] {
         subscriptionsStore.subscriptions.compactMap {
-            Self.item(for: $0.modelType, key: $0.modelKey)
+            MyTBAItem(modelType: $0.modelType, key: $0.modelKey)
         }
     }
 
@@ -374,11 +594,6 @@ class MyTBASubscriptionsViewController: MyTBATableViewController, Refreshable, S
         await MainActor.run { subscriptionsStore.replaceAll(with: subs) }
     }
 
-    func refresh() {
-        guard myTBA.isAuthenticated else { return }
-        refreshFromRemote()
-    }
-
     // MARK: - Refreshable
 
     var isDataSourceEmpty: Bool {
@@ -388,15 +603,6 @@ class MyTBASubscriptionsViewController: MyTBATableViewController, Refreshable, S
     // MARK: - Stateful
 
     var noDataText: String? { "No subscriptions" }
-
-    private static func item(for type: MyTBAModelType, key: String) -> MyTBAItem? {
-        switch type {
-        case .event: return .event(key: key)
-        case .team: return .team(key: key)
-        case .match: return .match(key: key)
-        default: return nil
-        }
-    }
 }
 
 // MARK: - NotificationObservable helper
@@ -411,5 +617,61 @@ extension NotificationObservable {
             queue: .main,
             using: handler
         )
+    }
+}
+
+// MARK: - Failure Banner View
+
+private final class FailureBannerView: UIControl {
+
+    private let label = UILabel()
+    private let chevron = UIImageView(image: UIImage(systemName: "chevron.right"))
+
+    var text: String? {
+        get { label.text }
+        set { label.text = newValue }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = UIColor.systemRed.withAlphaComponent(0.9)
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.textColor = .white
+        label.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        label.adjustsFontForContentSizeCategory = true
+        label.isUserInteractionEnabled = false
+
+        chevron.translatesAutoresizingMaskIntoConstraints = false
+        chevron.tintColor = .white
+        chevron.contentMode = .scaleAspectFit
+        chevron.isUserInteractionEnabled = false
+        chevron.setContentHuggingPriority(.required, for: .horizontal)
+        chevron.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let stack = UIStackView(arrangedSubviews: [label, chevron])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 12
+        stack.isUserInteractionEnabled = false
+        addSubview(stack)
+        stack.autoPinEdgesToSuperviewEdges(
+            with: UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
+        )
+
+        accessibilityTraits = .button
+        isAccessibilityElement = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var accessibilityLabel: String? {
+        get { label.text }
+        set { super.accessibilityLabel = newValue }
     }
 }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -17,8 +17,11 @@ public enum MyTBASection: Int {
 }
 
 protocol MyTBATableViewControllerDelegate: AnyObject {
-    func eventSelected(eventKey: String)
-    func teamSelected(teamKey: String)
+    func eventSelected(_ event: Event)
+    func teamSelected(_ team: Team)
+    // Fallbacks for the placeholder/failure path where we only have a key.
+    func eventSelected(eventKey: EventKey)
+    func teamSelected(teamKey: TeamKey)
 }
 
 enum MyTBAItem: Hashable {
@@ -158,10 +161,8 @@ class MyTBATableViewController: UIViewController, NotificationObservable,
         tableView.registerReusableCell(EventTableViewCell.self)
         tableView.registerReusableCell(TeamTableViewCell.self)
 
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0
-            tableView.contentInsetAdjustmentBehavior = .never
-        }
+        tableView.sectionHeaderTopPadding = 0
+        tableView.contentInsetAdjustmentBehavior = .never
 
         let stack = UIStackView(arrangedSubviews: [failureBannerContainer, tableView])
         stack.axis = .vertical
@@ -304,8 +305,8 @@ class MyTBATableViewController: UIViewController, NotificationObservable,
                 else {
                     return lhs.modelKey < rhs.modelKey
                 }
-                let lYear = Int(l.key.prefix(4)) ?? 0
-                let rYear = Int(r.key.prefix(4)) ?? 0
+                let lYear = l.key.year ?? 0
+                let rYear = r.key.year ?? 0
                 if lYear != rYear { return lYear > rYear }
                 return Event.sectionAscending(l, r)
             }
@@ -455,9 +456,15 @@ extension MyTBATableViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
-        switch item {
-        case .event(let key): delegate?.eventSelected(eventKey: key)
-        case .team(let key): delegate?.teamSelected(teamKey: key)
+        switch (item, loadedModels[item]) {
+        case (.event, .event(let event)):
+            delegate?.eventSelected(event)
+        case (.team, .team(let team)):
+            delegate?.teamSelected(team)
+        case (.event(let key), _):
+            delegate?.eventSelected(eventKey: key)
+        case (.team(let key), _):
+            delegate?.teamSelected(teamKey: key)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
@@ -173,11 +173,6 @@ extension MyTBAViewController: MyTBATableViewControllerDelegate {
         navigationController?.pushViewController(viewController, animated: true)
     }
 
-    func matchSelected(matchKey: String) {
-        let viewController = MatchViewController(matchKey: matchKey, dependencies: dependencies)
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-
 }
 
 extension MyTBAViewController: MyTBAAuthenticationObservable {

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
@@ -3,6 +3,7 @@ import GoogleSignIn
 import MyTBAKit
 import Photos
 import PureLayout
+import TBAAPI
 import UIKit
 import UserNotifications
 
@@ -163,12 +164,22 @@ class MyTBAViewController: ContainerViewController {
 
 extension MyTBAViewController: MyTBATableViewControllerDelegate {
 
-    func eventSelected(eventKey: String) {
+    func eventSelected(_ event: Event) {
+        let viewController = EventViewController(event: event, dependencies: dependencies)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func teamSelected(_ team: Team) {
+        let viewController = TeamViewController(team: team, dependencies: dependencies)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func eventSelected(eventKey: EventKey) {
         let viewController = EventViewController(eventKey: eventKey, dependencies: dependencies)
         navigationController?.pushViewController(viewController, animated: true)
     }
 
-    func teamSelected(teamKey: String) {
+    func teamSelected(teamKey: TeamKey) {
         let viewController = TeamViewController(teamKey: teamKey, dependencies: dependencies)
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -25,7 +25,7 @@ enum SearchSection: String {
 }
 
 protocol SearchViewControllerDelegate: AnyObject {
-    func eventSelected(eventKey: String, name: String?)
+    func eventSelected(eventKey: EventKey, name: String?)
     func teamSelected(teamKey: String, nickname: String?)
 }
 
@@ -144,8 +144,8 @@ class SearchViewController: TBATableViewController {
             let events = index.events
                 .filter { matches(event: $0, query: query) }
                 .sorted { lhs, rhs in
-                    let lYear = Int(lhs.key.prefix(4)) ?? 0
-                    let rYear = Int(rhs.key.prefix(4)) ?? 0
+                    let lYear = lhs.key.year ?? 0
+                    let rYear = rhs.key.year ?? 0
                     if lYear != rYear { return lYear > rYear }
                     return lhs.name < rhs.name
                 }
@@ -172,9 +172,10 @@ class SearchViewController: TBATableViewController {
 
     // Single source of truth for event row text so the search matcher operates on what the user sees —
     // event names from the API don't include the year, so without this typing "2026 michigan" wouldn't hit.
-    private static func eventDisplayName(key: String, name: String) -> String {
+    private static func eventDisplayName(key: EventKey, name: String) -> String {
         guard !name.isEmpty else { return key }
-        return "\(key.prefix(4)) \(name)"
+        guard let year = key.year else { return name }
+        return "\(year) \(name)"
     }
 
     // MARK: - Table View Delegate

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 class TeamAtEventViewController: ContainerViewController {
 
     let teamKey: String
-    let eventKey: String
+    let eventKey: EventKey
 
     var matchesViewController: MatchesViewController
 
@@ -18,7 +18,7 @@ class TeamAtEventViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(teamKey: TeamKey, eventKey: String, year: Int, dependencies: Dependencies) {
+    init(teamKey: TeamKey, eventKey: EventKey, year: Int, dependencies: Dependencies) {
         // B teams (e.g. "frc5940B") alias their parent team — there's no
         // /team/<N>B page, so route every caller to the canonical key.
         let teamKey = teamKey.parentKey
@@ -124,7 +124,7 @@ class TeamAtEventViewController: ContainerViewController {
         navigationController?.pushViewController(eventViewController, animated: true)
     }
 
-    private func pushTeamAtEvent(teamKey: String, eventKey: String, year: Int) {
+    private func pushTeamAtEvent(teamKey: String, eventKey: EventKey, year: Int) {
         let vc = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: eventKey,
@@ -179,7 +179,7 @@ extension TeamAtEventViewController: EventAwardsViewControllerDelegate {
         if self.teamKey == teamKey {
             return
         }
-        guard let year = Int(eventKey.prefix(4)) else { return }
+        guard let year = eventKey.year else { return }
         pushTeamAtEvent(teamKey: teamKey, eventKey: eventKey, year: year)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamStatsViewController.swift
@@ -5,13 +5,13 @@ import UIKit
 class TeamStatsViewController: TBATableViewController, Refreshable, Stateful {
 
     private let teamKey: String
-    private let eventKey: String
+    private let eventKey: EventKey
 
     private var stats: TeamStats?
 
     // MARK: - Init
 
-    init(teamKey: String, eventKey: String, dependencies: Dependencies) {
+    init(teamKey: String, eventKey: EventKey, dependencies: Dependencies) {
         self.teamKey = teamKey
         self.eventKey = eventKey
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -34,7 +34,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
     weak var delegate: TeamSummaryViewControllerDelegate?
 
     private let teamKey: String
-    private let eventKey: String
+    private let eventKey: EventKey
 
     private var team: Team?
     private var event: Event?
@@ -44,7 +44,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
 
     private var dataSource: TableViewDataSource<TeamSummarySection, TeamSummaryItem>!
 
-    init(teamKey: String, eventKey: String, dependencies: Dependencies) {
+    init(teamKey: String, eventKey: EventKey, dependencies: Dependencies) {
         self.teamKey = teamKey
         self.eventKey = eventKey
 


### PR DESCRIPTION
This PR got a little out of control as they all do.

The myTBA view was a bit of a nightmare state-wise. One thing I really disliked about this view was the initial placeholder cells that upgrade into fully populated cells. Ex: We just show a team cell from a `TeamKey`, and once we fetch the `Team` in the background we upgrade the cell. I feel like that pattern looks super messy.

It's a real problem for the Match cells because we need both a `Match` and the `Event` because the `Event.playoffType` determines how we render the `Match` cell. That's a whole different mess I'm working on - but it means the match cells actually fully load in and could be wrong for a moment while we're waiting for the Event to load in, and then they get a final reload where they're consistent. The Match cells are also just bad in this iteration of myTBA because we give no context about what event they're associated with, so you're just looking at some bare "Quals 22" with no indication of what event, year, etc. this match is tied to.

So a multi-part fix here. First - we no longer show the dummy myTBA cells before we have their full models. We only show the cells if we're able to render their full model. This makes that view look much cleaner. In the case of load failures, we'll show a banner at the top that some models failed to load. If you tap the banner they'll show up in the list as raw keys (the placeholder cells) and we'll still allow for pushing to them from the view.

We also fixed the odd behavior where the myTBA view would push to a Team or Event view but only use the keys we have from myTBA. Since we're already loading the full Event or Team - we ought to just push using the full model. In the case we're pushing from our fallback keys - we still push using a key.

Final bit here is - we added some `EventKey` helpers to clean up some code - the way we added `TeamKey` helpers. This makes this diff a little large - but that's okay.