### PR TITLE
Show YouTube videos in team media (closes #260)

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		921F609923CD4DFD00FE633B /* MatchBreakdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921F609823CD4DFD00FE633B /* MatchBreakdownView.swift */; };
 		9223AC831EE7003C00F54F93 /* CollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */; };
 		9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */; };
+		02600260260026002600A002 /* PlayerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02600260260026002600A001 /* PlayerCollectionViewCell.swift */; };
 		92435E2E23CBC2ED00CDD2D4 /* EventInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92435E2D23CBC2ED00CDD2D4 /* EventInsightsView.swift */; };
 		924602AB1ECE8B1D0030EDBF /* AwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924602AA1ECE8B1D0030EDBF /* AwardTableViewCell.swift */; };
 		924602AF1ECE8B580030EDBF /* AwardTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 924602AE1ECE8B580030EDBF /* AwardTableViewCell.xib */; };
@@ -233,6 +234,7 @@
 		9223AC821EE7003C00F54F93 /* CollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSource.swift; sourceTree = "<group>"; };
 		9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaCollectionViewCell.swift; sourceTree = "<group>"; };
 		9236EDF52F9C6287001546F8 /* the-blue-alliance-ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "the-blue-alliance-ios.entitlements"; sourceTree = "<group>"; };
+		02600260260026002600A001 /* PlayerCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerCollectionViewCell.swift; sourceTree = "<group>"; };
 		92435E2D23CBC2ED00CDD2D4 /* EventInsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventInsightsView.swift; sourceTree = "<group>"; };
 		924602AA1ECE8B1D0030EDBF /* AwardTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AwardTableViewCell.swift; sourceTree = "<group>"; };
 		924602AE1ECE8B580030EDBF /* AwardTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AwardTableViewCell.xib; sourceTree = "<group>"; };
@@ -506,6 +508,7 @@
 			isa = PBXGroup;
 			children = (
 				9223AC841EE7214A00F54F93 /* MediaCollectionViewCell.swift */,
+				02600260260026002600A001 /* PlayerCollectionViewCell.swift */,
 				145C57BC1ED3C3AA004955B2 /* PlayerView.swift */,
 			);
 			path = Media;
@@ -1354,6 +1357,7 @@
 				92FF10ED21A61A1B003BC5C4 /* TeamAtEventViewController.swift in Sources */,
 				1479694A215EBE460075AF4E /* EventAllianceCellViewModel.swift in Sources */,
 				9223AC851EE7214A00F54F93 /* MediaCollectionViewCell.swift in Sources */,
