### PR TITLE
Fix UIRefreshControl offscreen beginRefreshing warning on launch

### DIFF
--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -57,18 +57,39 @@ extension Refreshable {
             if self.isRefreshing {
                 self.hideNoData()
 
-                let refreshControlHeight = self.refreshControl?.frame.size.height ?? 0
-                self.refreshView.setContentOffset(
-                    CGPoint(x: 0, y: -refreshControlHeight),
-                    animated: true
-                )
-                self.refreshControl?.beginRefreshing()
+                self.showRefreshControl()
             } else {
                 self.refreshControl?.endRefreshing()
 
                 self.noDataReload()
             }
         }
+    }
+
+    /// Spins the refresh control and scrolls it into view.
+    ///
+    /// UIKit ignores `beginRefreshing()` while the scroll view is offscreen, and refreshes
+    /// start from `viewWillAppear` - before the view is in a window. `viewDidAppear` calls
+    /// `updateRefresh()` again to pick up anything still in flight.
+    func showRefreshControl() {
+        guard refreshView.window != nil else {
+            return
+        }
+
+        let refreshControlHeight = refreshControl?.frame.size.height ?? 0
+        refreshView.setContentOffset(
+            CGPoint(x: 0, y: -refreshControlHeight),
+            animated: true
+        )
+        refreshControl?.beginRefreshing()
+    }
+
+    /// Shows the indicator for a refresh that started while we were offscreen.
+    func updateRefreshOnAppear() {
+        guard isRefreshing else {
+            return
+        }
+        updateRefresh()
     }
 
     func enableRefreshing() {

--- a/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBACollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBACollectionViewController.swift
@@ -52,6 +52,12 @@ class TBACollectionViewController: UICollectionViewController, DataController, N
         collectionView.registerReusableCell(BasicCollectionViewCell.self)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        (self as? any Refreshable)?.updateRefreshOnAppear()
+    }
+
 }
 
 extension Refreshable where Self: TBACollectionViewController {

--- a/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBATableViewController.swift
@@ -57,6 +57,12 @@ class TBATableViewController: UITableViewController, DataController, Navigatable
         }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        (self as? any Refreshable)?.updateRefreshOnAppear()
+    }
+
     // MARK: - UITableViewDelegate
 
     override func tableView(

--- a/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBAViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBAViewController.swift
@@ -58,6 +58,12 @@ class TBAViewController: UIViewController, DataController, Navigatable {
         scrollView.autoPinEdgesToSuperviewEdges()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        (self as? any Refreshable)?.updateRefreshOnAppear()
+    }
+
     // TODO: https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/133
     func reloadData() {
         fatalError("Implement this downstream")

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -187,6 +187,12 @@ class MyTBATableViewController: UIViewController, NotificationObservable, DataCo
         }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        (self as? any Refreshable)?.updateRefreshOnAppear()
+    }
+
     // MARK: Subclass Hooks
 
     /// The entries to display, grouped by `MyTBASection` order.


### PR DESCRIPTION
Every launch logs:

```
A UIRefreshControl received offscreen beginRefreshing. Ignored. Break on
UIRefreshControlReceivedOffscreenBeginRefreshing to debug.
<UIRefreshControl: 0x1144a0780; frame = (0 -60; 0 60); ...>
```

### Cause

`ContainerViewController.viewWillAppear` → `show(view:)` → `refresh()` kicks off a refresh, which lands in `Refreshable.updateRefresh()` and calls `beginRefreshing()`. `viewWillAppear` runs *before* the view is added to the window — both when the window's root view controller is first shown and on every tab switch — so UIKit drops the call and logs the warning.

### Fix

- `showRefreshControl()` guards on `refreshView.window != nil`, so we don't ask UIKit to spin a control nobody can see.
- The data controllers (`TBATableViewController`, `TBACollectionViewController`, `TBAViewController`, `MyTBATableViewController`) call `updateRefreshOnAppear()` from `viewDidAppear`, so a refresh that's still in flight picks up its spinner as soon as it's on screen.

### Testing

Streamed the simulator log across launch and tab switches on iPhone 17 Pro:

- **Before:** warning fires on launch, and again on the first switch to each tab.
- **After:** no occurrences.

Pull-to-refresh and the programmatic refresh indicator still behave the same, and lists load as before.