### PR TITLE
Fix package tests failing on the OpenAPIGenerator plugin

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,10 @@ TEST_DEVICES = ["iPhone 17 Pro"].freeze
 TEST_OUTPUT_DIR = File.expand_path("test_output", __dir__).freeze
 DERIVED_DATA_DIR = File.expand_path("../DerivedData", __dir__).freeze
 
+# Build tool plugins (TBAAPI's OpenAPIGenerator) and macros are only trusted
+# through Xcode's UI, so xcodebuild won't run them on CI without these.
+TEST_XCARGS = "-skipPackagePluginValidation -skipMacroValidation COMPILER_INDEX_STORE_ENABLE=NO".freeze
+
 RELEASE_LANES = [:beta_ci, :app_store].freeze
 RELEASE_CHANNEL = "#app-releases".freeze
 RELEASE_BOT_ICON_URL = "https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-logo/master/ios/tba-icon-60%403x.png".freeze
@@ -84,7 +88,7 @@ platform :ios do
       derived_data_path: "DerivedData",
       deployment_target_version: "26.0",
       app_name: "The Blue Alliance",
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation COMPILER_INDEX_STORE_ENABLE=NO"
+      xcargs: TEST_XCARGS
     )
   end
 
@@ -312,7 +316,8 @@ platform :ios do
       devices: TEST_DEVICES,
       derived_data_path: DERIVED_DATA_DIR,
       result_bundle: true,
-      output_directory: output_directory
+      output_directory: output_directory,
+      xcargs: TEST_XCARGS
     )
   end
 


### PR DESCRIPTION
`Test packages` has been red on `main` since 858b0322. The TBAAPI lane never runs a test — it fails during the build:

```
Plugin “OpenAPIGenerator” from package “swift-openapi-generator” must be enabled before it can be used
Testing cancelled because the build failed.
```

TBAAPI generates its client with the `OpenAPIGenerator` build tool plugin. Build tool plugins are only ever trusted through Xcode's UI, which CI doesn't have, so `xcodebuild` refuses to run one unless you pass `-skipPackagePluginValidation`.

`test_app` already passed that flag, which is why `Test app` stayed green while `Test packages` went red. The package lanes never did — it just didn't matter until 858b0322 moved them off `spm`/`swift test` (which trusts plugins without asking) and onto scan.

It doesn't reproduce on a dev machine, which is what makes this an easy one to miss: Xcode writes the trust to `~/Library/org.swift.swiftpm/security/plugins.json` the first time you build the package, and every build after that is fine.

### The fix

Pass the same flags the app lane uses, hoisted into a shared `TEST_XCARGS` so the app and the packages can't drift apart like this again. `COMPILER_INDEX_STORE_ENABLE=NO` comes along with it — the index store is only read by the Xcode UI, and the packages job already deletes `DerivedData/Index.noindex` before caching.

### Verification

Reproduced locally by moving `plugins.json` aside to match a fresh runner, against a clean derived data dir each time:

| Command | Result |
|---|---|
| `xcodebuild … build-for-testing` | ❌ `** TEST BUILD FAILED **` — `Validate plug-in "OpenAPIGenerator"` |
| `xcodebuild … -skipPackagePluginValidation -skipMacroValidation COMPILER_INDEX_STORE_ENABLE=NO build-for-testing` | ✅ `** TEST BUILD SUCCEEDED **` |

Trust file restored afterward.