+				02600260260026002600A002 /* PlayerCollectionViewCell.swift in Sources */,
 				921DD67D241D3D6C00403192 /* RootController.swift in Sources */,
 				9255EB6D209AC9760006A745 /* RetryService.swift in Sources */,
 			);

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -171,8 +171,8 @@ extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewC
 
 extension TeamAtEventViewController: MediaViewer, TeamMediaCollectionViewControllerDelegate {
 
-    func mediaSelected(image: UIImage?, directURL: URL?) {
-        show(image: image, directURL: directURL)
+    func mediaSelected(image: UIImage?, directURL: URL?, viewURL: URL?) {
+        show(image: image, directURL: directURL, viewURL: viewURL)
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -3,22 +3,40 @@ import TBAAPI
 import UIKit
 
 protocol TeamMediaCollectionViewControllerDelegate: AnyObject {
-    func mediaSelected(image: UIImage?, directURL: URL?)
+    func mediaSelected(image: UIImage?, directURL: URL?, viewURL: URL?)
 }
 
-struct TeamMediaItem: Hashable {
-    let foreignKey: String
-    let type: String
-    let directURL: URL?
-    let viewURL: URL?
+enum MediaSection: Hashable {
+    case videos
+    case images
+}
+
+enum TeamMediaItem: Hashable {
+    case image(Photo)
+    case video(Video)
+
+    struct Photo: Hashable {
+        let foreignKey: String
+        let type: String
+        let directURL: URL?
+        let viewURL: URL?
+
+        var isInstagram: Bool { type == "instagram-image" }
+    }
+
+    struct Video: Hashable {
+        let youtubeKey: String
+        let viewURL: URL?
+    }
 }
 
 class TeamMediaCollectionViewController: TBACollectionViewController {
 
     private static let spacerSize: CGFloat = 3.0
     private static let imageTypes: Set<String> = [
-        "imgur", "cdphotothread", "avatar", "instagram-image",
+        "imgur", "instagram-image",
     ]
+    private static let videoTypes: Set<String> = ["youtube"]
 
     private let teamKey: String
     private let pasteboard: UIPasteboard
@@ -35,7 +53,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
 
     weak var delegate: TeamMediaCollectionViewControllerDelegate?
 
-    private var dataSource: CollectionViewDataSource<String, TeamMediaItem>!
+    private var dataSource: CollectionViewDataSource<MediaSection, TeamMediaItem>!
     private var media: [TeamMediaItem] = []
     private var imageCache: [String: UIImage] = [:]
     private var imageErrors: [String: Error] = [:]
@@ -55,7 +73,10 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
 
-        super.init(collectionViewLayout: Self.makeLayout(), dependencies: dependencies)
+        super.init(
+            collectionViewLayout: UICollectionViewCompositionalLayout { _, _ in nil },
+            dependencies: dependencies
+        )
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -64,41 +85,85 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
 
     // MARK: - Layout
 
-    private static func makeLayout() -> UICollectionViewLayout {
-        UICollectionViewCompositionalLayout { _, env in
-            let columns = env.traitCollection.horizontalSizeClass == .regular ? 3 : 2
-            let spacer = TeamMediaCollectionViewController.spacerSize
-            let containerWidth = env.container.effectiveContentSize.width
-            let itemWidth =
-                (containerWidth - spacer * CGFloat(columns - 1) - 2 * spacer) / CGFloat(columns)
-
-            let itemSize = NSCollectionLayoutSize(
-                widthDimension: .absolute(itemWidth),
-                heightDimension: .absolute(itemWidth)
-            )
-            let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-            let groupSize = NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(itemWidth)
-            )
-            let group = NSCollectionLayoutGroup.horizontal(
-                layoutSize: groupSize,
-                repeatingSubitem: item,
-                count: columns
-            )
-            group.interItemSpacing = .fixed(spacer)
-
-            let section = NSCollectionLayoutSection(group: group)
-            section.interGroupSpacing = spacer
-            section.contentInsets = NSDirectionalEdgeInsets(
-                top: spacer,
-                leading: spacer,
-                bottom: spacer,
-                trailing: spacer
-            )
-            return section
+    private func makeLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { [weak self] sectionIndex, env in
+            guard let self else { return nil }
+            let section = self.dataSource?.sectionIdentifier(for: sectionIndex) ?? .images
+            switch section {
+            case .videos:
+                return Self.makeVideoSection(env: env)
+            case .images:
+                return Self.makeImageSection(env: env)
+            }
         }
+    }
+
+    private static func makeImageSection(env: NSCollectionLayoutEnvironment)
+        -> NSCollectionLayoutSection
+    {
+        let columns = env.traitCollection.horizontalSizeClass == .regular ? 3 : 2
+        let spacer = TeamMediaCollectionViewController.spacerSize
+        let containerWidth = env.container.effectiveContentSize.width
+        let itemWidth =
+            (containerWidth - spacer * CGFloat(columns - 1) - 2 * spacer) / CGFloat(columns)
+
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(itemWidth),
+            heightDimension: .absolute(itemWidth)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(itemWidth)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            repeatingSubitem: item,
+            count: columns
+        )
+        group.interItemSpacing = .fixed(spacer)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = spacer
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: spacer,
+            leading: spacer,
+            bottom: spacer,
+            trailing: spacer
+        )
+        return section
+    }
+
+    private static func makeVideoSection(env: NSCollectionLayoutEnvironment)
+        -> NSCollectionLayoutSection
+    {
+        let spacer = TeamMediaCollectionViewController.spacerSize
+        let containerWidth = env.container.effectiveContentSize.width
+        let itemWidth = containerWidth - 2 * spacer
+        let itemHeight = itemWidth * (9.0 / 16.0)
+
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(itemHeight)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(itemHeight)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = spacer
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: spacer,
+            leading: spacer,
+            bottom: spacer,
+            trailing: spacer
+        )
+        return section
     }
 
     // MARK: - View Lifecycle
@@ -106,8 +171,12 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        collectionView.registerReusableCell(MediaCollectionViewCell.self)
+        collectionView.registerReusableCell(PlayerCollectionViewCell.self)
+
         setupDataSource()
         collectionView.dataSource = dataSource
+        collectionView.setCollectionViewLayout(makeLayout(), animated: false)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -123,7 +192,23 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         didSelectItemAt indexPath: IndexPath
     ) {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
-        delegate?.mediaSelected(image: imageCache[item.foreignKey], directURL: item.directURL)
+        switch item {
+        case .image(let photo):
+            if photo.isInstagram {
+                if let viewURL = photo.viewURL, urlOpener.canOpenURL(viewURL) {
+                    urlOpener.open(viewURL, options: [:], completionHandler: nil)
+                }
+            } else {
+                delegate?.mediaSelected(
+                    image: imageCache[photo.foreignKey],
+                    directURL: photo.directURL,
+                    viewURL: photo.viewURL
+                )
+            }
+        case .video:
+            // The embedded YouTube player handles its own play/pause taps.
+            break
+        }
     }
 
     override func collectionView(
@@ -132,18 +217,34 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         point: CGPoint
     ) -> UIContextMenuConfiguration? {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return nil }
-        let cachedImage = imageCache[item.foreignKey]
-        let configuration = UIContextMenuConfiguration(
-            identifier: item.foreignKey as NSString,
-            previewProvider: nil
-        ) {
-            _ in
-            let viewAction = UIAction(title: "View", image: UIImage(systemName: "eye.fill")) { _ in
-                self.delegate?.mediaSelected(image: cachedImage, directURL: item.directURL)
-            }
-            var actions: [UIMenuElement] = [viewAction]
+        switch item {
+        case .image(let photo):
+            return imageContextMenu(for: photo)
+        case .video(let video):
+            return videoContextMenu(for: video)
+        }
+    }
 
-            if let viewURL = item.viewURL, self.urlOpener.canOpenURL(viewURL) {
+    private func imageContextMenu(for photo: TeamMediaItem.Photo) -> UIContextMenuConfiguration {
+        let cachedImage = imageCache[photo.foreignKey]
+        return UIContextMenuConfiguration(
+            identifier: photo.foreignKey as NSString,
+            previewProvider: nil
+        ) { _ in
+            var actions: [UIMenuElement] = []
+            if !photo.isInstagram {
+                actions.append(
+                    UIAction(title: "View", image: UIImage(systemName: "eye.fill")) { _ in
+                        self.delegate?.mediaSelected(
+                            image: cachedImage,
+                            directURL: photo.directURL,
+                            viewURL: photo.viewURL
+                        )
+                    }
+                )
+            }
+
+            if let viewURL = photo.viewURL, self.urlOpener.canOpenURL(viewURL) {
                 let viewOnlineAction = UIAction(
                     title: "View Online",
                     image: UIImage(systemName: "safari.fill")
@@ -165,8 +266,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
                 let saveAction = UIAction(
                     title: "Save",
                     image: UIImage(systemName: "square.and.arrow.down.fill")
-                ) {
-                    _ in
+                ) { _ in
                     self.photoLibrary.performChanges(
                         {
                             PHAssetChangeRequest.creationRequestForAsset(from: image)
@@ -178,7 +278,22 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
             }
             return UIMenu(title: "", children: actions)
         }
-        return configuration
+    }
+
+    private func videoContextMenu(for video: TeamMediaItem.Video) -> UIContextMenuConfiguration? {
+        guard let viewURL = video.viewURL, urlOpener.canOpenURL(viewURL) else { return nil }
+        return UIContextMenuConfiguration(
+            identifier: video.youtubeKey as NSString,
+            previewProvider: nil
+        ) { _ in
+            let viewOnYouTubeAction = UIAction(
+                title: "View on YouTube",
+                image: UIImage(systemName: "safari.fill")
+            ) { _ in
+                self.urlOpener.open(viewURL, options: [:], completionHandler: nil)
+            }
+            return UIMenu(title: "", children: [viewOnYouTubeAction])
+        }
     }
 
     override func collectionView(
@@ -187,48 +302,73 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         animator: UIContextMenuInteractionCommitAnimating
     ) {
         guard let foreignKey = configuration.identifier as? String,
-            let item = media.first(where: { $0.foreignKey == foreignKey })
+            let item = media.first(where: { $0.contextMenuIdentifier == foreignKey })
         else { return }
-        delegate?.mediaSelected(image: imageCache[foreignKey], directURL: item.directURL)
+        switch item {
+        case .image(let photo):
+            delegate?.mediaSelected(
+                image: imageCache[photo.foreignKey],
+                directURL: photo.directURL,
+                viewURL: photo.viewURL
+            )
+        case .video(let video):
+            if let viewURL = video.viewURL, urlOpener.canOpenURL(viewURL) {
+                urlOpener.open(viewURL, options: [:], completionHandler: nil)
+            }
+        }
     }
 
     // MARK: Data Source
 
     private func setupDataSource() {
-        let cellRegistration = UICollectionView.CellRegistration<
-            MediaCollectionViewCell, TeamMediaItem
-        > {
-            [weak self] cell, _, item in
-            guard let self else { return }
-            if let image = self.imageCache[item.foreignKey] {
-                cell.state = .loaded(image)
-            } else if let error = self.imageErrors[item.foreignKey] {
-                cell.state = .error("Error loading media - \(error.localizedDescription)")
-            } else {
-                cell.state = .loading
+        dataSource = CollectionViewDataSource<MediaSection, TeamMediaItem>(
+            collectionView: collectionView
+        ) { [weak self] collectionView, indexPath, item in
+            guard let self else { return UICollectionViewCell() }
+            switch item {
+            case .image(let photo):
+                let cell: MediaCollectionViewCell = collectionView.dequeueReusableCell(
+                    indexPath: indexPath
+                )
+                if photo.isInstagram {
+                    cell.state = .error("Instagram image")
+                } else if let image = self.imageCache[photo.foreignKey] {
+                    cell.state = .loaded(image)
+                } else if self.imageErrors[photo.foreignKey] != nil {
+                    cell.state = .error("Image unavailable")
+                } else {
+                    cell.state = .loading
+                }
+                return cell
+            case .video(let video):
+                let cell: PlayerCollectionViewCell = collectionView.dequeueReusableCell(
+                    indexPath: indexPath
+                )
+                cell.configure(youtubeKey: video.youtubeKey)
+                return cell
             }
-            cell.accessibilityIdentifier = "media.\(item.foreignKey)"
-        }
-        dataSource = CollectionViewDataSource<String, TeamMediaItem>(collectionView: collectionView)
-        {
-            collectionView,
-            indexPath,
-            item in
-            return collectionView.dequeueConfiguredReusableCell(
-                using: cellRegistration,
-                for: indexPath,
-                item: item
-            )
         }
         dataSource.delegate = self
     }
 
     private func applyMedia(_ items: [TeamMediaItem]) {
         self.media = items
-        var snapshot = NSDiffableDataSourceSnapshot<String, TeamMediaItem>()
-        if !items.isEmpty {
-            snapshot.appendSections([""])
-            snapshot.appendItems(items, toSection: "")
+        var snapshot = NSDiffableDataSourceSnapshot<MediaSection, TeamMediaItem>()
+
+        let videos = items.compactMap { item -> TeamMediaItem? in
+            if case .video = item { return item } else { return nil }
+        }
+        let images = items.compactMap { item -> TeamMediaItem? in
+            if case .image = item { return item } else { return nil }
+        }
+
+        if !images.isEmpty {
+            snapshot.appendSections([.images])
+            snapshot.appendItems(images, toSection: .images)
+        }
+        if !videos.isEmpty {
+            snapshot.appendSections([.videos])
+            snapshot.appendItems(videos, toSection: .videos)
         }
         dataSource.applySnapshotUsingReloadData(snapshot)
     }
@@ -249,46 +389,64 @@ extension TeamMediaCollectionViewController: Refreshable {
                 teamKey: self.teamKey,
                 year: year
             )
-            let items: [TeamMediaItem] =
-                apiMedia
-                .filter { Self.imageTypes.contains($0._type.rawValue) }
-                .map { m in
-                    TeamMediaItem(
-                        foreignKey: m.foreignKey,
-                        type: m._type.rawValue,
-                        directURL: m.directUrl.flatMap { URL(string: $0) },
-                        viewURL: m.viewUrl.flatMap { URL(string: $0) }
-                    )
-                }
+            let items: [TeamMediaItem] = apiMedia.compactMap { Self.makeItem(from: $0) }
             self.imageErrors.removeAll()
             self.applyMedia(items)
-            for item in items { self.downloadImage(for: item) }
-        }
-    }
-
-    private func downloadImage(for item: TeamMediaItem) {
-        guard imageCache[item.foreignKey] == nil else { return }
-        guard let url = item.directURL else { return }
-        downloadTasks[item.foreignKey]?.cancel()
-        downloadTasks[item.foreignKey] = Task { @MainActor [weak self] in
-            do {
-                let (data, _) = try await URLSession.shared.data(from: url)
-                if let image = UIImage(data: data) {
-                    self?.imageCache[item.foreignKey] = image
-                } else {
-                    self?.imageErrors[item.foreignKey] = URLError(.cannotDecodeContentData)
-                }
-                self?.reconfigure(item: item)
-            } catch {
-                if !Task.isCancelled {
-                    self?.imageErrors[item.foreignKey] = error
-                    self?.reconfigure(item: item)
+            for item in items {
+                if case .image(let photo) = item, !photo.isInstagram {
+                    self.downloadImage(for: photo)
                 }
             }
         }
     }
 
-    private func reconfigure(item: TeamMediaItem) {
+    private static func makeItem(from media: Media) -> TeamMediaItem? {
+        let type = media._type.rawValue
+        if Self.imageTypes.contains(type) {
+            return .image(
+                .init(
+                    foreignKey: media.foreignKey,
+                    type: type,
+                    directURL: media.directUrl.flatMap { URL(string: $0) },
+                    viewURL: media.viewUrl.flatMap { URL(string: $0) }
+                )
+            )
+        }
+        if Self.videoTypes.contains(type), !media.foreignKey.isEmpty {
+            return .video(
+                .init(
+                    youtubeKey: media.foreignKey,
+                    viewURL: media.viewUrl.flatMap { URL(string: $0) }
+                )
+            )
+        }
+        return nil
+    }
+
+    private func downloadImage(for photo: TeamMediaItem.Photo) {
+        guard imageCache[photo.foreignKey] == nil else { return }
+        guard let url = photo.directURL else { return }
+        downloadTasks[photo.foreignKey]?.cancel()
+        downloadTasks[photo.foreignKey] = Task { @MainActor [weak self] in
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                if let image = UIImage(data: data) {
+                    self?.imageCache[photo.foreignKey] = image
+                } else {
+                    self?.imageErrors[photo.foreignKey] = URLError(.cannotDecodeContentData)
+                }
+                self?.reconfigure(photo: photo)
+            } catch {
+                if !Task.isCancelled {
+                    self?.imageErrors[photo.foreignKey] = error
+                    self?.reconfigure(photo: photo)
+                }
+            }
+        }
+    }
+
+    private func reconfigure(photo: TeamMediaItem.Photo) {
+        let item = TeamMediaItem.image(photo)
         var snapshot = dataSource.snapshot()
         if snapshot.itemIdentifiers.contains(item) {
             snapshot.reconfigureItems([item])
@@ -304,4 +462,13 @@ extension TeamMediaCollectionViewController: Stateful {
         return "No media for team"
     }
 
+}
+
+private extension TeamMediaItem {
+    var contextMenuIdentifier: String {
+        switch self {
+        case .image(let photo): return photo.foreignKey
+        case .video(let video): return video.youtubeKey
+        }
+    }
 }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -392,8 +392,8 @@ extension TeamViewController: EventsListViewControllerDelegate {
 
 extension TeamViewController: MediaViewer, TeamMediaCollectionViewControllerDelegate {
 
-    func mediaSelected(image: UIImage?, directURL: URL?) {
-        show(image: image, directURL: directURL)
+    func mediaSelected(image: UIImage?, directURL: URL?, viewURL: URL?) {
+        show(image: image, directURL: directURL, viewURL: viewURL)
     }
 
 }
@@ -401,14 +401,50 @@ extension TeamViewController: MediaViewer, TeamMediaCollectionViewControllerDele
 protocol MediaViewer: UIViewController {}
 extension MediaViewer {
 
-    func show(image: UIImage?, directURL: URL?) {
+    func show(image: UIImage?, directURL: URL?, viewURL: URL?) {
+        let agrume: Agrume
         if let image {
-            let agrume = Agrume(image: image)
-            agrume.show(from: self)
+            agrume = Agrume(image: image)
         } else if let directURL {
-            let agrume = Agrume(url: directURL)
-            agrume.show(from: self)
+            agrume = Agrume(url: directURL)
+        } else {
+            return
         }
+        agrume.onLongPress = { [weak self] image, agrumeVC in
+            self?.presentMediaActions(image: image, viewURL: viewURL, from: agrumeVC)
+        }
+        agrume.show(from: self)
+    }
+
+    fileprivate func presentMediaActions(
+        image: UIImage?,
+        viewURL: URL?,
+        from presenter: UIViewController
+    ) {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        if let viewURL, UIApplication.shared.canOpenURL(viewURL) {
+            alert.addAction(
+                UIAlertAction(title: "View Online", style: .default) { _ in
+                    UIApplication.shared.open(viewURL)
+                }
+            )
+        }
+        if let image {
+            alert.addAction(
+                UIAlertAction(title: "Copy", style: .default) { _ in
+                    UIPasteboard.general.image = image
+                }
+            )
+            alert.addAction(
+                UIAlertAction(title: "Save Photo", style: .default) { _ in
+                    UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+                }
+            )
+        }
+        guard !alert.actions.isEmpty else { return }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.popoverPresentationController?.sourceView = presenter.view
+        presenter.present(alert, animated: true)
     }
 
 }

--- a/the-blue-alliance-ios/ViewElements/Media/MediaCollectionViewCell.swift
+++ b/the-blue-alliance-ios/ViewElements/Media/MediaCollectionViewCell.swift
@@ -46,15 +46,29 @@ class MediaCollectionViewCell: UICollectionViewCell, Reusable {
     }()
     private lazy var noDataView: UIView = {
         let noDataView = UIView(forAutoLayout: ())
-        noDataView.addSubview(noDataLabel)
-        noDataLabel.autoPinEdgesToSuperviewEdges(
-            with: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
-        )
+        let stack = UIStackView(arrangedSubviews: [noDataIconView, noDataLabel])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 6
+        stack.configureForAutoLayout()
+        noDataView.addSubview(stack)
+        stack.autoCenterInSuperview()
+        stack.autoPinEdge(toSuperviewEdge: .leading, withInset: 8, relation: .greaterThanOrEqual)
+        stack.autoPinEdge(toSuperviewEdge: .trailing, withInset: 8, relation: .greaterThanOrEqual)
         return noDataView
+    }()
+    private let noDataIconView: UIImageView = {
+        let icon = UIImageView(
+            image: UIImage(systemName: "photo")?
+                .withConfiguration(UIImage.SymbolConfiguration(pointSize: 28, weight: .regular))
+        )
+        icon.tintColor = UIColor.label.withAlphaComponent(0.4)
+        icon.contentMode = .scaleAspectFit
+        return icon
     }()
     private let noDataLabel: UILabel = {
         let noDataLabel = UILabel(forAutoLayout: ())
-        noDataLabel.font = UIFont.systemFont(ofSize: 14)
+        noDataLabel.font = UIFont.systemFont(ofSize: 13)
         noDataLabel.numberOfLines = 0
         noDataLabel.textColor = UIColor.label
         noDataLabel.alpha = 0.5

--- a/the-blue-alliance-ios/ViewElements/Media/PlayerCollectionViewCell.swift
+++ b/the-blue-alliance-ios/ViewElements/Media/PlayerCollectionViewCell.swift
@@ -1,0 +1,37 @@
+import PureLayout
+import UIKit
+
+class PlayerCollectionViewCell: UICollectionViewCell, Reusable {
+
+    private let playerView: PlayerView = {
+        let playerView = PlayerView()
+        playerView.configureForAutoLayout()
+        return playerView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUpView()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setUpView()
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        playerView.stopVideo()
+    }
+
+    func configure(youtubeKey: String?) {
+        playerView.load(youtubeKey: youtubeKey)
+    }
+
+    private func setUpView() {
+        backgroundColor = .systemGray6
+        contentView.addSubview(playerView)
+        playerView.autoPinEdgesToSuperviewEdges()
+    }
+
+}

--- a/the-blue-alliance-ios/ViewElements/Media/PlayerView.swift
+++ b/the-blue-alliance-ios/ViewElements/Media/PlayerView.swift
@@ -10,8 +10,13 @@ protocol Playable {
 
 class PlayerView: UIView {
 
-    private let playable: Playable
     private let playerView: YTPlayerView = YTPlayerView(frame: .zero)
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+    private(set) var loadedKey: String?
 
     lazy var noDataViewController: NoDataViewController = {
         let noDataViewController = NoDataViewController()
@@ -19,22 +24,23 @@ class PlayerView: UIView {
         return noDataViewController
     }()
 
-    init(playable: Playable) {
-        self.playable = playable
-
+    init() {
         super.init(frame: .zero)
         backgroundColor = UIColor.systemGray6
 
         playerView.configureForAutoLayout()
+        playerView.delegate = self
         addSubview(playerView)
         playerView.autoPinEdgesToSuperviewEdges()
 
-        if let youtubeKey = playable.youtubeKey {
-            let parsed = YouTubeForeignKey(youtubeKey)
-            playerView.load(withVideoId: parsed.videoId, playerVars: parsed.playerVars)
-        } else {
-            showErrorView(error: "No YouTube key for video.")
-        }
+        loadingIndicator.configureForAutoLayout()
+        addSubview(loadingIndicator)
+        loadingIndicator.autoCenterInSuperview()
+    }
+
+    convenience init(playable: Playable) {
+        self.init()
+        load(youtubeKey: playable.youtubeKey)
     }
 
     deinit {
@@ -45,6 +51,28 @@ class PlayerView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func load(youtubeKey: String?) {
+        if youtubeKey == loadedKey {
+            return
+        }
+        playerView.stopVideo()
+        loadedKey = youtubeKey
+        if let youtubeKey {
+            removeErrorView()
+            loadingIndicator.startAnimating()
+            let parsed = YouTubeForeignKey(youtubeKey)
+            playerView.load(withVideoId: parsed.videoId, playerVars: parsed.playerVars)
+        } else {
+            loadingIndicator.stopAnimating()
+            showErrorView(error: "No YouTube key for video.")
+        }
+    }
+
+    func stopVideo() {
+        playerView.stopVideo()
+        loadingIndicator.stopAnimating()
+    }
+
     private func showErrorView(error: String) {
         noDataViewController.textLabel.text = error
         if noDataViewController.view.superview == nil {
@@ -53,6 +81,18 @@ class PlayerView: UIView {
         }
     }
 
+    private func removeErrorView() {
+        if noDataViewController.view.superview != nil {
+            noDataViewController.view.removeFromSuperview()
+        }
+    }
+
+}
+
+extension PlayerView: YTPlayerViewDelegate {
+    func playerViewDidBecomeReady(_ playerView: YTPlayerView) {
+        loadingIndicator.stopAnimating()
+    }
 }
 
 struct YouTubeForeignKey {


### PR DESCRIPTION
## Summary
- Adds `PlayerCollectionViewCell` wrapping `PlayerView`. `PlayerView` is now reusable via `load(youtubeKey:)` and shows a centered spinner that hides on `playerViewDidBecomeReady`.
- `TeamMediaCollectionViewController` becomes a sectioned diffable data source: photos on top, videos below, layout per section.
- Trims dead/awkward image types (`avatar`, `cdphotothread`) and replaces the loud "NSURLErrorDomain -1016" tile with a quiet SF-symbol placeholder. Instagram items show "Instagram image", skip the doomed download, tap opens Instagram, and the context menu drops the "View" action.
- Agrume long-press matches the cell's context menu (View Online / Copy / Save Photo) instead of the previous save-only flow.

## Test plan
- [ ] **Team 1678 / 2016** (`tba team media 1678 --year 2016`): expect 1 imgur photo and 1 Instagram tile (with "Instagram image" caption); 2 YouTube videos in their own section below — videos load with a spinner, then play inline; cdphotothread/grabcad rows are filtered out.
- [ ] **Team 254 / 2018**: 2 imgur photos + 1 Instagram tile + 1 YouTube; verify photos-on-top / videos-below ordering.
- [ ] **Team 254 / 2020** (no videos): only the photo grid renders, no empty video section.
- [ ] Tap a photo → opens Agrume; long-press inside Agrume → action sheet with View Online / Copy / Save Photo.
- [ ] Long-press a photo cell → context menu has View / View Online / Copy / Save (no View on `instagram-image`; tap on `instagram-image` opens Instagram).
- [ ] Long-press a video cell → "View on YouTube" only.
- [ ] Switch year while a video is playing → snapshot replaces, no crash.
- [ ] iPad regular width: photos in 3 columns, videos still full-width 16:9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)