### PR TITLE
Handle push notification taps and silent myTBA refreshes

### DIFF
--- a/debug/notifications/README.md
+++ b/debug/notifications/README.md
@@ -1,0 +1,106 @@
+# Push notification test payloads
+
+Sample APNS payloads contributors can use to exercise the iOS app's push
+notification handling without standing up a real FCM dispatch. Each `.apns`
+file mirrors the shape of a payload the TBA backend would actually send for
+one of the notification types we currently support.
+
+## Sending a payload to the Simulator
+
+Either drag-and-drop the `.apns` file onto a running iOS Simulator window,
+or push from the command line:
+
+```sh
+xcrun simctl push booted com.the-blue-alliance.tba \
+  debug/notifications/match_score_team_scoped.apns
+```
+
+`booted` targets whichever simulator is currently running; replace with a
+specific UDID from `xcrun simctl list devices` if you need to disambiguate.
+The bundle identifier is fixed (`com.the-blue-alliance.tba`) and is also
+embedded in each file's `Simulator Target Bundle` key.
+
+## Notification types covered
+
+| Type | Files | Tap action |
+|---|---|---|
+| `upcoming_match` | `upcoming_match_event_scoped.apns`, `upcoming_match_team_scoped.apns` | Modal `MatchViewController` |
+| `match_score` | `match_score_event_scoped.apns`, `match_score_team_scoped.apns` | Modal `MatchViewController` |
+| `match_video` | `match_video_event_scoped.apns`, `match_video_team_scoped.apns` | Modal `MatchViewController` |
+| `update_favorites` | `update_favorites.apns` | Silent — refreshes local favorites store |
+| `update_subscriptions` | `update_subscriptions.apns` | Silent — refreshes local subscriptions store |
+
+The visible types each ship in two flavors. `*_team_scoped.apns` includes
+`team_key: "frc2337"`, mirroring a push that fired because the user
+subscribed to a **team**. `*_event_scoped.apns` omits `team_key`, mirroring
+a push that fired because the user subscribed to an **event** or to the
+match itself. Both route the same way today, but `team_key` is forwarded
+into `MatchViewController` so it can highlight that team's alliance.
+
+The match payloads use real `frc2337` matches from the 2025 FIRST in
+Michigan State Championship – Aptiv Division (`2025micmp4`):
+
+- `*_score_*` and `*_video_*` reference `2025micmp4_f1m2` (Finals 1-2,
+  Red 191 / Blue 186, frc2337 wins; has a YouTube video).
+- `*_upcoming_*` references `2025micmp4_f1m1` (Finals 1-1).
+
+## Behavior to expect
+
+Visible payloads (`upcoming_match`, `match_score`, `match_video`):
+
+- App in **foreground**: a banner is presented, and `PushService`'s
+  `willPresent` delegate runs.
+- App in **background**: a banner appears in Notification Center.
+- **Tapping** the banner from any state calls `PushService`'s `didReceive`
+  delegate, which hands off to `PushNotificationRouter` and presents
+  `MatchViewController` modally with a Done button.
+
+Silent payloads (`update_favorites`, `update_subscriptions`):
+
+- No banner. The AppDelegate's `didReceiveRemoteNotification` parses the
+  payload and calls `PushNotificationRouter.performSilentRefresh(...)`,
+  which fetches the latest data from myTBA and writes it to the local
+  store. The router no-ops if the user isn't signed into myTBA.
+
+## Silent payloads need a real device
+
+The iOS Simulator does **not** deliver `content-available`-only pushes —
+it treats them as visible notifications with no display content and
+discards them before they reach `application(_:didReceiveRemoteNotification:)`.
+This applies to both `xcrun simctl push` and real FCM pushes routed to a
+simulator. Dragging `update_favorites.apns` onto the Simulator will
+appear to do nothing; that's expected.
+
+To exercise the silent path end-to-end:
+
+1. Run a TestFlight or Xcode-deployed build on a physical device.
+2. Sign into myTBA.
+3. Add or remove a favorite at
+   <https://www.thebluealliance.com/account/mytba>.
+4. The backend dispatches an `update_favorites` silent push to every
+   registered device for that user. (Web mutations don't pass a
+   `device_key`, so the originating-device skip filter never excludes
+   the device.) The same flow applies for subscription changes via the
+   `update_subscriptions` push.
+
+## Adding a new payload
+
+When the app starts handling a new notification type, drop a new `.apns`
+file in this directory. Each file should:
+
+- Set `Simulator Target Bundle` to `com.the-blue-alliance.tba`.
+- Include a realistic `aps` dictionary (with `alert` for visible types,
+  `content-available: 1` for silent types).
+- Include a top-level `notification_type` matching the server's value
+  from
+  [`src/backend/common/consts/notification_type.py`](https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/notification_type.py).
+- Include the per-type data keys the server would send (e.g.
+  `event_key`, `match_key`, `team_key`). See the existing files for the
+  shape, and the per-type model classes under
+  [`src/backend/common/models/notifications/`](https://github.com/the-blue-alliance/the-blue-alliance/tree/main/src/backend/common/models/notifications)
+  for the canonical fields.
+
+Use real keys from the [TBA API](https://www.thebluealliance.com/apidocs)
+or via the `tba` CLI so the body of the modal renders something realistic.
+Match the naming pattern `<type>_<scope>.apns` (`team_scoped`,
+`event_scoped`, etc.) so the variants stay easy to scan.

--- a/debug/notifications/match_score_event_scoped.apns
+++ b/debug/notifications/match_score_event_scoped.apns
@@ -1,0 +1,13 @@
+{
+  "Simulator Target Bundle": "com.the-blue-alliance.tba",
+  "aps": {
+    "alert": {
+      "title": "Match Score",
+      "body": "2025 FIM State Championship - Aptiv Division F1-2 score posted: Red 191, Blue 186."
+    },
+    "sound": "default"
+  },
+  "notification_type": "match_score",
+  "match_key": "2025micmp4_f1m2",
+  "event_key": "2025micmp4"
+}

--- a/debug/notifications/match_score_team_scoped.apns
+++ b/debug/notifications/match_score_team_scoped.apns
@@ -1,0 +1,14 @@
+{
+  "Simulator Target Bundle": "com.the-blue-alliance.tba",
+  "aps": {
+    "alert": {
+      "title": "Match Score",
+      "body": "2025 FIM State Championship - Aptiv Division F1-2 score posted: Red 191, Blue 186."
+    },
+    "sound": "default"
+  },
+  "notification_type": "match_score",
+  "match_key": "2025micmp4_f1m2",
+  "event_key": "2025micmp4",
+  "team_key": "frc2337"
+}

--- a/debug/notifications/match_video_event_scoped.apns
+++ b/debug/notifications/match_video_event_scoped.apns
@@ -1,0 +1,13 @@
+{
+  "Simulator Target Bundle": "com.the-blue-alliance.tba",
+  "aps": {
+    "alert": {
+      "title": "Match Video Added",
+      "body": "A video has been posted for 2025 FIM State Championship - Aptiv Division F1-2."
+    },
+    "sound": "default"
+  },
+  "notification_type": "match_video",
+  "match_key": "2025micmp4_f1m2",
+  "event_key": "2025micmp4"
+}

--- a/debug/notifications/match_video_team_scoped.apns
+++ b/debug/notifications/match_video_team_scoped.apns
@@ -1,0 +1,14 @@
+{
+  "Simulator Target Bundle": "com.the-blue-alliance.tba",
+  "aps": {
+    "alert": {
+      "title": "Match Video Added",
+      "body": "A video has been posted for 2025 FIM State Championship - Aptiv Division F1-2 (frc2337)."
+    },
+    "sound": "default"
+  },
+  "notification_type": "match_video",
+  "match_key": "2025micmp4_f1m2",
+  "event_key": "2025micmp4",
+  "team_key": "frc2337"
+}

--- a/debug/notifications/upcoming_match_event_scoped.apns
+++ b/debug/notifications/upcoming_match_event_scoped.apns
@@ -1,0 +1,13 @@
+{
+  "Simulator Target Bundle": "com.the-blue-alliance.tba",
+  "aps": {
+    "alert": {
+      "title": "Upcoming Match",
+      "body": "2025 FIM State Championship - Aptiv Division F1-1 is starting soon."
+    },
+    "sound": "default"
+  },
+  "notification_type": "upcoming_match",
+  "match_key": "2025micmp4_f1m1",
+  "event_key": "2025micmp4"
+}

--- a/debug/notifications/upcoming_match_team_scoped.apns
+++ b/debug/notifications/upcoming_match_team_scoped.apns
@@ -1,0 +1,14 @@
+{
+  "Simulator Target Bundle": "com.the-blue-alliance.tba",
+  "aps": {
+    "alert": {
+      "title": "Upcoming Match",
+      "body": "2025 FIM State Championship - Aptiv Division F1-1 is starting soon. frc2337 is on the Red alliance."
+    },
+    "sound": "default"
+  },
+  "notification_type": "upcoming_match",
+  "match_key": "2025micmp4_f1m1",
+  "event_key": "2025micmp4",
+  "team_key": "frc2337"
+}

--- a/debug/notifications/update_favorites.apns
+++ b/debug/notifications/update_favorites.apns
@@ -1,0 +1,7 @@
+{
+  "Simulator Target Bundle": "com.the-blue-alliance.tba",
+  "aps": {
+    "content-available": 1
+  },
+  "notification_type": "update_favorites"
+}

--- a/debug/notifications/update_subscriptions.apns
+++ b/debug/notifications/update_subscriptions.apns
@@ -1,0 +1,7 @@
+{
+  "Simulator Target Bundle": "com.the-blue-alliance.tba",
+  "aps": {
+    "content-available": 1
+  },
+  "notification_type": "update_subscriptions"
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		51BECA942F9D329C003EC868 /* MatchBreakdownConfigurator2025.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BECA932F9D329C003EC868 /* MatchBreakdownConfigurator2025.swift */; };
 		5EC0D41A2C26041600000002 /* LegacyCoreDataCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041600000001 /* LegacyCoreDataCleanup.swift */; };
 		5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */; };
