### PR TITLE
Fix CI on main reporting failure after tests pass

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,12 +22,6 @@ jobs:
     name: Test
     runs-on: macos-latest
     timeout-minutes: 30
-    env:
-      # Fastlane scan/run_tests runs `xcodebuild -showBuildSettings` with a
-      # tight timeout (3s → 6s → 12s → 24s, then gives up). On fresh CI
-      # runners that's not enough when there's a large SPM graph to resolve.
-      # Bump to 180s first try so package resolution has room to breathe.
-      FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "180"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,6 +25,12 @@ jobs:
     name: Test + Publish
     runs-on: macos-latest
     timeout-minutes: 30
+    env:
+      # Fastlane scan/run_tests runs `xcodebuild -showBuildSettings` with a
+      # tight timeout (3s → 6s → 12s → 24s, then gives up). On fresh CI
+      # runners that's not enough when there's a large SPM graph to resolve.
+      # Bump to 180s first try so package resolution has room to breathe.
+      FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "180"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,12 +25,6 @@ jobs:
     name: Test + Publish
     runs-on: macos-latest
     timeout-minutes: 30
-    env:
-      # Fastlane scan/run_tests runs `xcodebuild -showBuildSettings` with a
-      # tight timeout (3s → 6s → 12s → 24s, then gives up). On fresh CI
-      # runners that's not enough when there's a large SPM graph to resolve.
-      # Bump to 180s first try so package resolution has room to breathe.
-      FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "180"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -1,15 +1,4 @@
-# Fastlane shells out to `xcodebuild -showBuildSettings` to discover values like
-# SUPPORTED_PLATFORMS and BUILT_PRODUCTS_DIR. Its default timeout ladder is
-# 3s -> 6s -> 12s -> 24s, but on a cold CI runner that command takes ~100s
-# because of the size of our Swift package graph.
-#
-# When it gives up: scan can't locate the .xcresult and reports a build failure
-# even though every test passed, and gym falls back to guessing the target
-# platform. Neither failure mentions the real cause, which makes this expensive
-# to re-diagnose.
-#
-# This lives here rather than in each workflow so that every lane picks it up --
-# scan on push and pull_request, gym on release, and local runs too. Dotenv does
-# not override variables already present in the environment, so an individual
-# workflow can still override it.
+# `xcodebuild -showBuildSettings` takes ~100s on a cold CI runner; fastlane gives
+# up after 3s by default, which breaks scan and gym. Set here rather than per
+# workflow so every lane gets it. Dotenv won't override an existing env var.
 FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=180

--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -1,0 +1,15 @@
+# Fastlane shells out to `xcodebuild -showBuildSettings` to discover values like
+# SUPPORTED_PLATFORMS and BUILT_PRODUCTS_DIR. Its default timeout ladder is
+# 3s -> 6s -> 12s -> 24s, but on a cold CI runner that command takes ~100s
+# because of the size of our Swift package graph.
+#
+# When it gives up: scan can't locate the .xcresult and reports a build failure
+# even though every test passed, and gym falls back to guessing the target
+# platform. Neither failure mentions the real cause, which makes this expensive
+# to re-diagnose.
+#
+# This lives here rather than in each workflow so that every lane picks it up --
+# scan on push and pull_request, gym on release, and local runs too. Dotenv does
+# not override variables already present in the environment, so an individual
+# workflow can still override it.
+FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=180

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,12 @@ platform :ios do
       configuration: "Debug",
       devices: ["iPhone 17 Pro"],
       skip_package_dependencies_resolution: true,
+      # Without this, scan has to guess the .xcresult location by diffing the
+      # derived data directory, which it can only find via
+      # `xcodebuild -showBuildSettings`. When that lookup fails, scan reports a
+      # build failure even though the tests passed. Passing an explicit
+      # -resultBundlePath removes the guesswork.
+      result_bundle: true,
       xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,11 +30,8 @@ platform :ios do
       configuration: "Debug",
       devices: ["iPhone 17 Pro"],
       skip_package_dependencies_resolution: true,
