### PR TITLE
Show team numbers in event Awards list

### DIFF
--- a/the-blue-alliance-ios/ViewElements/Awards/AwardCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Awards/AwardCellViewModel.swift
@@ -17,9 +17,12 @@ struct AwardCellViewModel {
             var awardText: [String] = []
             if let teamKey = apiRecipient.teamKey, let awardee = apiRecipient.awardee {
                 awardText.append(awardee)
-                awardText.append(Self.teamDisplay(key: teamKey, teamsByKey: teamsByKey))
+                awardText.append(Self.teamNumber(key: teamKey, teamsByKey: teamsByKey))
             } else if let teamKey = apiRecipient.teamKey {
-                awardText.append(Self.teamDisplay(key: teamKey, teamsByKey: teamsByKey))
+                awardText.append(Self.teamNumber(key: teamKey, teamsByKey: teamsByKey))
+                if let nickname = teamsByKey[teamKey]?.nickname, !nickname.isEmpty {
+                    awardText.append(nickname)
+                }
             } else if let awardee = apiRecipient.awardee {
                 awardText.append(awardee)
             } else {
@@ -29,12 +32,12 @@ struct AwardCellViewModel {
         }
     }
 
-    private static func teamDisplay(key: String, teamsByKey: [String: TeamSimple]) -> String {
+    private static func teamNumber(key: String, teamsByKey: [String: TeamSimple]) -> String {
         if let team = teamsByKey[key] {
-            return team.displayNickname
+            return String(team.teamNumber)
         }
         if key.hasPrefix("frc") {
-            return "Team \(key.dropFirst(3))"
+            return String(key.dropFirst(3))
         }
         return key
     }


### PR DESCRIPTION
## Summary
- When the Core Data layer was removed, `AwardCellViewModel.teamDisplay` collapsed to `team.displayNickname`, which silently drops the team number whenever the team has a nickname. The Awards tab was showing just `"The Cheesy Poofs"` with no team number anywhere on the row.
- Restore the team number as the primary identifier on team-only rows (number on line 1, nickname underneath when present), matching the web's number-first emphasis while keeping the two-line touch target the cell already relies on.
- Awardee rows are unchanged in structure: awardee on line 1, bare team number on line 2 (no more `"Team N"` prefix — the repeated `Team` was noisy when stacked).

## Test plan
- [ ] Open an event with mixed award types (e.g. Smoky Mountains Regional 2026) → Awards tab
- [ ] Team-only awards (Impact, Regional Winners, etc.) show the bare team number on top, nickname underneath when one is known
- [ ] Awardee awards (Woodie Flowers, Volunteer of the Year, FIRST Leadership Finalist) show the awardee on top and the bare team number underneath
- [ ] Awards with neither team nor awardee still render `--`
- [ ] Tapping a team-only row still navigates to the team detail