### PR TITLE
Show event row at top of Team@Event Summary

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -65,15 +65,6 @@ class TeamAtEventViewController: ContainerViewController {
             dependencies: dependencies
         )
 
-        rightBarButtonItems = [
-            UIBarButtonItem(
-                image: UIImage.eventIcon,
-                style: .plain,
-                target: self,
-                action: #selector(pushEvent)
-            )
-        ]
-
         summaryViewController.delegate = self
         matchesViewController.delegate = self
         mediaViewController.delegate = self
@@ -118,7 +109,7 @@ class TeamAtEventViewController: ContainerViewController {
 
     // MARK: - Private Methods
 
-    @objc private func pushEvent() {
+    private func pushEvent() {
         let eventViewController = EventViewController(
             eventKey: eventKey,
             dependencies: dependencies
@@ -161,6 +152,10 @@ extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewC
 
     func teamInfoSelected(teamKey: String) {
         pushTeam(teamKey: teamKey)
+    }
+
+    func eventInfoSelected() {
+        pushEvent()
     }
 
     func matchSelected(_ match: Match) {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -154,7 +154,7 @@ extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewC
         pushTeam(teamKey: teamKey)
     }
 
-    func eventInfoSelected() {
+    func eventSelected() {
         pushEvent()
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -4,10 +4,12 @@ import UIKit
 
 protocol TeamSummaryViewControllerDelegate: AnyObject {
     func teamInfoSelected(teamKey: String)
+    func eventInfoSelected()
     func matchSelected(_ match: Match)
 }
 
 private enum TeamSummarySection: Int {
+    case event
     case teamInfo
     case pitLocation
     case eventInfo
@@ -25,12 +27,13 @@ extension TeamSummarySection: TableSectionTitleProviding {
         case .playoffInfo: return "Playoffs"
         case .qualInfo: return "Qualifications"
         case .lastMatch: return "Most Recent Match"
-        case .teamInfo, .pitLocation: return nil
+        case .event, .teamInfo, .pitLocation: return nil
         }
     }
 }
 
 private enum TeamSummaryItem: Hashable {
+    case event(event: Event)
     case teamInfo(team: Team)
     case pitLocation(location: String)
     case status(status: String)
@@ -75,6 +78,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
 
         tableView.registerReusableCell(ReverseSubtitleTableViewCell.self)
         tableView.registerReusableCell(InfoTableViewCell.self)
+        tableView.registerReusableCell(EventTableViewCell.self)
         tableView.registerReusableCell(MatchTableViewCell.self)
 
         tableView.dataSource = dataSource
@@ -89,6 +93,8 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             cellProvider: { [weak self] (tableView, indexPath, item) -> UITableViewCell? in
                 guard let self else { return nil }
                 switch item {
+                case .event(let event):
+                    return self.cellForEvent(event, in: tableView, at: indexPath)
                 case .teamInfo(let team):
                     return self.cellForTeam(team, in: tableView, at: indexPath)
                 case .pitLocation(let location):
@@ -164,7 +170,11 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
     private func rebuildSnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<TeamSummarySection, TeamSummaryItem>()
 
-        // Team info
+        if let event {
+            snapshot.appendSections([.event])
+            snapshot.appendItems([.event(event: event)], toSection: .event)
+        }
+
         if let team {
             snapshot.appendSections([.teamInfo])
             snapshot.appendItems([.teamInfo(team: team)], toSection: .teamInfo)
@@ -310,6 +320,20 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Cells
 
+    private func cellForEvent(_ event: Event, in tableView: UITableView, at indexPath: IndexPath)
+        -> UITableViewCell
+    {
+        let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
+        cell.viewModel = EventCellViewModel(
+            name: event.safeShortName,
+            location: event.locationString,
+            dateString: event.dateString
+        )
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .none
+        return cell
+    }
+
     private func cellForTeam(_ team: Team, in tableView: UITableView, at indexPath: IndexPath)
         -> UITableViewCell
     {
@@ -373,6 +397,8 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
 
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
         switch item {
+        case .event:
+            delegate?.eventInfoSelected()
         case .teamInfo:
             delegate?.teamInfoSelected(teamKey: teamKey)
         case .match(let match, _):

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 
 protocol TeamSummaryViewControllerDelegate: AnyObject {
     func teamInfoSelected(teamKey: String)
-    func eventInfoSelected()
+    func eventSelected()
     func matchSelected(_ match: Match)
 }
 
@@ -330,7 +330,6 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             dateString: event.dateString
         )
         cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .none
         return cell
     }
 
@@ -343,7 +342,6 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             subtitleStrings: [team.locationString].compactMap { $0 }
         )
         cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .none
         return cell
     }
 
@@ -398,7 +396,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
         switch item {
         case .event:
-            delegate?.eventInfoSelected()
+            delegate?.eventSelected()
         case .teamInfo:
             delegate?.teamInfoSelected(teamKey: teamKey)
         case .match(let match, _):


### PR DESCRIPTION
## Summary
- Replaces the event icon in the Team@Event navigation bar's top-right with a tappable event row at the top of the Summary tab.
- Mirrors the team row beneath it so the link to the parent event uses the same affordance as the link to the team.
- Reuses `EventTableViewCell` / `EventCellViewModel` (same cell used across the Events list) so the row matches event rows elsewhere in the app.

## Test plan
- [ ] Open a team's page, tap an event under "Event Status" → land on Team@Event Summary.
- [ ] Confirm the event icon in the top-right of the navigation bar is gone.
- [ ] Confirm a row with the event short name, location, and date range appears at the top of the Summary tab, above the team row.
- [ ] Tap the event row → pushes the EventViewController for that event.
- [ ] Tap the team row → still pushes the TeamViewController for that team.
- [ ] Pull to refresh on the Summary tab → event row redraws correctly.
- [ ] Switch to the other tabs (Matches, Media, Stats, Awards) → no event icon button there (it was only present on Summary's nav bar before).
- [ ] Verify with a B-team (e.g. `frc5940B`) that navigation still routes through the canonical parent team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)