-      # Without this, scan has to guess the .xcresult location by diffing the
-      # derived data directory, which it can only find via
-      # `xcodebuild -showBuildSettings`. When that lookup fails, scan reports a
-      # build failure even though the tests passed. Passing an explicit
-      # -resultBundlePath removes the guesswork.
+      # Passes an explicit -resultBundlePath, so scan doesn't have to locate the
+      # .xcresult by diffing derived data.
       result_bundle: true,
       xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )


### PR DESCRIPTION
Every push to `main` has been red for months, but **the tests were never actually failing**.

## What's happening

From the most recent `On push` run ([32066781347](https://github.com/the-blue-alliance/the-blue-alliance-ios/actions/runs/32066781347)):

```
$ xcodebuild -showBuildSettings -scheme The\ Blue\ Alliance -project the-blue-alliance-ios.xcodeproj -configuration Debug
Command timed out after 3 seconds on try 1 of 4, trying again with a 6 second timeout...
Command timed out after 6 seconds on try 2 of 4, trying again with a 12 second timeout...
Command timed out after 12 seconds on try 3 of 4, trying again with a 24 second timeout...
Can't retrieve BUILT_PRODUCTS_DIR from the project to detect derived data path.
Either set `derived_data_path` explicitly in `scan`, or enable build for running in the scheme.
...
Test Succeeded
[!] Cannot find .xcresult in derived data which is needed to determine test results.
```

`xcodebuild -showBuildSettings` takes ~107s on a cold runner because of the size of our Swift package graph. Fastlane's default retry ladder is 3s → 6s → 12s → 24s, so it gives up first.

Without those settings, scan never learns `BUILT_PRODUCTS_DIR`. It falls back to locating the `.xcresult` by diffing `<derived_data>/Logs/Test/*.xcresult` before and after the run — and with no derived data path that diff is empty, so `trainer_test_results` in `scan/lib/scan/runner.rb` hard-fails. Note `Test Succeeded` immediately above the error: every test passed.

## Why PRs are green and `main` is red

`pull_request.yml` set `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "180"`, added in #1097. `push.yml` never got it. Same fastlane, same Xcode, same tests — just a missing env var on one of the two workflows.

## `release.yml` has the same problem

`gym` reaches the same call through a different door:

```
Gym.project.mac?  ->  supported_platforms  ->  build_settings(key: "SUPPORTED_PLATFORMS")
```

`gym/lib/gym/module.rb:37` runs on every gym invocation, iOS included, and `FastlaneCore::Project.xcode_build_settings_timeout` is global to fastlane. `release.yml` never had the env var either, so a cold release runner would hit the same wall — except gym's failure is quieter: it logs `Could not read the "SUPPORTED_PLATFORMS" build setting, assuming that the project supports iOS only` and carries on with guessed platform detection.

## The fix

1. **`fastlane/.env.default`** — a single `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=180`, auto-loaded by fastlane on every invocation. The inline `env:` blocks come out of `push.yml` and `pull_request.yml`. This covers scan on push/PR, gym on release, and local runs, and means a newly added workflow can't silently miss it — which is exactly how `push.yml` broke. `Dotenv.load` doesn't override variables already in the environment, so a workflow can still override it.
2. **`Fastfile`** — `result_bundle: true` on `run_tests`, so scan passes an explicit `-resultBundlePath` instead of inferring the `.xcresult` location from derived data. This is the remedy fastlane's own error message suggests, and it means a slow `-showBuildSettings` can't turn a passing test run red again. Output lands in `fastlane/test_output`, already gitignored.

## Verifying

The failure only reproduces on a cold CI runner, so **this PR's own `On pull request` run is the test**: `pull_request.yml` no longer sets the variable inline, so a green run proves `fastlane/.env.default` is being picked up. If dotenv weren't loading, this PR would fail the same way `main` does.

Locally confirmed that fastlane's dotenv discovery finds the file:

```ruby
Dir.glob(File.join("fastlane", "*.env*"), File::FNM_DOTMATCH)  # => ["fastlane/.env.default"]
Dotenv.load("fastlane/.env.default")                           # => "180"
```

`update_wiki.yml` runs on Ubuntu and never invokes fastlane, so it's unaffected.
