### PR TITLE
Respect year when pushing from events -> team. Use `EventKey.year` for source of truth

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictViewController.swift
@@ -86,6 +86,7 @@ extension DistrictViewController: TeamsListViewControllerDelegate {
         let teamViewController = TeamViewController(
             teamKey: team.key,
             nickname: team.nickname,
+            year: year,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(teamViewController, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -68,7 +68,7 @@ class TeamAtDistrictViewController: ContainerViewController {
     // MARK: - Private Methods
 
     @objc private func pushTeam() {
-        let vc = TeamViewController(teamKey: teamKey, dependencies: dependencies)
+        let vc = TeamViewController(teamKey: teamKey, year: year, dependencies: dependencies)
         navigationController?.pushViewController(vc, animated: true)
     }
 
@@ -81,7 +81,6 @@ extension TeamAtDistrictViewController: DistrictTeamSummaryViewControllerDelegat
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: eventKey,
-            year: year,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
@@ -50,7 +50,6 @@ extension EventAlliancesContainerViewController: EventAlliancesViewControllerDel
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: event.key,
-            year: event.year,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -49,7 +49,6 @@ extension EventAwardsContainerViewController: EventAwardsViewControllerDelegate 
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: event.key,
-            year: event.year,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
@@ -48,7 +48,6 @@ extension EventDistrictPointsContainerViewController: EventDistrictPointsViewCon
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: event.key,
-            year: event.year,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -208,11 +208,9 @@ extension EventViewController: EventRankingsViewControllerDelegate {
     }
 
     private func pushTeamAtEvent(teamKey: String) {
-        let year = state.event?.year ?? state.key.year ?? 0
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: state.key,
-            year: year,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsContainerViewController.swift
@@ -106,7 +106,6 @@ extension EventInsightsContainerViewController: EventTeamStatsSelectionDelegate 
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: event.key,
-            year: event.year,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -141,11 +141,9 @@ extension MatchViewController: MatchSummaryViewDelegate {
 
     func teamPressed(teamKey: TeamKey) {
         guard let match = state.match, match.allTeamKeys.contains(teamKey) else { return }
-        let year = match.year ?? 0
         let teamAtEventVC = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: match.eventKey,
-            year: year,
             dependencies: dependencies
         )
         navigationController?.pushViewController(teamAtEventVC, animated: true)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -18,12 +18,14 @@ class TeamAtEventViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(teamKey: TeamKey, eventKey: EventKey, year: Int, dependencies: Dependencies) {
+    init(teamKey: TeamKey, eventKey: EventKey, dependencies: Dependencies) {
         // B teams (e.g. "frc5940B") alias their parent team — there's no
         // /team/<N>B page, so route every caller to the canonical key.
         let teamKey = teamKey.parentKey
         self.teamKey = teamKey
         self.eventKey = eventKey
+
+        let year = eventKey.year!
 
         summaryViewController = TeamSummaryViewController(
             teamKey: teamKey,
@@ -124,18 +126,21 @@ class TeamAtEventViewController: ContainerViewController {
         navigationController?.pushViewController(eventViewController, animated: true)
     }
 
-    private func pushTeamAtEvent(teamKey: String, eventKey: EventKey, year: Int) {
+    private func pushTeamAtEvent(teamKey: String, eventKey: EventKey) {
         let vc = TeamAtEventViewController(
             teamKey: teamKey,
             eventKey: eventKey,
-            year: year,
             dependencies: dependencies
         )
         navigationController?.pushViewController(vc, animated: true)
     }
 
     private func pushTeam(teamKey: String) {
-        let vc = TeamViewController(teamKey: teamKey, dependencies: dependencies)
+        let vc = TeamViewController(
+            teamKey: teamKey,
+            year: eventKey.year,
+            dependencies: dependencies
+        )
         navigationController?.pushViewController(vc, animated: true)
     }
 
@@ -179,8 +184,7 @@ extension TeamAtEventViewController: EventAwardsViewControllerDelegate {
         if self.teamKey == teamKey {
             return
         }
-        guard let year = eventKey.year else { return }
-        pushTeamAtEvent(teamKey: teamKey, eventKey: eventKey, year: year)
+        pushTeamAtEvent(teamKey: teamKey, eventKey: eventKey)
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -48,49 +48,52 @@ class TeamViewController: HeaderContainerViewController {
     // just collapse the avatar slot.
     private static let firstAvatarYear = 2018
 
-    // Backing storage for `year`. `loadTeamData` writes this directly to
-    // bypass the user-driven side effects (avatar refetch, child propagation)
-    // during initial load — those are handled inline alongside the team fetch.
     private var _year: Int?
     private var year: Int? {
         get { _year }
         set {
             guard _year != newValue else { return }
             _year = newValue
-            eventsViewController.year = newValue
-            mediaViewController.year =
-                newValue ?? Calendar.current.component(.year, from: Date())
-            updateInterface()
+            propagateYear()
+            animateAvatarForYearChange()
+        }
+    }
 
-            guard let newValue else { return }
+    private func propagateYear() {
+        eventsViewController.year = year
+        mediaViewController.year = year
+        updateInterface()
+    }
 
-            if newValue < Self.firstAvatarYear {
-                // Pre-avatar era: no fetch, no skeleton, no animation. Just
-                // nil out + hard-hide the slot.
-                avatarImage = nil
-                teamHeaderView.setAvatar(nil)
-                return
+    private func animateAvatarForYearChange() {
+        guard let year else { return }
+
+        if year < Self.firstAvatarYear {
+            // Pre-avatar era: no fetch, no skeleton, no animation. Just
+            // nil out + hard-hide the slot.
+            avatarImage = nil
+            teamHeaderView.setAvatar(nil)
+            return
+        }
+
+        if avatarImage != nil {
+            // Had an avatar — show skeleton, fetch, reveal result. The
+            // skeleton hide animates collapse-and-fade if the new year
+            // turns out to have no avatar, in sync with the skeleton out.
+            teamHeaderView.showAvatarSkeleton()
+            Task { @MainActor in
+                await loadAvatar(year: year)
+                guard self.year == year else { return }
+                teamHeaderView.hideAvatarSkeleton(revealing: avatarImage)
             }
-
-            if avatarImage != nil {
-                // Had an avatar — show skeleton, fetch, reveal result. The
-                // skeleton hide animates collapse-and-fade if the new year
-                // turns out to have no avatar, in sync with the skeleton out.
-                teamHeaderView.showAvatarSkeleton()
-                Task { @MainActor in
-                    await loadAvatar(year: newValue)
-                    guard self.year == newValue else { return }
-                    teamHeaderView.hideAvatarSkeleton(revealing: avatarImage)
-                }
-            } else {
-                // No prior avatar — silent off-screen fetch, no skeleton.
-                // Only animate the avatar in if we actually got one.
-                Task { @MainActor in
-                    await loadAvatar(year: newValue)
-                    guard self.year == newValue else { return }
-                    if avatarImage != nil {
-                        teamHeaderView.transitionAvatar(to: avatarImage)
-                    }
+        } else {
+            // No prior avatar — silent off-screen fetch, no skeleton.
+            // Only animate the avatar in if we actually got one.
+            Task { @MainActor in
+                await loadAvatar(year: year)
+                guard self.year == year else { return }
+                if avatarImage != nil {
+                    teamHeaderView.transitionAvatar(to: avatarImage)
                 }
             }
         }
@@ -98,18 +101,29 @@ class TeamViewController: HeaderContainerViewController {
 
     // MARK: Init
 
-    convenience init(teamKey: TeamKey, nickname: String? = nil, dependencies: Dependencies) {
+    convenience init(
+        teamKey: TeamKey,
+        nickname: String? = nil,
+        year: Int? = nil,
+        dependencies: Dependencies
+    ) {
         // B teams (e.g. "frc5940B") alias their parent team — there's no
         // /team/<N>B page, so route every caller to the canonical key.
         self.init(
             state: .key(teamKey.parentKey),
             partialNickname: nickname,
+            year: year,
             dependencies: dependencies
         )
     }
 
-    convenience init(team: Team, dependencies: Dependencies) {
-        self.init(state: .team(team), partialNickname: nil, dependencies: dependencies)
+    convenience init(team: Team, year: Int? = nil, dependencies: Dependencies) {
+        self.init(
+            state: .team(team),
+            partialNickname: nil,
+            year: year,
+            dependencies: dependencies
+        )
     }
 
     // TBA returns the literal "Team <N>" as a fallback nickname for teams
@@ -127,8 +141,14 @@ class TeamViewController: HeaderContainerViewController {
         return raw
     }
 
-    private init(state: TeamState, partialNickname: String?, dependencies: Dependencies) {
+    private init(
+        state: TeamState,
+        partialNickname: String?,
+        year: Int?,
+        dependencies: Dependencies
+    ) {
         self.state = state
+        self._year = year
 
         let teamNumber = state.team?.teamNumber ?? state.key.teamNumber ?? 0
         let nickname: String? = {
@@ -146,7 +166,7 @@ class TeamViewController: HeaderContainerViewController {
                 avatar: nil,
                 nickname: nickname,
                 teamNumberNickname: teamNumberNickname,
-                year: nil
+                year: year
             )
         )
 
@@ -161,19 +181,19 @@ class TeamViewController: HeaderContainerViewController {
         }
         eventsViewController = TeamEventsViewController(
             teamKey: state.key,
-            year: nil,
+            year: year,
             dependencies: dependencies
         )
         mediaViewController = TeamMediaCollectionViewController(
             teamKey: state.key,
-            year: Calendar.current.component(.year, from: Date()),
+            year: year,
             dependencies: dependencies
         )
 
         super.init(
             viewControllers: [infoViewController, eventsViewController, mediaViewController],
             navigationTitle: teamNumberNickname,
-            navigationSubtitle: "----",
+            navigationSubtitle: nil,
             segmentedControlTitles: ["Info", "Events", "Media"],
             dependencies: dependencies
         )
@@ -199,13 +219,20 @@ class TeamViewController: HeaderContainerViewController {
         super.viewDidLoad()
 
         teamHeaderView.showLoadingSkeleton()
+        if year != nil {
+            teamHeaderView.yearButton.isLoading = true
+        }
         loadTeamData()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        dependencies.reporter.log("Team: \(state.key)")
+        if let year {
+            dependencies.reporter.log("Team: \(state.key) | Year \(year)")
+        } else {
+            dependencies.reporter.log("Team: \(state.key)")
+        }
     }
 
     // MARK: - Private
@@ -222,25 +249,28 @@ class TeamViewController: HeaderContainerViewController {
                 try? await self.dependencies.api.teamYearsParticipated(key: self.state.key)
             }
 
+            if let years = await yearsHandle.value {
+                self.yearsParticipated = years.sorted().reversed()
+            }
+            teamHeaderView.yearButton.isLoading = false
+
             if let team = await teamHandle.value {
                 self.state = .team(team)
                 self.navigationTitle = team.teamNumberNickname
             }
-            if let years = await yearsHandle.value {
-                self.yearsParticipated = years.sorted().reversed()
-            }
 
-            // Set the initial year directly to bypass `year.didSet` — we kick
-            // off the avatar fetch inline below so the header reveals once
-            // with team + avatar in place rather than skeleton → avatar pop.
-            let initialYear = Self.latestYear(
-                currentSeason: statusService.currentSeason,
-                years: yearsParticipated
-            )
+            // Avatar fetch is awaited inline below so the header reveals
+            // once with team + avatar in place. Skip the public setter (which
+            // kicks off avatar work as a fire-and-forget Task) and drive the
+            // shared propagation directly.
+            let initialYear =
+                year
+                ?? Self.latestYear(
+                    currentSeason: statusService.currentSeason,
+                    years: yearsParticipated
+                )
             _year = initialYear
-            eventsViewController.year = initialYear
-            mediaViewController.year =
-                initialYear ?? Calendar.current.component(.year, from: Date())
+            propagateYear()
 
             if let initialYear, initialYear >= Self.firstAvatarYear {
                 await loadAvatar(year: initialYear)
@@ -276,7 +306,6 @@ class TeamViewController: HeaderContainerViewController {
                 year: year
             )
         }
-        navigationSubtitle = year?.description ?? "----"
     }
 
     private func loadAvatar(year: Int) async {
@@ -355,7 +384,6 @@ extension TeamViewController: EventsListViewControllerDelegate {
         let teamAtEventViewController = TeamAtEventViewController(
             teamKey: state.key,
             eventKey: event.key,
-            year: event.year,
             dependencies: dependencies
         )
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)

--- a/the-blue-alliance-ios/ViewElements/Teams/TeamHeaderView.swift
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamHeaderView.swift
@@ -355,7 +355,6 @@ class TeamHeaderView: UIView {
         avatarImageView.isHidden = false
         avatarImageView.alpha = 0
         teamNameLabel.isHidden = false
-        yearButton.alpha = 0
 
         // If we were pushed with a full Team (nickname known at init), skip
         // the subtitle skeleton and keep the real label visible — there's
@@ -364,6 +363,10 @@ class TeamHeaderView: UIView {
         let hasNickname = viewModel.nickname != nil
         skeletonSubtitleBar.isHidden = hasNickname
         teamNameLabel.alpha = hasNickname ? 1 : 0
+
+        let hasYear = viewModel.year != nil
+        skeletonYearPill.isHidden = hasYear
+        yearButton.alpha = hasYear ? 1 : 0
 
         // When the nickname is unknown, give teamNameLabel a single-space
         // placeholder so it claims its title3 intrinsic height. Without this
@@ -516,47 +519,96 @@ private class AvatarImageView: UIView {
 
 }
 
-class YearButton: UIButton {
+class YearButton: UIControl {
 
-    // HIG minimum touch target (44pt) — expanded via hitTest so the visible
-    // button stays compact without making the tappable area too small.
     private static let minimumTouchTarget: CGFloat = 44
 
+    private let label: UILabel = {
+        let label = UILabel()
+        let base = UIFont.preferredFont(forTextStyle: .callout).pointSize
+        label.font = UIFont.monospacedDigitSystemFont(ofSize: base, weight: .bold)
+        label.adjustsFontForContentSizeCategory = true
+        label.textColor = UIColor.navigationBarTintColor
+        label.text = "----"
+        return label
+    }()
+
+    private let chevronView: UIImageView = {
+        let imageView = UIImageView(
+            image: UIImage(
+                systemName: "chevron.down",
+                withConfiguration: UIImage.SymbolConfiguration(
+                    textStyle: .callout,
+                    scale: .small
+                )
+            )
+        )
+        imageView.tintColor = UIColor.navigationBarTintColor
+        imageView.contentMode = .center
+        return imageView
+    }()
+
+    private let spinner: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.color = UIColor.navigationBarTintColor
+        spinner.hidesWhenStopped = false
+        spinner.isHidden = true
+        return spinner
+    }()
+
+    private let trailingContainer = TrailingContainerView()
+
     var year: Int? {
+        didSet { label.text = year.map(String.init) ?? "----" }
+    }
+
+    var isLoading: Bool = false {
         didSet {
-            var updated = configuration
-            updated?.title = year.map(String.init) ?? "----"
-            configuration = updated
+            guard isLoading != oldValue else { return }
+            chevronView.isHidden = isLoading
+            spinner.isHidden = !isLoading
+            if isLoading {
+                spinner.startAnimating()
+            } else {
+                spinner.stopAnimating()
+            }
+        }
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            backgroundColor = isHighlighted ? UIColor.lightGray : UIColor.white
         }
     }
 
     init() {
         super.init(frame: .zero)
 
-        var config = UIButton.Configuration.plain()
-        config.baseForegroundColor = UIColor.navigationBarTintColor
-        config.background.backgroundColor = UIColor.white
-        config.cornerStyle = .capsule
-        config.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 8)
-        config.image = UIImage(systemName: "chevron.down")
-        config.imagePlacement = .trailing
-        config.imagePadding = 2
-        config.title = "----"
-        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
-            incoming in
-            var outgoing = incoming
-            let base = UIFont.preferredFont(forTextStyle: .callout).pointSize
-            outgoing.font = UIFont.monospacedDigitSystemFont(ofSize: base, weight: .bold)
-            return outgoing
-        }
-        configuration = config
+        backgroundColor = UIColor.white
+        layer.masksToBounds = true
 
-        configurationUpdateHandler = { button in
-            var updated = button.configuration
-            updated?.background.backgroundColor =
-                button.isHighlighted ? UIColor.lightGray : UIColor.white
-            button.configuration = updated
+        for child in [chevronView, spinner] as [UIView] {
+            child.translatesAutoresizingMaskIntoConstraints = false
+            trailingContainer.addSubview(child)
+            NSLayoutConstraint.activate([
+                child.centerXAnchor.constraint(equalTo: trailingContainer.centerXAnchor),
+                child.centerYAnchor.constraint(equalTo: trailingContainer.centerYAnchor),
+            ])
         }
+
+        let stack = UIStackView(arrangedSubviews: [label, trailingContainer])
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 2
+        stack.isUserInteractionEnabled = false
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+        ])
 
         setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
@@ -565,10 +617,27 @@ class YearButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = bounds.height / 2
+    }
+
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         let dx = max(0, (Self.minimumTouchTarget - bounds.width) / 2)
         let dy = max(0, (Self.minimumTouchTarget - bounds.height) / 2)
         return bounds.insetBy(dx: -dx, dy: -dy).contains(point)
     }
 
+}
+
+private final class TrailingContainerView: UIView {
+    override var intrinsicContentSize: CGSize {
+        var size = CGSize.zero
+        for sub in subviews {
+            let s = sub.intrinsicContentSize
+            size.width = max(size.width, s.width)
+            size.height = max(size.height, s.height)
+        }
+        return size
+    }
 }


### PR DESCRIPTION
Half bug fix, half paying down AI written code.

When viewing an event and then clicking through to a team, we would not respect the year of the event when we would load the team page. The flow isn't exactly that direct - we'd usually push through a Team@Event view. Either way - it was annoying and non-obvious the year would get reset when you ended up back on the Team view.

This PR fixes that flow so now `TeamViewController` takes a `year` (or, can take a year) which will contextualize the team view controller by default for that year.

The year selector button got a bit of a glow up and is now a `UIControl` so that we can size it a bit differently. This is to handle the case where we push to the Team view with a year - we need to indicate we're loading the years participated without showing the full skeleton view - because we already have a valid year for the team. The button also just looks nicer now, so I'm pretty pleased.

Finally - we were pulling the `year` off the `EventKey` and passing it down in a lot of cases - but we really don't need to do that. We can just pass the `EventKey` and pull the year off it. The one place we use it (our Team@Event controller) we just force unwrap since I figure - if our `EventKey` doesn't have a year, we're not gonna get any data anyways - so might as well be noisy about it.