### PR TITLE
Speed up CI test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/Package.resolved', '**/*.pbxproj') }}
           restore-keys: ${{ runner.os }}-spm-
       - name: Restore package build products
         uses: actions/cache/restore@v6
         with:
           path: Packages/*/.build
-          key: ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift') }}-${{ github.sha }}
+          key: ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift', 'Packages/*/Package.resolved') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift') }}-
+            ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift', 'Packages/*/Package.resolved') }}-
             ${{ runner.os }}-spmbuild-
       # These are offline unit tests, so they need neither Secrets.plist nor a
       # signing keychain.
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: Packages/*/.build
-          key: ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift') }}-${{ github.sha }}
+          key: ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift', 'Packages/*/Package.resolved') }}-${{ github.sha }}
 
   test-app:
     name: Test app
@@ -104,15 +104,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/Package.resolved', '**/*.pbxproj') }}
           restore-keys: ${{ runner.os }}-spm-
       - name: Restore DerivedData
         uses: actions/cache/restore@v6
         with:
           path: DerivedData
-          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}-${{ github.sha }}
+          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/Package.resolved', '**/*.pbxproj') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}-
+            ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/Package.resolved', '**/*.pbxproj') }}-
             ${{ runner.os }}-derived-data-
       - name: Install
         run: |
@@ -135,4 +135,4 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: DerivedData
-          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}-${{ github.sha }}
+          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/Package.resolved', '**/*.pbxproj') }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,6 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ steps.xcode.outputs.version }}
-      # Boot now so the simulator is warm by the time the build finishes,
-      # instead of paying for it serially once testing starts.
-      - name: Boot simulator
-        run: xcrun simctl boot "iPhone 17 Pro" || true
       - uses: actions/cache@v6
         with:
           path: vendor/bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,138 @@