+		5EC0D41A2C26041B00000002 /* PushNotificationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041B00000001 /* PushNotificationPayload.swift */; };
+		5EC0D41A2C26041B00000004 /* PushNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041B00000003 /* PushNotificationRouter.swift */; };
 		5EC0D41A2C26041700000004 /* WeekEventsGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041700000003 /* WeekEventsGrouping.swift */; };
 		5EC0D41A2C26041700000006 /* EventsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041700000005 /* EventsListViewController.swift */; };
 		5EC0D41A2C26041A00000006 /* TeamsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041A00000005 /* TeamsListViewController.swift */; };
@@ -212,6 +214,8 @@
 		51BECA932F9D329C003EC868 /* MatchBreakdownConfigurator2025.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2025.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041600000001 /* LegacyCoreDataCleanup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCoreDataCleanup.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBALocalStore.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26041B00000001 /* PushNotificationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationPayload.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26041B00000003 /* PushNotificationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRouter.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041700000003 /* WeekEventsGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekEventsGrouping.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041700000005 /* EventsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsListViewController.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041A00000005 /* TeamsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamsListViewController.swift; sourceTree = "<group>"; };
@@ -800,6 +804,8 @@
 				5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */,
 				9255EB6C209AC9760006A745 /* RetryService.swift */,
 				92F8E355209AAE890094213F /* PushService.swift */,
