### PR TITLE
Replace TableViewDataSourceDelegate with TableSectionTitleProviding protocol

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/Data Sources/TableViewDataSource.swift
@@ -1,18 +1,15 @@
 import Foundation
 import UIKit
 
-protocol TableViewDataSourceDelegate: AnyObject {
-    func title(forSection section: Int) -> String?
+protocol TableSectionTitleProviding {
+    var headerTitle: String? { get }
 }
 
-/// TableViewDataSource is a wrapper around a UITableViewDiffableDataSource that implements
-/// UITableViewDataSource for TBA where we manage no data states and whatnot for table views
 class TableViewDataSource<Section: Hashable, Item: Hashable>: UITableViewDiffableDataSource<
     Section, Item
 >
 {
 
-    weak var delegate: TableViewDataSourceDelegate?
     weak var statefulDelegate: (Stateful & Refreshable)?
 
     // MARK: - Public Methods
@@ -58,7 +55,9 @@ class TableViewDataSource<Section: Hashable, Item: Hashable>: UITableViewDiffabl
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int)
         -> String?
     {
-        return delegate?.title(forSection: section)
+        let identifiers = snapshot().sectionIdentifiers
+        guard section >= 0, section < identifiers.count else { return nil }
+        return (identifiers[section] as? TableSectionTitleProviding)?.headerTitle
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBATableViewController.swift
@@ -3,9 +3,7 @@ import MyTBAKit
 import TBAAPI
 import UIKit
 
-class TBATableViewController: UITableViewController, TableViewDataSourceDelegate, DataController,
-    Navigatable
-{
+class TBATableViewController: UITableViewController, DataController, Navigatable {
 
     let dependencies: Dependencies
 
@@ -78,12 +76,6 @@ class TBATableViewController: UITableViewController, TableViewDataSourceDelegate
             headerView.backgroundColor = UIColor.tableViewHeaderColor
             view.backgroundView = headerView
         }
-    }
-
-    // MARK: - TableViewDataSourceDelegate
-
-    func title(forSection section: Int) -> String? {
-        return nil
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -59,7 +59,6 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
     }
 
     override func updateDataSource() {

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
@@ -60,7 +60,6 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
     }
 
     private func apply(_ districts: [District]) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -109,7 +109,6 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
     }
 
     private func applyAwards(_ awards: [Award]) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
@@ -119,7 +119,6 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
     }
 
     private func apply(points: EventDistrictPoints?) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
@@ -64,7 +64,6 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
     }
 
     private func applyRanking(_ response: EventRanking?) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
@@ -13,13 +13,25 @@ struct InsightRow: Hashable {
     }
 }
 
