### PR TITLE
Avoid laying out the Team container's tables while offscreen

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -263,7 +263,10 @@ class TeamViewController: HeaderContainerViewController {
             // hideLoadingSkeleton itself so its slot collapse/expand animates
             // in sync with the skeleton fade-out.
             updateInterface()
-            teamHeaderView.layoutIfNeeded()
+            // Only worth settling the layout if there's an animation to run against it.
+            if teamHeaderView.window != nil {
+                teamHeaderView.layoutIfNeeded()
+            }
             teamHeaderView.hideLoadingSkeleton(revealing: avatarImage)
         }
     }

--- a/the-blue-alliance-ios/ViewElements/Teams/TeamHeaderView.swift
+++ b/the-blue-alliance-ios/ViewElements/Teams/TeamHeaderView.swift
@@ -275,6 +275,31 @@ class TeamHeaderView: UIView {
 
     // MARK: Private Methods
 
+    /// Animates `changes`, or applies them immediately when we're offscreen.
+    ///
+    /// `layoutIfNeeded()` lays out from the topmost dirty ancestor, which drags the
+    /// container's table views along with it - off-window that's an unnecessary layout
+    /// pass UIKit warns about.
+    private func animateLayout(
+        _ changes: @escaping () -> Void,
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        guard window != nil else {
+            changes()
+            completion?(true)
+            return
+        }
+
+        UIView.animate(
+            withDuration: 0.25,
+            animations: {
+                changes()
+                self.layoutIfNeeded()
+            },
+            completion: completion
+        )
+    }
+
     private func configureView() {
         // Avatar is intentionally NOT touched here — it's driven by the
         // explicit avatar API (setAvatar / transitionAvatar / hide…Skeleton)
@@ -318,20 +343,14 @@ class TeamHeaderView: UIView {
             avatarImageView.image = image
             avatarImageView.isHidden = false
             avatarImageView.alpha = 0
-            UIView.animate(
-                withDuration: 0.25,
-                animations: {
-                    self.avatarImageView.alpha = 1
-                    self.layoutIfNeeded()
-                }
-            )
+            animateLayout {
+                self.avatarImageView.alpha = 1
+            }
         case (.some, nil):
-            UIView.animate(
-                withDuration: 0.25,
-                animations: {
+            animateLayout(
+                {
                     self.avatarImageView.alpha = 0
                     self.avatarImageView.isHidden = true
-                    self.layoutIfNeeded()
                 },
                 completion: { _ in
                     self.avatarImageView.image = nil
@@ -393,9 +412,8 @@ class TeamHeaderView: UIView {
         avatarImageView.image = avatar
         let willHaveAvatar = avatar != nil
 
-        UIView.animate(
-            withDuration: 0.25,
-            animations: {
+        animateLayout(
+            {
                 self.skeletonStackView.alpha = 0
                 self.teamNameLabel.alpha = 1
                 self.yearButton.alpha = 1
@@ -406,7 +424,6 @@ class TeamHeaderView: UIView {
                     self.avatarImageView.alpha = 0
                     self.avatarImageView.isHidden = true
                 }
-                self.layoutIfNeeded()
             },
             completion: { _ in
                 self.skeletonStackView.isHidden = true
@@ -431,9 +448,8 @@ class TeamHeaderView: UIView {
         avatarImageView.image = avatar
         let willHaveAvatar = avatar != nil
 
-        UIView.animate(
-            withDuration: 0.25,
-            animations: {
+        animateLayout(
+            {
                 self.avatarSkeletonOverlay.alpha = 0
                 if willHaveAvatar {
                     self.avatarImageView.isHidden = false
@@ -442,7 +458,6 @@ class TeamHeaderView: UIView {
                     self.avatarImageView.alpha = 0
                     self.avatarImageView.isHidden = true
                 }
-                self.layoutIfNeeded()
             },
             completion: { _ in
                 self.avatarSkeletonOverlay.isHidden = true


### PR DESCRIPTION
Fixes this warning:

```
Warning once only: UITableView was told to layout its visible cells and other
contents without being in the view hierarchy (the table view or one of its
superviews has not been added to a window). ...
Table view: <UITableView: 0x10462d570; frame = (0 0; 402 669.667); ...
  animations = { bounds.size=<CABasicAnimation>; position=<CABasicAnimation>; };
  contentSize: {402, 843.33333333333292};
  dataSource: <...EventsListDataSource: 0x1144560c0>>
```

### Cause

`TeamHeaderView` calls `layoutIfNeeded()` inside `UIView.animate` in `hideLoadingSkeleton`, `hideAvatarSkeleton` and `transitionAvatar`. `layoutIfNeeded()` lays out from the topmost ancestor that needs layout — here the whole `HeaderContainerViewController`, including the `TeamEventsViewController` table hosted in its container view.

`loadTeamData()` runs unstructured and isn't cancelled on disappear, so when the team/avatar requests land after you've navigated away, that layout pass runs on a table view that's no longer in the window.

That matches the logged table exactly: an `EventsListDataSource` table that already has content, plus `bounds.size`/`position` animations picked up from the enclosing animation block.

### Fix

- `TeamHeaderView.animateLayout(_:completion:)` applies the end state directly when the header isn't in a window, instead of animating a forced layout nobody can see.
- `TeamViewController` skips its pre-animation `teamHeaderView.layoutIfNeeded()` for the same reason.

### Testing

The Team screen's header reveal (avatar, nickname, year pill, skeleton cross-fade) is unchanged on screen — verified against a build of `main` on iPhone 17 Pro.

Note: this one is a race that only warns once per process, so I couldn't trigger it on demand; the fix is based on tracing the logged table view back to the only code path that lays it out from an animation block. Worth a close look in review.