+				5EC0D41A2C26041B00000001 /* PushNotificationPayload.swift */,
+				5EC0D41A2C26041B00000003 /* PushNotificationRouter.swift */,
 				92DF54E021B1B65A0082C58C /* StatusService.swift */,
 				92564C6A21644AA30047917F /* Secrets.swift */,
 			);
@@ -1110,6 +1116,8 @@
 			files = (
 				5EC0D41A2C26041600000002 /* LegacyCoreDataCleanup.swift in Sources */,
 				5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */,
+				5EC0D41A2C26041B00000002 /* PushNotificationPayload.swift in Sources */,
+				5EC0D41A2C26041B00000004 /* PushNotificationRouter.swift in Sources */,
 				5EC0D41A2C26041700000004 /* WeekEventsGrouping.swift in Sources */,
 				5EC0D41A2C26041700000006 /* EventsListViewController.swift in Sources */,
 				BA0000000000000000000002 /* EventSection.swift in Sources */,

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -43,6 +43,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         retryService: RetryService(),
         registrar: self
     )
+    @MainActor
+    lazy var pushNotificationRouter: PushNotificationRouter = PushNotificationRouter(
+        dependencies: dependencies
+    )
     lazy var statusService: any StatusServiceProtocol = StatusService(
         reporter: reporter,
         api: api,
@@ -106,8 +110,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
-        print("Remote notification: \(userInfo)")
-        completionHandler(.noData)
+        guard
+            let payload = PushNotificationPayload.parse(userInfo),
+            case .silentRefresh(let kind) = payload
+        else {
+            completionHandler(.noData)
+            return
+        }
+        Task { @MainActor in
+            await pushNotificationRouter.performSilentRefresh(kind)
+            completionHandler(.newData)
+        }
     }
 
 }