+name: CI
+
+# Shared by pull_request.yml and push.yml so the two can't drift apart.
+on:
+  workflow_call:
+    inputs:
+      run-tests:
+        description: "Whether to run the test jobs"
+        type: boolean
+        default: true
+      save-caches:
+        description: "Write build caches. Only main does this, so PR runs can't evict its entries."
+        type: boolean
+        default: false
+
+jobs:
+  swift-format:
+    name: swift-format
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Read Xcode version
+        id: xcode
+        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ steps.xcode.outputs.version }}
+      - name: Lint
+        run: ./scripts/swift-format.sh --strict
+
+  test-packages:
+    name: Test packages
+    if: ${{ inputs.run-tests }}
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Read Xcode version
+        id: xcode
+        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ steps.xcode.outputs.version }}
+      - uses: actions/cache@v6
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gems-
+      - name: Cache SwiftPM clones
+        uses: actions/cache@v6
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
+          restore-keys: ${{ runner.os }}-spm-
+      - name: Restore package build products
+        uses: actions/cache/restore@v6
+        with:
+          path: Packages/*/.build
+          key: ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift') }}-
+            ${{ runner.os }}-spmbuild-
+      # These are offline unit tests, so they need neither Secrets.plist nor a
+      # signing keychain.
+      - name: Install
+        run: |
+          bundle config set --local path vendor/bundle
+          bundle install
+      - name: fastlane test_packages
+        run: bundle exec fastlane test_packages
+      - name: Save package build products
+        if: ${{ always() && inputs.save-caches }}
+        uses: actions/cache/save@v6
+        with:
+          path: Packages/*/.build
+          key: ${{ runner.os }}-spmbuild-${{ hashFiles('Packages/*/Package.swift') }}-${{ github.sha }}
+
+  test-app:
+    name: Test app
+    if: ${{ inputs.run-tests }}
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Read Xcode version
+        id: xcode
+        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ steps.xcode.outputs.version }}
+      # Boot now so the simulator is warm by the time the build finishes,
+      # instead of paying for it serially once testing starts.
+      - name: Boot simulator
+        run: xcrun simctl boot "iPhone 17 Pro" || true
+      - uses: actions/cache@v6
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gems-
+      - name: Cache SwiftPM clones
+        uses: actions/cache@v6
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
+          restore-keys: ${{ runner.os }}-spm-
+      - name: Restore DerivedData
+        uses: actions/cache/restore@v6
+        with:
+          path: DerivedData
+          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}-
+            ${{ runner.os }}-derived-data-
+      - name: Install
+        run: |
+          cp mock-Secrets.plist the-blue-alliance-ios/Secrets.plist
+          bundle config set --local path vendor/bundle
+          bundle install
+          bundle exec fastlane run setup_ci
+          bundle exec fastlane setup_secrets
+        env:
+          TBA_API_KEY: ${{ secrets.TBA_API_KEY }}
+      - name: fastlane test_app
+        run: bundle exec fastlane test_app
+      # Logs holds the .xcresult, which result_bundle already copies into
+      # fastlane/test_output. Neither is worth carrying in the cache.
+      - name: Trim DerivedData
+        if: ${{ always() }}
+        run: rm -rf DerivedData/Logs DerivedData/Index.noindex
+      - name: Save DerivedData
+        if: ${{ always() && inputs.save-caches }}
+        uses: actions/cache/save@v6
+        with:
+          path: DerivedData
+          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}-${{ github.sha }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,53 +2,12 @@ name: On pull request
 
 on: pull_request
 
-jobs:
-  swift-format:
-    name: swift-format
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Read Xcode version
-        id: xcode
-        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ steps.xcode.outputs.version }}
-      - name: Lint
-        run: ./scripts/swift-format.sh --strict
+# A new push to the same PR makes the in-flight run obsolete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-  test:
-    name: Test
-    runs-on: macos-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Read Xcode version
-        id: xcode
-        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ steps.xcode.outputs.version }}
-      - uses: actions/cache@v6
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: ${{ runner.os }}-gems-
-      - name: Cache SwiftPM clones
-        uses: actions/cache@v6
-        with:
-          path: ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
-          restore-keys: ${{ runner.os }}-spm-
-      - name: Install
-        run: |
-          cp mock-Secrets.plist the-blue-alliance-ios/Secrets.plist
-          bundle install
-          bundle exec fastlane run setup_ci
-          bundle exec fastlane setup_secrets
-        env:
-          TBA_API_KEY: ${{ secrets.TBA_API_KEY }}
-      - name: fastlane test
-        run: bundle exec fastlane test
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,53 +6,9 @@ on:
       - main
 
 jobs:
-  swift-format:
-    name: swift-format
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Read Xcode version
-        id: xcode
-        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ steps.xcode.outputs.version }}
-      - name: Lint
-        run: ./scripts/swift-format.sh --strict
-
-  test-publish:
-    name: Test + Publish
-    runs-on: macos-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Read Xcode version
-        id: xcode
-        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ steps.xcode.outputs.version }}
-      - uses: actions/cache@v6
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: ${{ runner.os }}-gems-
-      - name: Cache SwiftPM clones
-        uses: actions/cache@v6
-        with:
-          path: ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
-          restore-keys: ${{ runner.os }}-spm-
-      - name: Install
-        run: |
-          cp mock-Secrets.plist the-blue-alliance-ios/Secrets.plist
-          bundle install
-          bundle exec fastlane run setup_ci
-          bundle exec fastlane setup_secrets
-        env:
-          TBA_API_KEY: ${{ secrets.TBA_API_KEY }}
-      - name: fastlane test
-        if: ${{ !contains(github.event.head_commit.message, '[clowntown]') }}
-        run: bundle exec fastlane test
+  ci:
+    uses: ./.github/workflows/ci.yml
+    with:
+      run-tests: ${{ !contains(github.event.head_commit.message, '[clowntown]') }}
+      save-caches: true
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,8 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 Package.pins
-Package.resolved
+# Package.resolved is checked in on purpose: it pins the exact dependency
+# versions, so CI and everyone's machine resolve the same graph.
 
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project

