### PR TITLE
Fix TBAAPI test build broken by static call on protocol metatype

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Teams/APITeam+Helpers.swift
@@ -30,7 +30,8 @@ extension TeamDisplayable {
     // context (e.g. partial nicknames passed in before a full team is loaded).
     public static func nonFallback(_ nickname: String?, forTeamNumber teamNumber: Int) -> String? {
         guard let nickname, !nickname.isEmpty,
-              nickname != "Team \(teamNumber)" else { return nil }
+            nickname != "Team \(teamNumber)"
+        else { return nil }
         return nickname
     }
 

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Teams/APITeam+HelpersTests.swift
@@ -85,19 +85,19 @@ struct APITeamHelpersTests {
     // MARK: - TeamDisplayable.nonFallback(_:forTeamNumber:)
 
     @Test func nonFallbackStatic_nilForNil() {
-        #expect(TeamDisplayable.nonFallback(nil, forTeamNumber: 18) == nil)
+        #expect(Team.nonFallback(nil, forTeamNumber: 18) == nil)
     }
 
     @Test func nonFallbackStatic_nilForEmpty() {
-        #expect(TeamDisplayable.nonFallback("", forTeamNumber: 18) == nil)
+        #expect(Team.nonFallback("", forTeamNumber: 18) == nil)
     }
 
     @Test func nonFallbackStatic_nilForFallback() {
-        #expect(TeamDisplayable.nonFallback("Team 18", forTeamNumber: 18) == nil)
+        #expect(Team.nonFallback("Team 18", forTeamNumber: 18) == nil)
     }
 
     @Test func nonFallbackStatic_returnsRealNickname() {
-        #expect(TeamDisplayable.nonFallback("The Cheesy Poofs", forTeamNumber: 254) == "The Cheesy Poofs")
+        #expect(Team.nonFallback("The Cheesy Poofs", forTeamNumber: 254) == "The Cheesy Poofs")
     }
 
     // MARK: - Team.locationString

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -138,7 +138,7 @@ class TeamViewController: HeaderContainerViewController {
         let teamNumber = state.team?.teamNumber ?? state.key.teamNumber ?? 0
         let nickname: String? = {
             if let team = state.team { return team.nonFallbackNickname }
-            return TeamDisplayable.nonFallback(partialNickname, forTeamNumber: teamNumber)
+            return Team.nonFallback(partialNickname, forTeamNumber: teamNumber)
         }()
         let teamNumberNickname = state.team?.teamNumberNickname ?? "Team \(teamNumber)"
 


### PR DESCRIPTION
## Summary
- After #1114 landed, the `Test` and `swift-format` jobs are red on `main` ([CI run](https://github.com/the-blue-alliance/the-blue-alliance-ios/actions/runs/26202307012)).
- The TBAAPI test target fails to compile with `static member 'nonFallback' cannot be used on protocol metatype '(any TeamDisplayable).Type'`. Swift doesn't allow invoking a static method declared in a protocol extension via the protocol type itself; it has to go through a conforming concrete type.
- Routes the 4 affected tests and the one production caller in `TeamViewController.swift` through `Team.nonFallback(...)` instead of `TeamDisplayable.nonFallback(...)`, which resolves through extension inheritance.
- Also reformats the multi-line guard in `APITeam+Helpers.swift` to satisfy swift-format (indentation + line break before `else`).

## Test plan
- [x] `cd Packages/TBAAPI && swift test` — all 143 tests pass locally.
- [x] `scripts/swift-format.sh --strict` — clean, no violations.
- [ ] CI `Test + Publish` job — green.
- [ ] CI `swift-format` job — green.
- [ ] Open a team without a nickname (e.g. a team whose only nickname is "Team N") — header still renders correctly with no duplicate "Team N" line.
- [ ] Open a team with a real nickname — header shows the nickname as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)