### PR TITLE
Show scoring plate assignments in 2018 match breakdowns

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -121,6 +121,39 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
         }
 
         dataSource.applySnapshotUsingReloadData(snapshot)
+        updateTableFooter(breakdown: breakdown, red: red, blue: blue)
+    }
+
+    private func updateTableFooter(
+        breakdown: [String: Any]?,
+        red: [String: Any]?,
+        blue: [String: Any]?
+    ) {
+        guard let breakdownConfigurator,
+            let text = breakdownConfigurator.footerText(breakdown, red, blue)
+        else {
+            tableView.tableFooterView = UIView(frame: .zero)
+            return
+        }
+
+        let label = UILabel()
+        label.text = text
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 0
+        label.frame = CGRect(x: 16, y: 12, width: tableView.bounds.width - 32, height: 0)
+        label.sizeToFit()
+
+        let footer = UIView(
+            frame: CGRect(
+                x: 0,
+                y: 0,
+                width: tableView.bounds.width,
+                height: label.frame.height + 24
+            )
+        )
+        footer.addSubview(label)
+        tableView.tableFooterView = footer
     }
 
     // MARK: - Refreshable

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift
@@ -10,9 +10,22 @@ protocol MatchBreakdownConfigurator {
         _ blue: [String: Any]?,
         _ compLevel: Components.Schemas.CompLevel?
     )
+    static func footerText(
+        _ breakdown: [String: Any]?,
+        _ red: [String: Any]?,
+        _ blue: [String: Any]?
+    ) -> String?
 }
 
 extension MatchBreakdownConfigurator {
+
+    static func footerText(
+        _ breakdown: [String: Any]?,
+        _ red: [String: Any]?,
+        _ blue: [String: Any]?
+    ) -> String? {
+        return nil
+    }
 
     // MARK: - Helper Methods
 

--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2018.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2018.swift
@@ -194,4 +194,17 @@ struct MatchBreakdownConfigurator2018: MatchBreakdownConfigurator {
         }
     }
 
+    static func footerText(
+        _ breakdown: [String: Any]?,
+        _ red: [String: Any]?,
+        _ blue: [String: Any]?
+    ) -> String? {
+        guard let plates = (red?["tba_gameData"] ?? blue?["tba_gameData"]) as? String,
+            !plates.isEmpty
+        else {
+            return nil
+        }
+        return "Scoring Plate Assignments: \(plates)"
+    }
+
 }


### PR DESCRIPTION
## Summary

- Surface the per-match `tba_gameData` field (e.g. `LRL`) at the bottom of 2018 match breakdowns, matching the web app's "Scoring Plate Assignments: LRL" caption
- Adds an optional `footerText` hook to `MatchBreakdownConfigurator` (default returns `nil`) so other years aren't affected
- Renders via `tableFooterView` rather than a section footer so it scrolls with content instead of sticking in the `.plain` table style

Closes #108

## Test plan

- [x] Open a 2018 match (e.g. `2018misjo_qm4`) → Breakdown tab. Confirm `Scoring Plate Assignments: LRL` (or whatever `tba_gameData` returns) appears below "Ranking Points" and scrolls with the table
- [x] Pull-to-refresh on the breakdown — footer text persists
- [x] Open a non-2018 match (any year) → Breakdown tab. Confirm no extra footer is shown
- [x] If a 2018 match somehow lacks `tba_gameData`, no footer is shown (graceful fallback)