+// Section 0 renders a custom EventInsightsHeaderView; suppress its default title.
+private final class EventInsightsDataSource: TableViewDataSource<String, InsightRow> {
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int)
+        -> String?
+    {
+        guard section > 0 else { return nil }
+        let identifiers = snapshot().sectionIdentifiers
+        guard section < identifiers.count else { return nil }
+        return identifiers[section]
+    }
+}
+
 class EventInsightsViewController: TBATableViewController, Refreshable, Stateful {
 
     private let eventKey: EventKey
     private let year: Int
     private let eventStatsConfigurator: EventInsightsConfigurator.Type?
 
-    private var dataSource: TableViewDataSource<String, InsightRow>!
+    private var dataSource: EventInsightsDataSource!
 
     init(eventKey: EventKey, year: Int, dependencies: Dependencies) {
         self.eventKey = eventKey
@@ -93,21 +105,10 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
         return headerView
     }
 
-    // MARK: - TableViewDataSourceDelegate
-
-    override func title(forSection section: Int) -> String? {
-        if section == 0 {
-            return nil
-        }
-        let snapshot = dataSource.snapshot()
-        let title = snapshot.sectionIdentifiers[section]
-        return title
-    }
-
     // MARK: - Private Methods
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<String, InsightRow>(tableView: tableView) {
+        dataSource = EventInsightsDataSource(tableView: tableView) {
             (tableView, indexPath, row) -> UITableViewCell? in
             if indexPath.section == 0 {
                 let cell =
@@ -145,7 +146,6 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
                 return cell
             }
         }
-        dataSource.delegate = self
         dataSource.statefulDelegate = self
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -102,7 +102,6 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
     }
 
     private func apply(oprs response: EventOPRs?) {

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
@@ -10,6 +10,20 @@ extension EventsListViewControllerDelegate {
     func title(for event: Event) -> String? { nil }
 }
 
+// Lets the host VC overlay a per-event header title on top of the section's natural title.
+private final class EventsListDataSource: TableViewDataSource<EventSection, Event> {
+    var titleOverride: ((Event) -> String?)?
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int)
+        -> String?
+    {
+        let firstItem = itemIdentifier(for: IndexPath(item: 0, section: section))
+        guard let event = firstItem else { return "Events" }
+        if let custom = titleOverride?(event) { return custom }
+        return super.tableView(tableView, titleForHeaderInSection: section)
+    }
+}
+
 class EventsListViewController: TBATableViewController, Refreshable, Stateful {
 
     typealias APIEvent = Event
@@ -17,7 +31,7 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
     weak var delegate: EventsListViewControllerDelegate?
 
     private(set) var events: [APIEvent] = []
-    private var dataSource: TableViewDataSource<EventSection, APIEvent>!
+    private var dataSource: EventsListDataSource!
 
     // MARK: - View Lifecycle
 
@@ -39,7 +53,7 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: - Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<EventSection, APIEvent>(tableView: tableView) {
+        dataSource = EventsListDataSource(tableView: tableView) {
             [weak self] tableView, indexPath, event in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
             cell.viewModel = EventCellViewModel(
@@ -52,7 +66,7 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
+        dataSource.titleOverride = { [weak self] event in self?.delegate?.title(for: event) }
         tableView.dataSource = dataSource
     }
 
@@ -76,17 +90,6 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let event = dataSource.itemIdentifier(for: indexPath) else { return }
         delegate?.eventSelected(event)
-    }
-
-    // MARK: - TableViewDataSourceDelegate
-
-    override func title(forSection section: Int) -> String? {
-        guard let event = dataSource.itemIdentifier(for: IndexPath(item: 0, section: section))
-        else {
-            return "Events"
-        }
-        if let customTitle = delegate?.title(for: event) { return customTitle }
-        return event.section.title
     }
 
     // MARK: - Refreshable

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -101,7 +101,6 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
             cell.type = row.type
             return cell
         }
-        dataSource.delegate = self
         dataSource.statefulDelegate = self
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchSection.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchSection.swift
@@ -52,6 +52,10 @@ extension MatchSection: Comparable {
     }
 }
 
+extension MatchSection: TableSectionTitleProviding {
+    var headerTitle: String? { title }
+}
+
 extension MatchSection {
 
     static func section(for match: Match, playoffType: PlayoffType?) -> MatchSection {

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -112,7 +112,6 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
     }
 
     private func applyMatches(_ matches: [Match]) {
@@ -135,14 +134,6 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
             snapshot.appendItems(grouped[section] ?? [], toSection: section)
         }
         dataSource.applySnapshotUsingReloadData(snapshot)
-    }
-
-    // MARK: TableViewDataSourceDelegate
-
-    override func title(forSection section: Int) -> String? {
-        let sectionIDs = dataSource.snapshot().sectionIdentifiers
-        guard section >= 0, section < sectionIDs.count else { return nil }
-        return sectionIDs[section].title
     }
 
     // MARK: UITableView Delegate

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -7,8 +7,10 @@ import UIKit
 public enum MyTBASection: Int {
     case event
     case team
+}
 
-    var headerTitle: String {
+extension MyTBASection: TableSectionTitleProviding {
+    var headerTitle: String? {
         switch self {
         case .event: return "Events"
         case .team: return "Teams"
@@ -55,8 +57,8 @@ enum MyTBAItem: Hashable {
 // SubscriptionsStore, then pass their entries through the common rendering
 // pipeline. Owns the loaded-model cache, failure tracking, and the pinned
 // failure banner that sits above the table.
-class MyTBATableViewController: UIViewController, NotificationObservable,
-    TableViewDataSourceDelegate, DataController, Navigatable
+class MyTBATableViewController: UIViewController, NotificationObservable, DataController,
+    Navigatable
 {
 
     let dependencies: Dependencies
@@ -224,7 +226,6 @@ class MyTBATableViewController: UIViewController, NotificationObservable,
                 return UITableViewCell()
             }
         )
-        dataSource.delegate = self
     }
 
     private func makeCell(
@@ -320,14 +321,6 @@ class MyTBATableViewController: UIViewController, NotificationObservable,
                 return l.teamNumber < r.teamNumber
             }
         }
-    }
-
-    // MARK: - TableViewDataSourceDelegate
-
-    func title(forSection sectionIndex: Int) -> String? {
-        let sections = dataSource.snapshot().sectionIdentifiers
-        guard sectionIndex < sections.count else { return nil }
-        return sections[sectionIndex].headerTitle
     }
 
     // MARK: - Stateful wiring

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -24,6 +24,10 @@ enum SearchSection: String {
     case events = "Events"
 }
 
+extension SearchSection: TableSectionTitleProviding {
+    var headerTitle: String? { rawValue }
+}
+
 protocol SearchViewControllerDelegate: AnyObject {
     func eventSelected(eventKey: EventKey, name: String?)
     func teamSelected(teamKey: String, nickname: String?)
@@ -102,7 +106,6 @@ class SearchViewController: TBATableViewController {
                 return cell
             }
         }
-        dataSource.delegate = self
         dataSource.statefulDelegate = self
     }
 
@@ -187,10 +190,6 @@ class SearchViewController: TBATableViewController {
         case .event(let key, let name): delegate?.eventSelected(eventKey: key, name: name)
         case .team(let key, let nickname): delegate?.teamSelected(teamKey: key, nickname: nickname)
         }
-    }
-
-    override func title(forSection section: Int) -> String? {
-        dataSource.snapshot().sectionIdentifiers[section].rawValue
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -17,6 +17,19 @@ private enum TeamSummarySection: Int {
     case qualInfo
 }
 
+extension TeamSummarySection: TableSectionTitleProviding {
+    var headerTitle: String? {
+        switch self {
+        case .eventInfo: return "Summary"
+        case .nextMatch: return "Next Match"
+        case .playoffInfo: return "Playoffs"
+        case .qualInfo: return "Qualifications"
+        case .lastMatch: return "Most Recent Match"
+        case .teamInfo, .pitLocation: return nil
+        }
+    }
+}
+
 private enum TeamSummaryItem: Hashable {
     case teamInfo(team: Team)
     case pitLocation(location: String)
@@ -145,7 +158,6 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
                 }
             }
         )
