### PR TITLE
Wiki documentation for Match Breakdown

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -12,8 +12,13 @@ How to ship a TestFlight or App Store build via the **Actions → Release → Ru
 Common maintainer tasks: bumping dependencies, regenerating distribution certificates, configuring APNs, and symbolicating crash logs.
 
 # Per-Year Work
+Work that needs to be done manually to add feature support every season.
+
 ## [Event Insights](https://github.com/the-blue-alliance/the-blue-alliance-ios/wiki/Event-Insights)
 How `EventInsightsViewController` and the per-year `EventInsightsConfigurator` classes work, and how to add support for a new FRC season.
+
+## [Match Breakdown](https://github.com/the-blue-alliance/the-blue-alliance-ios/wiki/Match-Breakdown)
+How `MatchBreakdownViewController` and the per-year `MatchBreakdownConfigurator` classes work, and how to add support for a new FRC season.
 
 # Recovery / Reproduction
 

--- a/docs/Match-Breakdown.md
+++ b/docs/Match-Breakdown.md
@@ -1,0 +1,43 @@
+# Match Breakdown
+The Blue Alliance for iOS shows a detailed breakdown of each match under **Match → Breakdown**. Due to the fact that each season has different points and scoring, the Match Breakdown must be configured via small per-year classes that translate the `/match/{match_key}` endpoint.
+
+## Code Location
+
+- View controller: [`MatchBreakdownViewController`](https://github.com/the-blue-alliance/the-blue-alliance-ios/blob/main/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift) - fetches the breakdown payload and routes it to the right configurator based on `year`.
+- Configurator protocol + shared helpers: [`MatchBreakdownConfigurator.swift`](https://github.com/the-blue-alliance/the-blue-alliance-ios/blob/main/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift).
+- Per-year configurators: [`MatchBreakdownConfigurator{year}.swift`] - one file per supported year, 2021 falls back to 2020.
+
+## How Years are Rendered
+
+Each per-year configurator implements:
+
+```swift
+static func configureDataSource(
+        _ snapshot: inout NSDiffableDataSourceSnapshot<String?, BreakdownRow>,
+        _ breakdown: [String: Any]?,
+        _ red: [String: Any]?,
+        _ blue: [String: Any]?,
+        _ compLevel: Components.Schemas.CompLevel?
+    )
+```
+The `breakdown` dictionary contains the raw breakdown object from the response. `red` and `blue` are the `red` and `blue` objects of the response. The configurator builds an array of `BreakdownRow`s and appends them to the snapshot.
+`compLevel` is used to determine whether to show the RP related rows in a breakdown (in non-quals, those rows are not required).
+
+### Row Types
+These live in `MatchBreakdownConfigurator.swift`.
+- `row`: A basic row with text values.
+- `nestedRow`: Same as `row`, but to be used when the value is not at the top level in the API.
+- `rankingPointsRow`: Used for RP values in the breakdown.
+- `boolImageRow`: Used to show a ✓/✗ in the given row based on a boolean value.
+
+## Adding a New Year
+1. **Find the API shape**: hit `/match/{match_key}` for an event in the new year, one that is real and finished.
+2. **Pick a reference year**: find a similar year in terms of general structure from the configurators that already exist.
+3. **Create `MatchBreakdownConfigurator{year}.swift`** in `the-blue-alliance-ios/ViewElements/Match/Breakdown/`. If you’ve found a similar enough year, it can help to directly duplicate the file.
+4. **Add rows**: start appending rows using `rows.append(row)` one by one. Look at the predefined types - they may save you time.
+  	- RP rows should use `rankingPointsRow`, where they will automatically be hidden in playoffs
+6. **Add to the switch case**: go to `MatchBreakdownViewController.swift` in `the-blue-alliance-ios/ViewControllers/Match` by adding a new `case {year}: breakdownConfigurator = MatchBreakdownConfigurator{year}.self` in the existing switch.
+7. **Test on a match**: Run the app, navigate to a match from the year, and check the Breakdown tab, comparing it to the same match on the web. Look for:
+	- Rows that should have populated values but are empty.
+    - Incorrect statistics in rows.
+    - Bonus/RP rows showing in playoff matches.

--- a/docs/Match-Breakdown.md
+++ b/docs/Match-Breakdown.md
@@ -3,9 +3,9 @@ The Blue Alliance for iOS shows a detailed breakdown of each match under **Match
 
 ## Code Location
 
-- View controller: [`MatchBreakdownViewController`](https://github.com/the-blue-alliance/the-blue-alliance-ios/blob/main/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift) - fetches the breakdown payload and routes it to the right configurator based on `year`.
+- View controller: [`MatchBreakdownViewController.swift`](https://github.com/the-blue-alliance/the-blue-alliance-ios/blob/main/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift) - fetches the breakdown payload and routes it to the right configurator based on `year`.
 - Configurator protocol + shared helpers: [`MatchBreakdownConfigurator.swift`](https://github.com/the-blue-alliance/the-blue-alliance-ios/blob/main/the-blue-alliance-ios/ViewElements/Match/Breakdown/MatchBreakdownConfigurator.swift).
-- Per-year configurators: [`MatchBreakdownConfigurator{year}.swift`] - one file per supported year, 2021 falls back to 2020.
+- Per-year configurators: `MatchBreakdownConfigurator{year}.swift` - one file per supported year, 2021 falls back to 2020.
 
 ## How Years are Rendered
 


### PR DESCRIPTION
## Description
Added wiki documentation for creating a new Match Breakdown for every FRC Season. Modeled to look similar to the Event Insights wiki page.

## Motivation and Context
Documentation was previously missing for Match Breakdowns.