### PR TITLE
Fix CI test job hanging up to 6 hours on iOS simulator

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,15 +9,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Read Xcode version
+        id: xcode
+        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version-file: .xcode-version
+          xcode-version: ${{ steps.xcode.outputs.version }}
       - name: Lint
         run: ./scripts/swift-format.sh --strict
 
   test:
     name: Test
     runs-on: macos-latest
+    timeout-minutes: 30
     env:
       # Fastlane scan/run_tests runs `xcodebuild -showBuildSettings` with a
       # tight timeout (3s → 6s → 12s → 24s, then gives up). On fresh CI
@@ -27,9 +31,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Read Xcode version
+        id: xcode
+        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version-file: .xcode-version
+          xcode-version: ${{ steps.xcode.outputs.version }}
       - uses: actions/cache@v5
         with:
           path: vendor/bundle

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,21 +12,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Read Xcode version
+        id: xcode
+        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version-file: .xcode-version
+          xcode-version: ${{ steps.xcode.outputs.version }}
       - name: Lint
         run: ./scripts/swift-format.sh --strict
 
   test-publish:
     name: Test + Publish
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Read Xcode version
+        id: xcode
+        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version-file: .xcode-version
+          xcode-version: ${{ steps.xcode.outputs.version }}
       - uses: actions/cache@v5
         with:
           path: vendor/bundle

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,7 @@ platform :ios do
       project: "the-blue-alliance-ios.xcodeproj",
       scheme: "The Blue Alliance",
       configuration: "Debug",
-      devices: [],
+      devices: ["iPhone 17 Pro"],
       skip_package_dependencies_resolution: true,
       xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )


### PR DESCRIPTION
## Summary
- The `setup-xcode` `xcode-version-file` input was being silently ignored ("Unexpected input(s) 'xcode-version-file'"), so the runner used its default Xcode instead of the pinned `26.3`. Read `.xcode-version` in a shell step and pass via `xcode-version:` so the pin actually applies.
- Add `timeout-minutes: 30` to the `test` / `test-publish` jobs as a failsafe — the last dependabot PR run sat at `Testing started` with zero output for 5h 53m before GHA's 6h cap killed it ([job](https://github.com/the-blue-alliance/the-blue-alliance-ios/actions/runs/26337193643)).
- Pin `test_app` in `Fastfile` to `devices: ["iPhone 17 Pro"]` so destination selection is deterministic instead of "first of multiple matching destinations."

## Test plan
- [ ] CI runs on this PR and the `Test` job completes (not cancelled at 6h)
- [ ] The setup-xcode step no longer logs `Unexpected input(s) 'xcode-version-file'`
- [ ] The xcodebuild log shows it selected an iPhone 17 Pro simulator (no more "Using the first of multiple matching destinations" warning)
- [ ] If the simulator wedges again, the job fails at 30 minutes rather than 6 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)