-        dataSource.delegate = self
         dataSource.statefulDelegate = self
     }
 
@@ -352,21 +364,6 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             )
         }
         return cell
-    }
-
-    // MARK: TableViewDataSourceDelegate
-
-    override func title(forSection section: Int) -> String? {
-        let snapshot = dataSource.snapshot()
-        let section = snapshot.sectionIdentifiers[section]
-        switch section {
-        case .eventInfo: return "Summary"
-        case .nextMatch: return "Next Match"
-        case .playoffInfo: return "Playoffs"
-        case .qualInfo: return "Qualifications"
-        case .lastMatch: return "Most Recent Match"
-        default: return nil
-        }
     }
 
     // MARK: - Table View Delegate

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -69,7 +69,6 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
             return cell
         }
         dataSource.statefulDelegate = self
-        dataSource.delegate = self
     }
 
     private func applyTeams(_ teams: [APITeam]) {

--- a/the-blue-alliance-ios/ViewModels/Event/EventSection.swift
+++ b/the-blue-alliance-ios/ViewModels/Event/EventSection.swift
@@ -13,6 +13,10 @@ public struct EventSection: Hashable, Comparable {
     }
 }
 
+extension EventSection: TableSectionTitleProviding {
+    public var headerTitle: String? { title }
+}
+
 extension APIEventType {
     // Mostly the TBA rawValue; preseason (100) and unlabeled (-1) are pushed
     // to the ends so they don't render in the middle of the chronological flow.


### PR DESCRIPTION
## Summary

- Replaces the `TableViewDataSourceDelegate` channel on `TableViewDataSource` with a small `TableSectionTitleProviding` protocol that section identifier types conform to. The shared data source overrides `titleForHeaderInSection` once and runtime-casts the section identifier to ask it for its header title — no per-VC override required.
- Section types that render headers (`MatchSection`, `EventSection`, `SearchSection`, `MyTBASection`, `TeamSummarySection`) gain one small extension; the per-section `title(forSection:)` switches that previously lived in their VCs move into the section type itself, where the title naturally belongs.
- VCs whose Section type is plain `String` (single-section tables like Districts, Teams, EventRankings, EventAwards, EventDistrictPoints, EventTeamStats, MatchBreakdown, DistrictRankings) shed the now-vestigial `dataSource.delegate = self` line. Behavior is unchanged: those tables never displayed headers and still don't.
- Two screens have genuinely VC-specific header logic and use small local `TableViewDataSource` subclasses instead of a shared delegate channel:
    - `EventsListDataSource` overlays the per-event title hook from `EventsListViewControllerDelegate`.
    - `EventInsightsDataSource` suppresses section 0's default title (it has a custom `EventInsightsHeaderView` rendering qual/playoff column titles).

This is intentionally a behavior-preserving refactor — first step toward a broader plan to (a) wrap OpenAPI item types in stable-ID structs, (b) flip `applySnapshotUsingReloadData` callers to animated `apply()`, and (c) eventually migrate to `UICollectionView` + `UICollectionLayoutListConfiguration`. Cleaning up section identity is the contained, no-prerequisite piece of that plan.

## Test plan
- [ ] Districts list renders unchanged (no section header)
- [ ] District rankings list renders unchanged (no section header)
- [ ] Events list renders section headers per event type/week (and per-event override from host VC, e.g. "Upcoming")
- [ ] Event awards / rankings / district points / team stats tables render unchanged (no section headers)
- [ ] Event Insights section 0 still renders the custom qual/playoff header view; sections 1+ display their string titles
- [ ] Match breakdown table renders unchanged
- [ ] Matches list renders headers per playoff round / qual / round-robin section
- [ ] Search results render "Teams" and "Events" section headers
- [ ] myTBA Favorites and Subscriptions render "Events" / "Teams" headers and the failure banner still works
- [ ] TeamSummary (Team@Event) renders the existing per-section labels (Summary, Next Match, Playoffs, Qualifications, Most Recent Match)
- [ ] Teams list renders unchanged (no section header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)