### PR TITLE
Align Match Info "Score" header with score column

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -121,6 +121,16 @@ class MatchInfoViewController: TBAViewController, Refreshable {
             withMultiplier: (1.0 / 3.0)
         )
 
+        // Match the data row's column proportions: 3 team columns + 1 score
+        // column, all equal width. So the "Score" header gets 1/4 of the row
+        // and "Teams" fills the remaining 3/4 — both center-aligned.
+        scoreTitleLabel.autoMatch(
+            .width,
+            to: .width,
+            of: infoStackView,
+            withMultiplier: 0.25
+        )
+
         scrollView.addSubview(videoStackView)
         videoStackView.autoPinEdge(.top, to: .bottom, of: matchStackView, withOffset: 8)
         videoStackView.autoPinEdge(toSuperviewSafeArea: .leading, withInset: 16)


### PR DESCRIPTION
## Summary
- The "Teams" / "Score" header row was sized at intrinsic widths, so "Score" floated above the team-number columns instead of over the score column.
- Anchor the score header label to 1/4 of the row width with PureLayout, matching the data row's 3-team + 1-score equal-column proportions.

## Test plan
- [x] Open a Match Info view: "Teams" centers over the team columns and "Score" centers over the score column.
- [x] Confirm in a narrow form-sheet width (modal presentation): alignment still holds.
- [x] Verify Time-style rows (matches without scores) — header reads "Time" and still occupies the rightmost 1/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)