### PR TITLE
Pass full Event when pushing from Team@Event to Event

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -109,11 +109,8 @@ class TeamAtEventViewController: ContainerViewController {
 
     // MARK: - Private Methods
 
-    private func pushEvent() {
-        let eventViewController = EventViewController(
-            eventKey: eventKey,
-            dependencies: dependencies
-        )
+    private func pushEvent(_ event: Event) {
+        let eventViewController = EventViewController(event: event, dependencies: dependencies)
         navigationController?.pushViewController(eventViewController, animated: true)
     }
 
@@ -154,8 +151,8 @@ extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewC
         pushTeam(teamKey: teamKey)
     }
 
-    func eventSelected() {
-        pushEvent()
+    func eventSelected(_ event: Event) {
+        pushEvent(event)
     }
 
     func matchSelected(_ match: Match) {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 
 protocol TeamSummaryViewControllerDelegate: AnyObject {
     func teamInfoSelected(teamKey: String)
-    func eventSelected()
+    func eventSelected(_ event: Event)
     func matchSelected(_ match: Match)
 }
 
@@ -395,8 +395,8 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
 
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
         switch item {
-        case .event:
-            delegate?.eventSelected()
+        case .event(let event):
+            delegate?.eventSelected(event)
         case .teamInfo:
             delegate?.teamInfoSelected(teamKey: teamKey)
         case .match(let match, _):


### PR DESCRIPTION
## Summary
- `TeamAtEventViewController` was pushing `EventViewController` with only an `EventKey`, forcing the new screen to re-fetch the event. The Team@Event summary already loads the full `Event`, so plumb it through the `TeamSummaryViewControllerDelegate.eventSelected` callback and construct `EventViewController(event:dependencies:)` instead.
- Matches the existing pattern in `EventsContainerViewController` and `DistrictViewController`, which already pass the full `Event` when one is in hand.

## Test plan
- [ ] Open a team detail → tap an upcoming/past event → arrive at Team@Event.
- [ ] In the Team@Event "Summary" tab, tap the event header row → `EventViewController` should push with the event already populated (title/subtitle, info, matches) and no spinner waiting on the event fetch.
- [ ] Pull-to-refresh the Team@Event summary, then tap the event header again — still pushes with the refreshed event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)