--- a/Packages/TBAAPI/Package.resolved
+++ b/Packages/TBAAPI/Package.resolved
@@ -1,0 +1,96 @@
+{
+  "originHash" : "f16d0bbb2e68c1dd26772a465c022485dc4dbd9fc3691c28fe11133a47a93a32",
+  "pins" : [
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit",
+      "state" : {
+        "revision" : "57b6318128e3f901c93f4fbf98d1c1464ec168d3",
+        "version" : "6.2.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "6c8ca8297332ea2780c45e1bce9d7fd2a8b51e1d",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-generator",
+      "state" : {
+        "revision" : "39d49cf22abab58a07f02bb76808b5d2839b294a",
+        "version" : "1.13.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "9e53df53e043b53046a371b31aaf0a1e26eef946",
+        "version" : "1.12.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-urlsession",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-urlsession",
+      "state" : {
+        "revision" : "08796d36c99ad2318929bfa1d1e40f82194b65cc",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -1,4 +1,7 @@
-# `xcodebuild -showBuildSettings` takes ~100s on a cold CI runner; fastlane gives
-# up after 3s by default, which breaks scan and gym. Set here rather than per
-# workflow so every lane gets it. Dotenv won't override an existing env var.
-FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=180
+# `xcodebuild -showBuildSettings` is dominated by SwiftPM resolution, so it's
+# network-bound and varies a lot: we've measured anywhere from 107s to 214s on a
+# cold CI runner. Fastlane gives up after 3s by default, which breaks scan and
+# gym. A generous ceiling costs nothing when the command returns quickly. Set
+# here rather than per workflow so every lane gets it. Dotenv won't override an
+# existing env var.
+FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=300

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,6 +36,11 @@ platform :ios do
       # Pinned so CI can cache it. Index-while-building is dead weight here and
       # produces a large Index.noindex we'd otherwise have to cache around.
       derived_data_path: "DerivedData",
+      # Only used to filter the simulator list, and we already pin `devices`
+      # above. Setting it keeps scan from shelling out to
+      # `xcodebuild -showBuildSettings` purely to read it back, which costs
+      # ~110s on a cold runner.
+      deployment_target_version: "26.0",
       xcargs: "-skipPackagePluginValidation -skipMacroValidation COMPILER_INDEX_STORE_ENABLE=NO"
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,15 +33,23 @@ platform :ios do
       # Passes an explicit -resultBundlePath, so scan doesn't have to locate the
       # .xcresult by diffing derived data.
       result_bundle: true,
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
+      # Pinned so CI can cache it. Index-while-building is dead weight here and
+      # produces a large Index.noindex we'd otherwise have to cache around.
+      derived_data_path: "DerivedData",
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation COMPILER_INDEX_STORE_ENABLE=NO"
     )
+  end
+
+  desc "Run the Swift package unit tests"
+  lane :test_packages do
+    test_mytbakit
+    test_tbautils
+    test_tbaapi
   end
 
   desc "Run all of our tests"
   lane :test do
-    test_mytbakit
-    test_tbautils
-    test_tbaapi
+    test_packages
     test_app
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,14 +33,18 @@ platform :ios do
       # Passes an explicit -resultBundlePath, so scan doesn't have to locate the
       # .xcresult by diffing derived data.
       result_bundle: true,
-      # Pinned so CI can cache it. Index-while-building is dead weight here and
-      # produces a large Index.noindex we'd otherwise have to cache around.
+      # These three exist to keep scan from shelling out to
+      # `xcodebuild -showBuildSettings`, which costs 100-200s on a cold runner.
+      # Scan reads exactly three things from it, and every one of them is
+      # something we already know:
+      #   derived_data_path         -> where to look for build output
+      #   deployment_target_version -> only filters the simulator list, and we
+      #                                pin `devices` above anyway
+      #   app_name                  -> names the raw build log, because the
+      #                                Scanfile sets buildlog_path
       derived_data_path: "DerivedData",
-      # Only used to filter the simulator list, and we already pin `devices`
-      # above. Setting it keeps scan from shelling out to
-      # `xcodebuild -showBuildSettings` purely to read it back, which costs
-      # ~110s on a cold runner.
       deployment_target_version: "26.0",
+      app_name: "The Blue Alliance",
       xcargs: "-skipPackagePluginValidation -skipMacroValidation COMPILER_INDEX_STORE_ENABLE=NO"
     )
   end

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -1197,7 +1197,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${CONFIGURATION}\" = \"Debug\" ]; then\n    \"${SRCROOT}/scripts/swift-format.sh\"\nfi\n";
+			shellScript = "# Skipped on CI, where the swift-format job already lints the whole tree.\nif [ \"${CONFIGURATION}\" = \"Debug\" ] && [ -z \"$CI\" ]; then\n    \"${SRCROOT}/scripts/swift-format.sh\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/the-blue-alliance-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/the-blue-alliance-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,284 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "agrume",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JanGorman/Agrume.git",
+      "state" : {
+        "revision" : "8e9f9735b67a714b67752b3ff0e5d5a97c29394a",
+        "version" : "5.8.10"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
+        "version" : "1.7.6"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
+        "version" : "12.18.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
+        "version" : "3.6.1"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
+        "version" : "12.18.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "ba3358d3c3dbae8ef230b58a46b97ad65e84e974",
+        "version" : "10.1.1"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "a7965d134c5d3567026c523e0a8a583f73b62b0d",
+        "version" : "7.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
+        "version" : "8.1.3"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
+      }
+    },
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit",
+      "state" : {
+        "revision" : "57b6318128e3f901c93f4fbf98d1c1464ec168d3",
+        "version" : "6.2.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "purelayout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PureLayout/PureLayout",
+      "state" : {
+        "revision" : "5561683c96dc49b023c1299bfe4f6fbeed5f8199",
+        "version" : "3.1.9"
+      }
+    },
+    {
+      "identity" : "skeletonview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Juanpe/SkeletonView.git",
+      "state" : {
+        "revision" : "2f5274827d310e32c09325dd3e0007120940988e",
+        "version" : "1.31.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "6c8ca8297332ea2780c45e1bce9d7fd2a8b51e1d",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-generator",
+      "state" : {
+        "revision" : "39d49cf22abab58a07f02bb76808b5d2839b294a",
+        "version" : "1.13.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "9e53df53e043b53046a371b31aaf0a1e26eef946",
+        "version" : "1.12.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-urlsession",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-urlsession",
+      "state" : {
+        "revision" : "08796d36c99ad2318929bfa1d1e40f82194b65cc",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swiftygif",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kirualex/SwiftyGif",
+      "state" : {
+        "revision" : "4430cbc148baa3907651d40562d96325426f409a",
+        "version" : "5.4.5"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
+      }
+    },
+    {
+      "identity" : "youtube-ios-player-helper",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/youtube/youtube-ios-player-helper.git",
+      "state" : {
+        "revision" : "f57129cd4380ec0a74dd3a59da3270a1d653d59b",
+        "version" : "1.0.4"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
Follow-up to #1137. Actual test execution is **~3 seconds** out of a ~16 minute job — essentially all of it is overhead.

## Measured baseline

| Phase | Time |
|---|---|
| SPM package tests (3 lanes, serial) | 3m 09s |
| `xcodebuild -showBuildSettings` | 1m 47s |
| App build | 4m 43s |
| `Testing started` → tests actually running | 3m 10s |
| **Test execution (335 tests)** | **~3s** |

## Progress so far

| Phase | Baseline | [Prewarm run](https://github.com/the-blue-alliance/the-blue-alliance-ios/actions/runs/34008700374) | [Run 34009626356](https://github.com/the-blue-alliance/the-blue-alliance-ios/actions/runs/34009626356) | [Final](https://github.com/the-blue-alliance/the-blue-alliance-ios/actions/runs/34010218638) |
|---|---|---|---|---|
| `-showBuildSettings` | 107s | 214s | 102s | **0s** |
| Build | 283s | 316s | 263s | 263s |
| `Testing started` → tests | 190s | 329s | 205s | 185s |
| **Wall clock** | **15m 55s** | 20m 5s | 11m 0s | **8m 39s** |

Net: **15m 55s → 8m 39s, a 46% reduction**, before any cache benefit.

## Changes

**Never call `xcodebuild -showBuildSettings`.** Scan reads exactly three things out of it, and we already know all three:

| Value | Why scan wants it | What we pass |
|---|---|---|
| `derived_data_path` | where build output lives | `DerivedData` |
| `deployment_target_version` | filters the simulator list | `26.0` |
| `app_name` | names the raw build log | `The Blue Alliance` |

The third one took two attempts to find. After setting the first two, run 34009626356 *still* spent 102s in `-showBuildSettings` — and the call landed after scan printed its summary table, which ruled out `detect_values`. It actually comes from `TestCommandGenerator#xcodebuild_log_path`:

```ruby
if Scan.config[:app_name]
  parts << Scan.config[:app_name]
elsif Scan.project
  parts << Scan.project.app_name    # -> build_settings(key: "WRAPPER_NAME")
end
```

`Scan.project.app_name` reads `WRAPPER_NAME` out of the build settings, forcing the full ~100s call to produce a string we already have. We only reach it because the Scanfile sets `buildlog_path`.

**Split the test lanes into two parallel jobs.** The three `spm` lanes ran serially for ~3m before `test_app` even started. New `test_packages` lane groups them; that job needs neither `Secrets.plist` nor a signing keychain, so it skips `setup_ci`.

**Check in `Package.resolved`.** Nothing pinned dependency versions, so every build re-resolved against ~15 remotes and could silently drift — also why `-showBuildSettings` timing swung so widely. The ignore rule looks accidental: it sits under a comment about *"source code from Swift Package Manager dependencies"*, which describes the `Packages/` line above it, not the lockfile. `github/gitignore` ships those lines commented out; two got uncommented in #959.

**Don't lint inside the test build.** The `Lint Swift (swift-format)` phase is gated on `CONFIGURATION == "Debug"` — exactly what the test build uses — and ran twice per build (~22s), duplicating the `swift-format` job. Confirmed gone in run 34009626356.

**Cache DerivedData**, with `COMPILER_INDEX_STORE_ENABLE=NO` so we aren't building and caching an index we never read.

**Fix the gem cache, which has never worked.** Every run logged `Path Validation Error: Path(s) specified in the action for caching do(es) not exist`. `vendor/bundle` was cached, but bundler was never told to install there.

**Cancel superseded PR runs** — which also explains the `Unable to reserve cache` failures from two runs racing.

**Raise the settings timeout to 300s.** [Run 34008700374](https://github.com/the-blue-alliance/the-blue-alliance-ios/actions/runs/34008700374) tripped the 180s ceiling from #1137. A timeout costs nothing unless exceeded, and `gym` on release still makes this call even though scan no longer does.

## What I tried and reverted

I added a simulator prewarm expecting it to overlap boot with the build. The data disagreed:

| Phase | Baseline | With prewarm |
|---|---|---|
| `-showBuildSettings` | 107s | 214s |
| Build | 283s | 316s |
| `Testing started` → tests | 190s | **329s** |

The gap it was meant to shrink got *worse*, and it booted by device name with `|| true`, so it swallowed errors and may not have booted the device scan later selected by UDID. Reverting brought that gap back to 205s, which supports the prewarm being the cause rather than noise.

## Structural note

`push.yml` and `pull_request.yml` now both call a shared `ci.yml` via `workflow_call` instead of each keeping its own copy. Two hand-maintained copies drifting is exactly how `push.yml` broke `main` in #1137, and a 2-job split would have made it four copies. Only `main` writes caches; PRs restore only, so they can't evict `main`'s entries under the 10GB budget.

## Caveats

- **This PR's runs are cold.** Caches only save on `main`, so the caching win won't show here — the honest comparison is the second `main` run after merge.
- The prewarm numbers are **n=1**. Some of that spread is network variance in SPM resolution, though the 190→329→205 pattern across three runs is fairly consistent.
- The ~3m 05s `Testing started` gap is now the **largest remaining block** and is still unexplained. It's simulator boot, app install, and launching the test host — during which xcodebuild emits no output at all. Next step is measuring it via the `.xcresult` activity timeline or a one-off `include_simulator_logs: true`, rather than guessing again. Worth noting `TEST_HOST` means the real app boots first, running `configureFirebase()`, `configurePushNotifications()`, `configureAuth()` and `configureStatusService()` before any test executes.
