### PR TITLE
Coordinate team + avatar loading on Team page with skeleton header

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		92C079C723F99CA400AE2AFA /* EventInsightsConfigurator2020.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C079C623F99CA400AE2AFA /* EventInsightsConfigurator2020.swift */; };
 		92C5FBDC2B0037E10006AE48 /* YouTubeiOSPlayerHelper in Frameworks */ = {isa = PBXBuildFile; productRef = 92C5FBDB2B0037E10006AE48 /* YouTubeiOSPlayerHelper */; };
 		92C5FBDF2B0038250006AE48 /* Agrume in Frameworks */ = {isa = PBXBuildFile; productRef = 92C5FBDE2B0038250006AE48 /* Agrume */; };
+		92F63EAA2BA91B500025CC03 /* SkeletonView in Frameworks */ = {isa = PBXBuildFile; productRef = 92F63EAB2BA91B500025CC03 /* SkeletonView */; };
 		92C8CE4021AC5D5C00683558 /* MyTBAPreferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C8CE3F21AC5D5C00683558 /* MyTBAPreferenceViewController.swift */; };
 		92C8CE4421ACB03300683558 /* Subscribable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C8CE4321ACB03300683558 /* Subscribable.swift */; };
 		92C8CE4821ADAA5100683558 /* MyTBAContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C8CE4721ADAA5100683558 /* MyTBAContainerViewController.swift */; };
@@ -376,6 +377,7 @@
 				92F63E9B2BA91B4F0025CC03 /* MyTBAKit in Frameworks */,
 				92C5FBDF2B0038250006AE48 /* Agrume in Frameworks */,
 				924BDD9526D2B391008BE7D2 /* GoogleSignIn in Frameworks */,
+				92F63EAA2BA91B500025CC03 /* SkeletonView in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -965,6 +967,7 @@
 				92F63E9A2BA91B4F0025CC03 /* MyTBAKit */,
 				921843022DB42424003B4F9E /* TBAAPI */,
 				921843062DB42424003B4F9E /* TBAUtils */,
+				92F63EAB2BA91B500025CC03 /* SkeletonView */,
 			);
 			productName = "the-blue-alliance";
 			productReference = 92942D921E2154DA008E79CA /* The Blue Alliance.app */;
@@ -1010,6 +1013,7 @@
 				92B3217D26ED1A79003B28DC /* XCRemoteSwiftPackageReference "PureLayout" */,
 				92C5FBDA2B0037E10006AE48 /* XCRemoteSwiftPackageReference "youtube-ios-player-helper" */,
 				92C5FBDD2B0038250006AE48 /* XCRemoteSwiftPackageReference "Agrume" */,
+				92F63EAC2BA91B500025CC03 /* XCRemoteSwiftPackageReference "SkeletonView" */,
 				92F63E992BA91B4F0025CC03 /* XCLocalSwiftPackageReference "Packages/MyTBAKit" */,
 				921843012DB42424003B4F9E /* XCLocalSwiftPackageReference "Packages/TBAAPI" */,
 			);
@@ -1504,6 +1508,14 @@
 				minimumVersion = 5.0.0;
 			};
 		};
+		92F63EAC2BA91B500025CC03 /* XCRemoteSwiftPackageReference "SkeletonView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Juanpe/SkeletonView.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.31.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1558,6 +1570,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 92C5FBDD2B0038250006AE48 /* XCRemoteSwiftPackageReference "Agrume" */;
 			productName = Agrume;
