### PR TITLE
Remove Twitter/YouTube/Chief Delphi links from Event and Team Info

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -26,9 +26,6 @@ private enum EventInfoItem: Hashable {
     case insights
     case awards
     case website
-    case twitter
-    case youtube
-    case chiefDelphi
 }
 
 class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
@@ -132,18 +129,6 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
                     let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
                     cell.textLabel?.text = "View event's website"
                     return cell
-                case .twitter:
-                    let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
-                    cell.textLabel?.text = "View \(self.state.key) on Twitter"
-                    return cell
-                case .youtube:
-                    let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
-                    cell.textLabel?.text = "View \(self.state.key) on YouTube"
-                    return cell
-                case .chiefDelphi:
-                    let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
-                    cell.textLabel?.text = "View photos on Chief Delphi"
-                    return cell
                 }
             }
         )
@@ -188,12 +173,10 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         snapshot.appendSections([.detail])
         snapshot.appendItems(detailItems, toSection: .detail)
 
-        var linkItems: [EventInfoItem] = [.twitter, .youtube, .chiefDelphi]
         if state.event?.hasWebsite == true {
-            linkItems.insert(.website, at: 0)
+            snapshot.appendSections([.link])
+            snapshot.appendItems([.website], toSection: .link)
         }
-        snapshot.appendSections([.link])
-        snapshot.appendItems(linkItems, toSection: .link)
 
         dataSource.applySnapshotUsingReloadData(snapshot)
     }
@@ -252,12 +235,6 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
             urlString = webcast.urlString
         case .website:
             urlString = state.event?.website
-        case .twitter:
-            urlString = "https://twitter.com/search?q=%23\(state.key)"
-        case .youtube:
-            urlString = "https://www.youtube.com/results?search_query=\(state.key)"
-        case .chiefDelphi:
-            urlString = "https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A\(state.key)"
         default:
             break
         }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -12,9 +12,6 @@ private enum TeamInfoItem {
     case rookieYear
     case sponsors
     case website
-    case twitter
-    case youtube
-    case chiefDelphi
 }
 
 class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
@@ -77,18 +74,6 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
                     let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
                     cell.textLabel?.text = "View team's website"
                     return cell
-                case .twitter:
-                    let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
-                    cell.textLabel?.text = "View \(self.state.key) on Twitter"
-                    return cell
-                case .youtube:
-                    let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
-                    cell.textLabel?.text = "View \(self.state.key) on YouTube"
-                    return cell
-                case .chiefDelphi:
-                    let cell = self.tableView(tableView, linkCellForRowAt: indexPath)
-                    cell.textLabel?.text = "View photos on Chief Delphi"
-                    return cell
                 }
             }
         )
@@ -118,12 +103,10 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
         }
 
         // Links
-        var linkItems: [TeamInfoItem] = [.twitter, .youtube, .chiefDelphi]
         if team.hasWebsite {
-            linkItems.insert(.website, at: 0)
+            snapshot.appendSections([.link])
+            snapshot.appendItems([.website], toSection: .link)
         }
-        snapshot.appendSections([.link])
-        snapshot.appendItems(linkItems, toSection: .link)
 
         dataSource.applySnapshotUsingReloadData(snapshot)
     }
@@ -203,12 +186,6 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
             reloadSponsors()
         case .website:
             urlString = state.team?.website
-        case .twitter:
-            urlString = "https://twitter.com/search?q=%23\(state.key)"
-        case .youtube:
-            urlString = "https://www.youtube.com/results?search_query=\(state.key)"
-        case .chiefDelphi:
-            urlString = "https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A\(state.key)"
         default:
             break
         }


### PR DESCRIPTION
## Summary
- Drop the Twitter, YouTube, and Chief Delphi search-link rows from the Event Info and Team Info pages
- The link section now only renders when an actual website URL is available; otherwise it's omitted entirely

## Motivation
The Twitter hashtag-search URL no longer works on X, and the YouTube / Chief Delphi rows lead to broad search results that rarely match the event or team you're looking at. Removing them cleans up the Info page and removes a dead link.

## Test plan
- [ ] Open an event with a website → Link section shows a single "View event's website" row that opens the site
- [ ] Open an event without a website → no Link section appears at all (no empty section header)
- [ ] Open a team with a website → Link section shows a single "View team's website" row
- [ ] Open a team without a website → no Link section appears
- [ ] Confirm Twitter/YouTube/Chief Delphi rows no longer appear on either screen