### PR TITLE
Show X icon for empty stage activations in 2020 breakdowns

### DIFF
--- a/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2020.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator2020.swift
@@ -371,20 +371,20 @@ struct MatchBreakdownConfigurator2020: MatchBreakdownConfigurator {
             blueActivation.append(blueStage);
         }
 
-        let elements = [redActivation, blueActivation].map { (stage) -> String in
+        let elements = [redActivation, blueActivation].map { (stage) -> [AnyHashable] in
             if stage[0] == 1 {
                 if compLevel == .qm {
-                    return "3 (+1 RP)"
+                    return ["3 (+1 RP)"]
                 }
-                return "3"
+                return ["3"]
             } else if stage[1] == 1 {
-                return "2"
+                return ["2"]
             } else if stage[2] == 1 {
-                return "1"
+                return ["1"]
             }
-            return ""
+            return [BreakdownStyle.imageView(image: BreakdownStyle.xImage)]
         }
-        return BreakdownRow(title: title, red: [elements.first], blue: [elements.last])
+        return BreakdownRow(title: title, red: elements.first ?? [], blue: elements.last ?? [])
     }
 
 }


### PR DESCRIPTION
## Summary
- Render `BreakdownStyle.xImage` in the 2020 Stage Activations row when no stages were activated, instead of leaving the cell blank.
- Matches the existing pattern in `shieldOperationalRow` / `shieldSwitchLevelRow` in the same configurator and mirrors the web change in the-blue-alliance/the-blue-alliance#2726.

Closes #851.

## Test plan
- [x] `scripts/swift-format.sh --strict` passes
- [x] `xcodebuild -scheme "The Blue Alliance" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` succeeds
- [ ] Open a 2020 match where neither alliance activated a stage (e.g. an early-season qualification match) and confirm both Stage Activations cells show the X icon
- [ ] Open a 2020 match where one or both alliances reached stage 1/2/3 and confirm the existing text ("1", "2", "3", "3 (+1 RP)") still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)