+		};
+		92F63EAB2BA91B500025CC03 /* SkeletonView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 92F63EAC2BA91B500025CC03 /* XCRemoteSwiftPackageReference "SkeletonView" */;
+			productName = SkeletonView;
 		};
 		92F63E9A2BA91B4F0025CC03 /* MyTBAKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -43,14 +43,56 @@ class TeamViewController: HeaderContainerViewController {
         TeamSubscribable(modelKey: state.key)
     }
 
+    // Avatars were introduced into FRC in 2018. Pre-2018 years never have
+    // avatar media, so we skip the API roundtrip + skeleton entirely and
+    // just collapse the avatar slot.
+    private static let firstAvatarYear = 2018
+
+    // Backing storage for `year`. `loadTeamData` writes this directly to
+    // bypass the user-driven side effects (avatar refetch, child propagation)
+    // during initial load — those are handled inline alongside the team fetch.
+    private var _year: Int?
     private var year: Int? {
-        didSet {
-            if oldValue == year { return }
-            eventsViewController.year = year
-            mediaViewController.year = year ?? Calendar.current.component(.year, from: Date())
-            avatarImage = nil
+        get { _year }
+        set {
+            guard _year != newValue else { return }
+            _year = newValue
+            eventsViewController.year = newValue
+            mediaViewController.year =
+                newValue ?? Calendar.current.component(.year, from: Date())
             updateInterface()
-            if let year { loadAvatar(year: year) }
+
+            guard let newValue else { return }
+
+            if newValue < Self.firstAvatarYear {
+                // Pre-avatar era: no fetch, no skeleton, no animation. Just
+                // nil out + hard-hide the slot.
+                avatarImage = nil
+                teamHeaderView.setAvatar(nil)
+                return
+            }
+
+            if avatarImage != nil {
+                // Had an avatar — show skeleton, fetch, reveal result. The
+                // skeleton hide animates collapse-and-fade if the new year
+                // turns out to have no avatar, in sync with the skeleton out.
+                teamHeaderView.showAvatarSkeleton()
+                Task { @MainActor in
+                    await loadAvatar(year: newValue)
+                    guard self.year == newValue else { return }
+                    teamHeaderView.hideAvatarSkeleton(revealing: avatarImage)
+                }
+            } else {
+                // No prior avatar — silent off-screen fetch, no skeleton.
+                // Only animate the avatar in if we actually got one.
+                Task { @MainActor in
+                    await loadAvatar(year: newValue)
+                    guard self.year == newValue else { return }
+                    if avatarImage != nil {
+                        teamHeaderView.transitionAvatar(to: avatarImage)
+                    }
+                }
+            }
         }
     }
 
@@ -70,13 +112,31 @@ class TeamViewController: HeaderContainerViewController {
         self.init(state: .team(team), partialNickname: nil, dependencies: dependencies)
     }
 
+    // TBA returns the literal "Team <N>" as a fallback nickname for teams
+    // without a real one (e.g. team 18). The header view already shows the
+    // team number on its own line, so echoing "Team N" as the subtitle
+    // duplicates it. Treat the fallback as no nickname here — list-style
+    // cells (TeamCell etc.) keep using the raw value, this only affects the
+    // header subtitle.
+    private static func displayNickname(
+        _ raw: String?,
+        teamNumber: Int
+    ) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        if raw == "Team \(teamNumber)" { return nil }
+        return raw
+    }
+
     private init(state: TeamState, partialNickname: String?, dependencies: Dependencies) {
         self.state = state
 
         let teamNumber = state.team?.teamNumber ?? state.key.teamNumber ?? 0
         let nickname: String? = {
-            if let team = state.team, !team.nickname.isEmpty { return team.nickname }
-            return partialNickname
+            let raw: String? = {
+                if let team = state.team, !team.nickname.isEmpty { return team.nickname }
+                return partialNickname
+            }()
+            return Self.displayNickname(raw, teamNumber: teamNumber)
         }()
         let teamNumberNickname = state.team?.teamNumberNickname ?? "Team \(teamNumber)"
 
@@ -138,6 +198,7 @@ class TeamViewController: HeaderContainerViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        teamHeaderView.showLoadingSkeleton()
         loadTeamData()
     }
 
@@ -164,17 +225,34 @@ class TeamViewController: HeaderContainerViewController {
             if let team = await teamHandle.value {
                 self.state = .team(team)
                 self.navigationTitle = team.teamNumberNickname
-                updateInterface()
             }
             if let years = await yearsHandle.value {
                 self.yearsParticipated = years.sorted().reversed()
-                if year == nil {
-                    year = Self.latestYear(
-                        currentSeason: statusService.currentSeason,
-                        years: yearsParticipated
-                    )
-                }
             }
+
+            // Set the initial year directly to bypass `year.didSet` — we kick
+            // off the avatar fetch inline below so the header reveals once
+            // with team + avatar in place rather than skeleton → avatar pop.
+            let initialYear = Self.latestYear(
+                currentSeason: statusService.currentSeason,
+                years: yearsParticipated
+            )
+            _year = initialYear
+            eventsViewController.year = initialYear
+            mediaViewController.year =
+                initialYear ?? Calendar.current.component(.year, from: Date())
+
+            if let initialYear, initialYear >= Self.firstAvatarYear {
+                await loadAvatar(year: initialYear)
+            }
+
+            // Update text-based subviews FIRST so they're sized at their final
+            // layout under the still-visible skeleton. The avatar is set by
+            // hideLoadingSkeleton itself so its slot collapse/expand animates
+            // in sync with the skeleton fade-out.
+            updateInterface()
+            teamHeaderView.layoutIfNeeded()
+            teamHeaderView.hideLoadingSkeleton(revealing: avatarImage)
         }
     }
 
@@ -193,7 +271,7 @@ class TeamViewController: HeaderContainerViewController {
             teamHeaderView.viewModel = TeamHeaderViewModel(
                 teamNumber: team.teamNumber,
                 avatar: avatarImage,
-                nickname: team.nickname.isEmpty ? nil : team.nickname,
+                nickname: Self.displayNickname(team.nickname, teamNumber: team.teamNumber),
                 teamNumberNickname: team.teamNumberNickname,
                 year: year
             )
@@ -201,19 +279,20 @@ class TeamViewController: HeaderContainerViewController {
         navigationSubtitle = year?.description ?? "----"
     }
 
-    private func loadAvatar(year: Int) {
-        Task { @MainActor in
-            guard
-                let media = try? await dependencies.api.teamMediaByYear(
-                    teamKey: state.key,
-                    year: year
-                )
-            else { return }
-            guard self.year == year else { return }
-            let avatar = media.first(where: { $0._type == .avatar })
-            avatarImage = Self.decodeAvatar(from: avatar)
-            updateInterface()
+    private func loadAvatar(year: Int) async {
+        let media: [Media]
+        do {
+            media = try await dependencies.api.teamMediaByYear(
+                teamKey: state.key,
+                year: year
+            )
+        } catch {
+            // Network/decoding failure: leave any existing avatar in place.
+            return
         }
+        guard self.year == year else { return }
+        let avatar = media.first(where: { $0._type == .avatar })
+        avatarImage = Self.decodeAvatar(from: avatar)
     }
 
     private static func decodeAvatar(from media: Media?) -> UIImage? {

--- a/the-blue-alliance-ios/ViewElements/Teams/TeamHeaderView.swift
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamHeaderView.swift
@@ -1,7 +1,49 @@
 import Foundation
+import SkeletonView
 import UIKit
 
 class TeamHeaderView: UIView {
+
+    // MARK: Shared geometry / fonts
+    //
+    // Both the real subviews and their skeleton counterparts read from this
+    // single source — change a value here and both stay aligned, so the two
+    // parallel hierarchies can't drift on their own.
+
+    fileprivate static let avatarSize: CGSize = .init(width: 55, height: 55)
+    fileprivate static let avatarCornerRadius: CGFloat = 5
+    fileprivate static let yearPillSize: CGSize = .init(width: 84, height: 28)
+    fileprivate static var yearPillCornerRadius: CGFloat { yearPillSize.height / 2 }
+    fileprivate static let headerStackSpacing: CGFloat = 8
+
+    fileprivate static func teamNumberFont() -> UIFont {
+        let font = UIFont.preferredFont(forTextStyle: .title1)
+        let metrics = UIFontMetrics(forTextStyle: .title1)
+        return metrics.scaledFont(
+            for: UIFont.systemFont(ofSize: font.pointSize, weight: .semibold)
+        )
+    }
+
+    fileprivate static func teamNameFont() -> UIFont {
+        UIFont.preferredFont(forTextStyle: .title3)
+    }
+
+    // Median nickname length across all 3,729 FRC teams with a nickname in
+    // 2026 (TBA data, computed via `tba team list --year 2026`). Mean was
+    // pulled up by sponsor-list nicknames; mode was a noisy tie. Used to
+    // size the subtitle skeleton so it looks "right" for the typical team.
+    fileprivate static let medianTeamNameLength = 13
+
+    fileprivate static func skeletonSubtitleWidth() -> CGFloat {
+        // Measure with lowercase 'a' as a neutral-width stand-in (M would
+        // overshoot, i would undershoot). Re-measured per call so dynamic
+        // type changes propagate.
+        let sample = String(repeating: "a", count: medianTeamNameLength)
+        let width = (sample as NSString).size(
+            withAttributes: [.font: teamNameFont()]
+        ).width
+        return ceil(width)
+    }
 
     var viewModel: TeamHeaderViewModel {
         didSet {
@@ -21,12 +63,14 @@ class TeamHeaderView: UIView {
         return UIColor.avatarBlue
     }
 
+    // MARK: Real content
+
     private lazy var rootStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
             avatarImageView, teamInfoStackView, yearStackView,
         ])
         stackView.axis = .horizontal
-        stackView.spacing = 8
+        stackView.spacing = Self.headerStackSpacing
         stackView.alignment = .center
         return stackView
     }()
@@ -35,17 +79,13 @@ class TeamHeaderView: UIView {
 
     private lazy var teamNumberLabel: UILabel = {
         let label = TeamHeaderView.teamHeaderLabel()
-        let font = UIFont.preferredFont(forTextStyle: .title1)
-        let fontMetrics = UIFontMetrics(forTextStyle: .title1)
-        label.font = fontMetrics.scaledFont(
-            for: UIFont.systemFont(ofSize: font.pointSize, weight: .semibold)
-        )
+        label.font = Self.teamNumberFont()
         label.adjustsFontSizeToFitWidth = true
         return label
     }()
     private lazy var teamNameLabel: UILabel = {
         let label = TeamHeaderView.teamHeaderLabel()
-        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.font = Self.teamNameFont()
         label.numberOfLines = 0
         return label
     }()
@@ -68,6 +108,128 @@ class TeamHeaderView: UIView {
         return stackView
     }()
 
+    // MARK: Skeleton overlay
+    //
+    // A parallel stack mirroring rootStackView, drawn on top while data loads.
+    // Real subviews stay laid out at their final positions underneath (alpha 0)
+    // so when we cross-fade to them they don't reflow / grow in.
+
+    private lazy var skeletonAvatar: UIView = {
+        let v = UIView()
+        v.isSkeletonable = true
+        v.skeletonCornerRadius = Float(Self.avatarCornerRadius)
+        v.autoSetDimensions(to: Self.avatarSize)
+        return v
+    }()
+
+    // Invisible label sized like teamNumberLabel — reserves vertical space in
+    // the skeleton info stack so the subtitle bar lands where teamNameLabel
+    // will end up. Team number is known at init, so the real label stays
+    // visible throughout loading and never needs a skeleton placeholder.
+    private lazy var skeletonNumberSpacer: UILabel = {
+        let label = TeamHeaderView.teamHeaderLabel()
+        label.font = Self.teamNumberFont()
+        label.adjustsFontSizeToFitWidth = true
+        label.textColor = .clear
+        return label
+    }()
+
+    private lazy var skeletonSubtitleBar: UIView = {
+        let v = UIView()
+        v.isSkeletonable = true
+        v.skeletonCornerRadius = 4
+        v.autoSetDimension(.height, toSize: 16)
+        v.autoSetDimension(.width, toSize: Self.skeletonSubtitleWidth())
+        return v
+    }()
+
+    // Wraps skeletonSubtitleBar in a slot whose intrinsic height matches
+    // teamNameLabel (title3). The bar is leading-pinned + vertically centered
+    // inside, so it stays narrow even when skeletonInfoStack uses the same
+    // .fill alignment as the real teamInfoStackView.
+    private lazy var skeletonSubtitleSlot: UIView = {
+        let container = UIView()
+
+        let measuringLabel = UILabel()
+        measuringLabel.font = Self.teamNameFont()
+        measuringLabel.text = " "
+        measuringLabel.textColor = .clear
+        container.addSubview(measuringLabel)
+        measuringLabel.autoPinEdgesToSuperviewEdges()
+
+        container.addSubview(skeletonSubtitleBar)
+        skeletonSubtitleBar.autoPinEdge(toSuperviewEdge: .leading)
+        skeletonSubtitleBar.autoAlignAxis(toSuperviewAxis: .horizontal)
+
+        container.isSkeletonable = true
+        return container
+    }()
+
+    // Mirrors teamInfoStackView: vertical axis, default alignment (.fill),
+    // default spacing (0). With that match, skeletonNumberSpacer +
+    // skeletonSubtitleSlot land at the same vertical positions as
+    // teamNumberLabel + teamNameLabel will.
+    private lazy var skeletonInfoStack: UIStackView = {
+        let s = UIStackView(arrangedSubviews: [skeletonNumberSpacer, skeletonSubtitleSlot])
+        s.axis = .vertical
+        s.isSkeletonable = true
+        return s
+    }()
+
+    private lazy var skeletonYearPill: UIView = {
+        let v = UIView()
+        v.isSkeletonable = true
+        v.skeletonCornerRadius = Float(Self.yearPillCornerRadius)
+        // Sized for "YYYY" + chevron + YearButton's content insets — the year
+        // is always 4 digits, so this matches the real button to within a
+        // pixel and avoids a width snap when the real button replaces it.
+        v.autoSetDimensions(to: Self.yearPillSize)
+        return v
+    }()
+
+    // Mirrors yearStackView: spacer-on-top pushes the pill to the bottom so
+    // it aligns with the real yearButton (which sits at the bottom of its
+    // height-matched stack).
+    private lazy var skeletonYearStack: UIStackView = {
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .vertical)
+        let s = UIStackView(arrangedSubviews: [spacer, skeletonYearPill])
+        s.axis = .vertical
+        s.alignment = .trailing
+        s.isSkeletonable = true
+        return s
+    }()
+
+    private lazy var skeletonStackView: UIStackView = {
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        let s = UIStackView(arrangedSubviews: [
+            skeletonAvatar, skeletonInfoStack, spacer, skeletonYearStack,
+        ])
+        s.axis = .horizontal
+        s.spacing = Self.headerStackSpacing
+        s.alignment = .center
+        s.isSkeletonable = true
+        s.isHidden = true
+        return s
+    }()
+
+    // Standalone overlay pinned to avatarImageView for the year-change
+    // skeleton — skeletonStackView is hidden after the initial load, so its
+    // skeletonAvatar can't be reused for subsequent avatar loads.
+    private lazy var avatarSkeletonOverlay: UIView = {
+        let v = UIView()
+        v.isSkeletonable = true
+        v.skeletonCornerRadius = Float(Self.avatarCornerRadius)
+        v.isHidden = true
+        return v
+    }()
+
+    // Lighter wash so the skeleton reads against the navy header background.
+    private static let skeletonGradient = SkeletonGradient(
+        baseColor: UIColor(white: 1.0, alpha: 0.22)
+    )
+
     init(_ viewModel: TeamHeaderViewModel) {
         self.viewModel = viewModel
 
@@ -76,6 +238,8 @@ class TeamHeaderView: UIView {
         backgroundColor = UIColor.navigationBarTintColor
         clipsToBounds = true
         configureView()
+
+        isSkeletonable = true
 
         addSubview(rootStackView)
         rootStackView.autoPinEdge(toSuperviewSafeArea: .leading, withInset: 16)
@@ -88,8 +252,21 @@ class TeamHeaderView: UIView {
 
         yearStackView.autoMatch(.height, to: .height, of: rootStackView)
 
-        avatarImageView.autoSetDimensions(to: .init(width: 55, height: 55))
+        avatarImageView.autoSetDimensions(to: Self.avatarSize)
         avatarImageView.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        addSubview(skeletonStackView)
+        skeletonStackView.autoPinEdge(.leading, to: .leading, of: rootStackView)
+        skeletonStackView.autoPinEdge(.trailing, to: .trailing, of: rootStackView)
+        skeletonStackView.autoPinEdge(.top, to: .top, of: rootStackView)
+        skeletonStackView.autoPinEdge(.bottom, to: .bottom, of: rootStackView)
+        skeletonYearStack.autoMatch(.height, to: .height, of: skeletonStackView)
+
+        addSubview(avatarSkeletonOverlay)
+        avatarSkeletonOverlay.autoPinEdge(.leading, to: .leading, of: avatarImageView)
+        avatarSkeletonOverlay.autoPinEdge(.trailing, to: .trailing, of: avatarImageView)
+        avatarSkeletonOverlay.autoPinEdge(.top, to: .top, of: avatarImageView)
+        avatarSkeletonOverlay.autoPinEdge(.bottom, to: .bottom, of: avatarImageView)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -99,34 +276,179 @@ class TeamHeaderView: UIView {
     // MARK: Private Methods
 
     private func configureView() {
-        let newAvatar = viewModel.avatar
-        let shouldHide = newAvatar == nil
-        let avatarChanged =
-            avatarImageView.image != newAvatar || avatarImageView.isHidden != shouldHide
+        // Avatar is intentionally NOT touched here — it's driven by the
+        // explicit avatar API (setAvatar / transitionAvatar / hide…Skeleton)
+        // so callers can coordinate slot-collapse animations with the
+        // skeleton cross-fade. configureView fires from viewModel didSet
+        // synchronously and would otherwise jump the layout mid-animation.
+        teamNumberLabel.text = viewModel.teamNumberNickname
+        teamNameLabel.text = viewModel.nickname
+        teamNameLabel.isHidden = viewModel.nickname == nil
 
-        if window != nil, avatarChanged {
+        yearButton.year = viewModel.year
+    }
+
+    // MARK: Avatar API
+    //
+    // Slot reservation rules:
+    //   - avatarImageView.isHidden == false → 55×55 slot in rootStackView.
+    //   - avatarImageView.isHidden == true  → slot collapses, labels shift left.
+    // All four transitions (nil↔image, image↔image, etc.) go through
+    // transitionAvatar so the slot collapse/expand stays animated and in sync
+    // with whatever skeleton animation the caller is running.
+
+    func setAvatar(_ image: UIImage?) {
+        avatarImageView.image = image
+        avatarImageView.isHidden = image == nil
+    }
+
+    func transitionAvatar(to image: UIImage?) {
+        let oldImage = avatarImageView.image
+        switch (oldImage, image) {
+        case (nil, nil):
+            return
+        case (.some, .some):
             UIView.transition(
                 with: avatarImageView,
                 duration: 0.25,
                 options: .transitionCrossDissolve,
+                animations: { self.avatarImageView.image = image }
+            )
+        case (nil, .some):
+            avatarImageView.image = image
+            avatarImageView.isHidden = false
+            avatarImageView.alpha = 0
+            UIView.animate(
+                withDuration: 0.25,
                 animations: {
-                    self.avatarImageView.image = newAvatar
+                    self.avatarImageView.alpha = 1
+                    self.layoutIfNeeded()
                 }
             )
-            UIView.animate(withDuration: 0.25) {
-                self.avatarImageView.isHidden = shouldHide
-            }
-        } else {
-            avatarImageView.image = newAvatar
-            avatarImageView.isHidden = shouldHide
+        case (.some, nil):
+            UIView.animate(
+                withDuration: 0.25,
+                animations: {
+                    self.avatarImageView.alpha = 0
+                    self.avatarImageView.isHidden = true
+                    self.layoutIfNeeded()
+                },
+                completion: { _ in
+                    self.avatarImageView.image = nil
+                    self.avatarImageView.alpha = 1
+                }
+            )
+        }
+    }
+
+    // MARK: Skeleton API
+
+    func showLoadingSkeleton() {
+        // Mirror the (already-known) team number into the spacer so the
+        // skeleton info stack matches teamInfoStackView's height exactly.
+        skeletonNumberSpacer.text = viewModel.teamNumberNickname
+
+        // Reserve the avatar/nickname slots so rootStackView's layout matches
+        // the skeleton overlay's. Without this, an init-time-nil avatar or
+        // nickname leaves teamNumberLabel flush against the leading edge
+        // while the skeleton avatar sits beside it.
+        avatarImageView.isHidden = false
+        avatarImageView.alpha = 0
+        teamNameLabel.isHidden = false
+        yearButton.alpha = 0
+
+        // If we were pushed with a full Team (nickname known at init), skip
+        // the subtitle skeleton and keep the real label visible — there's
+        // nothing to load. Slot height stays reserved by skeletonSubtitleSlot's
+        // measuring label either way, so the skeleton stack still aligns.
+        let hasNickname = viewModel.nickname != nil
+        skeletonSubtitleBar.isHidden = hasNickname
+        teamNameLabel.alpha = hasNickname ? 1 : 0
+
+        // When the nickname is unknown, give teamNameLabel a single-space
+        // placeholder so it claims its title3 intrinsic height. Without this
+        // the info stack collapses to just teamNumberLabel's height; centered
+        // in rootStackView it sits ~12pt low, then jumps up when the real
+        // nickname lands and grows the stack. configureView overwrites the
+        // " " with the real text on load.
+        if !hasNickname {
+            teamNameLabel.text = " "
         }
 
-        teamNumberLabel.text = viewModel.teamNumberNickname
+        skeletonStackView.isHidden = false
+        skeletonStackView.showAnimatedGradientSkeleton(
+            usingGradient: Self.skeletonGradient
+        )
+    }
 
-        teamNameLabel.text = viewModel.nickname
-        teamNumberLabel.isHidden = viewModel.nickname == nil
+    func hideLoadingSkeleton(revealing avatar: UIImage?) {
+        // Caller is expected to update viewModel (text fields) BEFORE calling
+        // this so the real subviews have their final sizes already laid out
+        // under the still-visible skeleton. The avatar IS set here so its
+        // slot collapse/expand animates in sync with the skeleton fade.
+        skeletonStackView.hideSkeleton(reloadDataAfter: false)
+        avatarImageView.image = avatar
+        let willHaveAvatar = avatar != nil
 
-        yearButton.year = viewModel.year
+        UIView.animate(
+            withDuration: 0.25,
+            animations: {
+                self.skeletonStackView.alpha = 0
+                self.teamNameLabel.alpha = 1
+                self.yearButton.alpha = 1
+                if willHaveAvatar {
+                    self.avatarImageView.isHidden = false
+                    self.avatarImageView.alpha = 1
+                } else {
+                    self.avatarImageView.alpha = 0
+                    self.avatarImageView.isHidden = true
+                }
+                self.layoutIfNeeded()
+            },
+            completion: { _ in
+                self.skeletonStackView.isHidden = true
+                self.skeletonStackView.alpha = 1
+                if !willHaveAvatar {
+                    self.avatarImageView.alpha = 1  // reset for future reveals
+                }
+            }
+        )
+    }
+
+    func showAvatarSkeleton() {
+        avatarImageView.alpha = 0
+        avatarSkeletonOverlay.isHidden = false
+        avatarSkeletonOverlay.showAnimatedGradientSkeleton(
+            usingGradient: Self.skeletonGradient
+        )
+    }
+
+    func hideAvatarSkeleton(revealing avatar: UIImage?) {
+        avatarSkeletonOverlay.hideSkeleton(reloadDataAfter: false)
+        avatarImageView.image = avatar
+        let willHaveAvatar = avatar != nil
+
+        UIView.animate(
+            withDuration: 0.25,
+            animations: {
+                self.avatarSkeletonOverlay.alpha = 0
+                if willHaveAvatar {
+                    self.avatarImageView.isHidden = false
+                    self.avatarImageView.alpha = 1
+                } else {
+                    self.avatarImageView.alpha = 0
+                    self.avatarImageView.isHidden = true
+                }
+                self.layoutIfNeeded()
+            },
+            completion: { _ in
+                self.avatarSkeletonOverlay.isHidden = true
+                self.avatarSkeletonOverlay.alpha = 1
+                if !willHaveAvatar {
+                    self.avatarImageView.alpha = 1
+                }
+            }
+        )
     }
 
     static func teamHeaderLabel() -> UILabel {
@@ -171,7 +493,7 @@ private class AvatarImageView: UIView {
         layer.borderColor = baseColor.cgColor
         layer.borderWidth = 5
         layer.masksToBounds = true
-        layer.cornerRadius = 5
+        layer.cornerRadius = TeamHeaderView.avatarCornerRadius
 
         let tapGestureRecognizer = UITapGestureRecognizer(
             target: self,


### PR DESCRIPTION
With the TBAData/TBAAPI migration we changed the way the team avatar loads in and - I finally saw it enough that I hated it, and decided we needed to do better.

This PR revamps the Team header to have some loading states for both the years + the avatars. On first push we'll now show a loading state for the team nickname (if we don't already have it) as well as for the avatar and the year selector. When switching between years, we'll show the skeleton view for the avatar. Years before avatars were supported (before 2018) will silently hide the avatar view. If we hit a situation where we load in an avatar after the previous view not showing an avatar, we'll slide in the avatar view from the side.

https://github.com/user-attachments/assets/32ceafb7-303d-43e1-ac6e-eaf93272b6fd 

Additionally I took a first stab at fixing https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/1086 by not duplicating the team nickname if we do not have one. This should help make that view look less wonky.

The team nickname skeleton view is sized for the median team nickname length - so the skeleton view SHOULD look the most right for the most teams.