@@ -144,6 +157,7 @@ private extension AppDelegate {
         messaging.delegate = pushService
         UNUserNotificationCenter.current().delegate = pushService
         myTBA.authenticationProvider.add(observer: pushService)
+        pushService.router = pushNotificationRouter
         // Best-effort registration; failures will surface later.
         pushService.registerForRemoteNotifications(nil)
     }

--- a/the-blue-alliance-ios/AppDelegate/AppServicesProviding.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppServicesProviding.swift
@@ -10,6 +10,7 @@ enum PendingAlert {
 protocol AppServicesProviding: AnyObject {
     var dependencies: Dependencies { get }
     var pushService: PushService { get }
+    var pushNotificationRouter: PushNotificationRouter { get }
     var fcmTokenProvider: any FCMTokenProvider { get }
     var pendingAlerts: [PendingAlert] { get set }
 }

--- a/the-blue-alliance-ios/AppDelegate/SceneDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/SceneDelegate.swift
@@ -15,13 +15,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, SceneAlertPresenting {
 
         let services = UIApplication.shared.appServices
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = PhoneRootViewController(
+        let root = PhoneRootViewController(
             fcmTokenProvider: services.fcmTokenProvider,
             pushService: services.pushService,
             dependencies: services.dependencies
         )
+        window.rootViewController = root
         window.makeKeyAndVisible()
         self.window = window
+        services.pushNotificationRouter.rootViewController = root
 
         if !AppDelegate.isAppVersionSupported(
             minimumAppVersion: services.dependencies.statusService.status.minAppVersion

--- a/the-blue-alliance-ios/Services/PushNotificationPayload.swift
+++ b/the-blue-alliance-ios/Services/PushNotificationPayload.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+// Typed shape of an incoming TBA push notification, parsed from the FCM
+// `userInfo` dictionary. The dispatcher always adds `notification_type` as a
+// top-level data key; per-type payloads are flat key/value pairs alongside it.
+//
+// Reference (server-side): the-blue-alliance/the-blue-alliance
+//   src/backend/common/consts/notification_type.py
+//   src/backend/common/models/notifications/
+enum PushNotificationPayload: Equatable {
+    case match(kind: MatchKind, matchKey: String, eventKey: String, teamKey: String?)
+    case silentRefresh(SilentKind)
+    case unhandled(typeKey: String)
+
+    enum MatchKind: String {
+        case upcoming = "upcoming_match"
+        case score = "match_score"
+        case video = "match_video"
+    }
+
+    enum SilentKind: String {
+        case favorites = "update_favorites"
+        case subscriptions = "update_subscriptions"
+    }
+
+    static func parse(_ userInfo: [AnyHashable: Any]) -> PushNotificationPayload? {
+        guard let typeKey = userInfo["notification_type"] as? String else { return nil }
+
+        if let matchKind = MatchKind(rawValue: typeKey) {
+            guard
+                let matchKey = userInfo["match_key"] as? String,
+                let eventKey = userInfo["event_key"] as? String
+            else {
+                return .unhandled(typeKey: typeKey)
+            }
+            let teamKey = userInfo["team_key"] as? String
+            return .match(kind: matchKind, matchKey: matchKey, eventKey: eventKey, teamKey: teamKey)
+        }
+
+        if let silent = SilentKind(rawValue: typeKey) {
+            return .silentRefresh(silent)
+        }
+
+        return .unhandled(typeKey: typeKey)
+    }
+}

--- a/the-blue-alliance-ios/Services/PushNotificationRouter.swift
+++ b/the-blue-alliance-ios/Services/PushNotificationRouter.swift
@@ -1,0 +1,83 @@
+import Foundation
+import MyTBAKit
+import UIKit
+
+@MainActor
+protocol PushNotificationRouting: AnyObject {
+    var rootViewController: UIViewController? { get set }
+    func handleTap(_ payload: PushNotificationPayload)
+    func performSilentRefresh(_ kind: PushNotificationPayload.SilentKind) async
+}
+
+@MainActor
+final class PushNotificationRouter: PushNotificationRouting {
+
+    private let dependencies: Dependencies
+    weak var rootViewController: UIViewController?
+
+    init(dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
+
+    // MARK: - Tap routing
+
+    func handleTap(_ payload: PushNotificationPayload) {
+        switch payload {
+        case let .match(_, matchKey, _, teamKey):
+            presentMatch(matchKey: matchKey, teamKey: teamKey)
+        case .silentRefresh(let kind):
+            // Silent pushes shouldn't normally reach the tap path, but if one
+            // ever does (e.g. server misroutes one as visible), still refresh.
+            Task { await performSilentRefresh(kind) }
+        case .unhandled(let typeKey):
+            dependencies.reporter.log("Unhandled push notification tap: \(typeKey)")
+        }
+    }
+
+    private func presentMatch(matchKey: String, teamKey: String?) {
+        guard let presenter = topPresenter() else {
+            dependencies.reporter.log("Push routing: no presenter for match \(matchKey)")
+            return
+        }
+        let matchVC = MatchViewController(
+            matchKey: matchKey,
+            teamKey: teamKey,
+            dependencies: dependencies
+        )
+        let nav = UINavigationController(rootViewController: matchVC)
+        matchVC.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            systemItem: .done,
+            primaryAction: UIAction { [weak nav] _ in nav?.dismiss(animated: true) }
+        )
+        nav.modalPresentationStyle = .formSheet
+        presenter.present(nav, animated: true)
+    }
+
+    // Walks the presented-VC chain so we present on top of any modal that's
+    // already up (e.g. the user tapped a notification while a sheet was open).
+    private func topPresenter() -> UIViewController? {
+        var current = rootViewController
+        while let presented = current?.presentedViewController {
+            current = presented
+        }
+        return current
+    }
+
+    // MARK: - Silent refresh
+
+    func performSilentRefresh(_ kind: PushNotificationPayload.SilentKind) async {
+        guard dependencies.myTBA.isAuthenticated else { return }
+        do {
+            switch kind {
+            case .favorites:
+                let favorites = try await dependencies.myTBA.fetchFavorites()
+                dependencies.myTBAStores.favorites.replaceAll(with: favorites)
+            case .subscriptions:
+                let subscriptions = try await dependencies.myTBA.fetchSubscriptions()
+                dependencies.myTBAStores.subscriptions.replaceAll(with: subscriptions)
+            }
+        } catch {
+            dependencies.reporter.record(error)
+        }
+    }
+}

--- a/the-blue-alliance-ios/Services/PushService.swift
+++ b/the-blue-alliance-ios/Services/PushService.swift
@@ -21,6 +21,7 @@ class PushService: NSObject, PushServiceProtocol {
     private var myTBA: any MyTBAProtocol
     internal var retryService: RetryService
     private let registrar: any RemoteNotificationRegistering
+    weak var router: (any PushNotificationRouting)?
 
     private var registerTask: Task<Void, Never>?
 
@@ -109,8 +110,28 @@ extension PushService: UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler:
             @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        // Show all notifications in the foreground.
+        let payload = PushNotificationPayload.parse(notification.request.content.userInfo)
+        if case .silentRefresh = payload {
+            completionHandler([])
+            return
+        }
         completionHandler([.banner, .list, .badge, .sound])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        guard let payload = PushNotificationPayload.parse(userInfo) else {
+            completionHandler()
+            return
+        }
+        Task { @MainActor [weak self] in
+            self?.router?.handleTap(payload)
+            completionHandler()
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

Wires up tap handling and silent-refresh handling for the first five push notification types. Previously the app registered for FCM but ignored incoming notifications — `application:didReceiveRemoteNotification:` was a `print` stub and we had no `UNUserNotificationCenterDelegate` `didReceive` implementation, so taps were no-ops.

The work splits into three small new files plus minimal wiring:

- **`PushNotificationPayload`** — parses the FCM `userInfo` into a typed enum (`.match`, `.silentRefresh`, `.unhandled`).
- **`PushNotificationRouter`** — presents `MatchViewController` modally (form sheet, with a Done button, walking the presented-VC chain so it sits on top of any existing modal) for match taps, and runs `myTBA.fetchFavorites()` / `fetchSubscriptions()` + `replaceAll(with:)` for silent refresh pushes.
- **`PushService` / `AppDelegate` / `SceneDelegate`** — implements the missing delegate methods, suppresses banner presentation for silent types in `willPresent`, owns the router, and hands it the root VC once the scene connects.

### Notification types handled in this PR

| Type | Action |
|---|---|
| `upcoming_match`, `match_score`, `match_video` | Tap → modal `MatchViewController` (forwards `team_key` if present) |
| `update_favorites` | Silent — refresh local favorites store from myTBA |
| `update_subscriptions` | Silent — refresh local subscriptions store from myTBA |
| Anything else | Banner shown with default presentation; `reporter.log` and no-op on tap |

Remaining types — `starting_comp_level`, `alliance_selection`, `awards_posted`, `schedule_updated`, `district_points_updated`, `event_match_video`, `ping`, `broadcast`, `media_posted`, `final_results` — are tracked in #178 and will land in follow-up PRs.

Cold-launch taps work with no special handling: iOS calls `didReceive` after `scene(_:willConnectTo:)` returns, by which point the router has its root VC.

### Contributor tooling

`debug/notifications/` ships sample APNS payloads for each handled type, with team-scoped and event-scoped variants for the match types. Match payloads use real frc2337 matches from 2025 MSC – Aptiv Division. The README walks contributors through drag-and-drop and `xcrun simctl push`, expected behavior in foreground/background/tap states, the iOS Simulator's silent-push limitation, and how to add new payloads as we pick up more types.

Closes #182

## Test plan

- [x] Foreground push (`xcrun simctl push booted ... match_score_team_scoped.apns`) — banner shows.
- [x] Tap from background — modal `MatchViewController` slides up with a Done button.
- [x] Tap with another modal already presented — modal lands on top of it (router walks the presented chain).
- [x] Variants: `_team_scoped` forwards `team_key` to `MatchInfoViewController`; `_event_scoped` doesn't.
- [ ] On-device: sign into myTBA, add a favorite at <https://www.thebluealliance.com/account/mytba>, confirm an `update_favorites` silent push triggers `PushNotificationRouter.performSilentRefresh` and the local favorites store reflects the change. (Cannot be verified on the Simulator — see the README.)
- [ ] Same for `update_subscriptions` via a subscription change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)