### PR TITLE
Address Copilot follow-ups from #1105

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -225,48 +225,39 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         }
     }
 
-    private func imageContextMenu(for photo: TeamMediaItem.Photo) -> UIContextMenuConfiguration {
+    private func imageContextMenu(for photo: TeamMediaItem.Photo) -> UIContextMenuConfiguration? {
         let cachedImage = imageCache[photo.foreignKey]
-        return UIContextMenuConfiguration(
-            identifier: photo.foreignKey as NSString,
-            previewProvider: nil
-        ) { _ in
-            var actions: [UIMenuElement] = []
-            if !photo.isInstagram {
-                actions.append(
-                    UIAction(title: "View", image: UIImage(systemName: "eye.fill")) { _ in
-                        self.delegate?.mediaSelected(
-                            image: cachedImage,
-                            directURL: photo.directURL,
-                            viewURL: photo.viewURL
-                        )
-                    }
-                )
-            }
+        var actions: [UIMenuElement] = []
 
-            if let viewURL = photo.viewURL, self.urlOpener.canOpenURL(viewURL) {
-                let viewOnlineAction = UIAction(
-                    title: "View Online",
-                    image: UIImage(systemName: "safari.fill")
-                ) { _ in
+        if !photo.isInstagram {
+            actions.append(
+                UIAction(title: "View", image: UIImage(systemName: "eye.fill")) { _ in
+                    self.delegate?.mediaSelected(
+                        image: cachedImage,
+                        directURL: photo.directURL,
+                        viewURL: photo.viewURL
+                    )
+                }
+            )
+        }
+
+        if let viewURL = photo.viewURL, urlOpener.canOpenURL(viewURL) {
+            actions.append(
+                UIAction(title: "View Online", image: UIImage(systemName: "safari.fill")) { _ in
                     self.urlOpener.open(viewURL, options: [:], completionHandler: nil)
                 }
-                actions.append(viewOnlineAction)
-            }
+            )
+        }
 
-            if let image = cachedImage {
-                let copyAction = UIAction(
-                    title: "Copy",
-                    image: UIImage(systemName: "doc.on.doc.fill")
-                ) { _ in
+        if let image = cachedImage {
+            actions.append(
+                UIAction(title: "Copy", image: UIImage(systemName: "doc.on.doc.fill")) { _ in
                     self.pasteboard.image = image
                 }
-                actions.append(copyAction)
-
-                let saveAction = UIAction(
-                    title: "Save",
-                    image: UIImage(systemName: "square.and.arrow.down.fill")
-                ) { _ in
+            )
+            actions.append(
+                UIAction(title: "Save", image: UIImage(systemName: "square.and.arrow.down.fill")) {
+                    _ in
                     self.photoLibrary.performChanges(
                         {
                             PHAssetChangeRequest.creationRequestForAsset(from: image)
@@ -274,9 +265,15 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
                         completionHandler: nil
                     )
                 }
-                actions.append(saveAction)
-            }
-            return UIMenu(title: "", children: actions)
+            )
+        }
+
+        guard !actions.isEmpty else { return nil }
+        return UIContextMenuConfiguration(
+            identifier: photo.foreignKey as NSString,
+            previewProvider: nil
+        ) { _ in
+            UIMenu(title: "", children: actions)
         }
     }
 

--- a/the-blue-alliance-ios/ViewElements/Media/PlayerView.swift
+++ b/the-blue-alliance-ios/ViewElements/Media/PlayerView.swift
@@ -52,7 +52,9 @@ class PlayerView: UIView {
     }
 
     func load(youtubeKey: String?) {
-        if youtubeKey == loadedKey {
+        // Only short-circuit when we already loaded the same non-nil key, so a
+        // fresh view (loadedKey == nil) loaded with nil still surfaces the error.
+        if let youtubeKey, youtubeKey == loadedKey {
             return
         }
         playerView.stopVideo()
@@ -92,6 +94,11 @@ class PlayerView: UIView {
 extension PlayerView: YTPlayerViewDelegate {
     func playerViewDidBecomeReady(_ playerView: YTPlayerView) {
         loadingIndicator.stopAnimating()
+    }
+
+    func playerView(_ playerView: YTPlayerView, receivedError error: YTPlayerError) {
+        loadingIndicator.stopAnimating()
+        showErrorView(error: "Unable to load video.")
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes the three valid Copilot review comments on #1105:

- `PlayerView.load(youtubeKey:)` short-circuited when both the new key and `loadedKey` were `nil`, so a fresh `PlayerView` loaded with a missing key never showed the intended "No YouTube key for video." error. Now only short-circuits when the key is non-nil and matches.
- `PlayerView` only stopped the loading spinner in `playerViewDidBecomeReady`. A failed YouTube load left the spinner running forever. Adds `playerView(_:receivedError:)` to stop the indicator and present an error state.
- `TeamMediaCollectionViewController.imageContextMenu(for:)` always returned a `UIContextMenuConfiguration`, even when the action list ended up empty (e.g. an Instagram item with no openable `viewURL`). Now returns `UIContextMenuConfiguration?` and returns `nil` when there are no actions, matching `videoContextMenu(for:)`.

## Test plan
- [ ] Long-press a non-Instagram photo → context menu shows View / View Online (when applicable) / Copy / Save (when image is cached) — same as before.
- [ ] Long-press an Instagram tile that has a `viewURL` opening in the Instagram app → context menu shows only "View Online".
- [ ] Long-press an Instagram tile with no usable `viewURL` → no context menu appears (instead of an empty one).
- [ ] Long-press a video cell → still shows "View on YouTube" only.
- [ ] Load a video with a valid YouTube key → spinner appears, then video plays.
- [ ] Force a YouTube load failure (e.g. airplane mode while scrolling videos in) → spinner stops and "Unable to load video." appears instead of spinning forever.
- [ ] Construct a `PlayerView(playable:)` whose `youtubeKey` is `nil` → "No YouTube key for video." renders immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)