### PR TITLE
Run search filtering off the main actor; fix all-teams search only narrowing

### DIFF
--- a/TBAUnitTests/Mocks/DependenciesMocks.swift
+++ b/TBAUnitTests/Mocks/DependenciesMocks.swift
@@ -1,0 +1,109 @@
+import Foundation
+import MyTBAKit
+import TBAAPI
+import TBAAuth
+import UIKit
+
+@testable import The_Blue_Alliance
+
+struct Unstubbed: Error {}
+
+/// Every endpoint throws until a test stubs it; add a stored property per endpoint as needed.
+@MainActor
+final class MockTBAAPI: TBAAPIProtocol {
+
+    var teams: [TeamSimple] = []
+
+    func setCachePolicy(_ policy: TBAAPI.CachePolicy) async {}
+    func clearCache() async {}
+    func getStatus() async throws -> APIStatus { throw Unstubbed() }
+    func getSearchIndex() async throws -> SearchIndex { throw Unstubbed() }
+    func allTeams() async throws -> [Team] { throw Unstubbed() }
+    func allTeamsSimple() async throws -> [TeamSimple] { teams }
+    func team(key teamKey: TeamKey) async throws -> Team { throw Unstubbed() }
+    func teamYearsParticipated(key teamKey: TeamKey) async throws -> [Int] { throw Unstubbed() }
+    func teamEventsByYear(key teamKey: TeamKey, year: Int) async throws -> [Event] { throw Unstubbed() }
+    func teamEventMatches(teamKey: TeamKey, eventKey: EventKey) async throws -> [Match] { throw Unstubbed() }
+    func teamEventAwards(teamKey: TeamKey, eventKey: EventKey) async throws -> [Award] { throw Unstubbed() }
+    func teamEventStatus(teamKey: TeamKey, eventKey: EventKey) async throws -> TeamEventStatus { throw Unstubbed() }
+    func teamMediaByYear(teamKey: TeamKey, year: Int) async throws -> [Media] { throw Unstubbed() }
+    func eventTeamsStatuses(key eventKey: EventKey) async throws -> [String: TeamEventStatus] { throw Unstubbed() }
+    func eventsByYear(_ year: Int) async throws -> [Event] { throw Unstubbed() }
+    func event(key eventKey: EventKey) async throws -> Event { throw Unstubbed() }
+    func eventTeams(key eventKey: EventKey) async throws -> [Team] { throw Unstubbed() }
+    func eventTeamsSimple(key eventKey: EventKey) async throws -> [TeamSimple] { throw Unstubbed() }
+    func eventRankings(key eventKey: EventKey) async throws -> EventRanking { throw Unstubbed() }
+    func eventAlliances(key eventKey: EventKey) async throws -> [EliminationAlliance]? { throw Unstubbed() }
+    func eventAwards(key eventKey: EventKey) async throws -> [Award] { throw Unstubbed() }
+    func eventDistrictPoints(key eventKey: EventKey) async throws -> EventDistrictPoints { throw Unstubbed() }
+    func eventInsights(key eventKey: EventKey) async throws -> EventInsights { throw Unstubbed() }
+    func eventMatches(key eventKey: EventKey) async throws -> [Match] { throw Unstubbed() }
+    func match(key matchKey: String) async throws -> Match { throw Unstubbed() }
+    func eventOPRs(key eventKey: EventKey) async throws -> EventOPRs { throw Unstubbed() }
+    func districtsByYear(_ year: Int) async throws -> [District] { throw Unstubbed() }
+    func districtEvents(key districtKey: String) async throws -> [Event] { throw Unstubbed() }
+    func districtTeams(key districtKey: String) async throws -> [Team] { throw Unstubbed() }
+    func districtTeamsSimple(key districtKey: String) async throws -> [TeamSimple] { throw Unstubbed() }
+    func districtRankings(key districtKey: String) async throws -> [DistrictRanking]? { throw Unstubbed() }
+
+}
+
+final class MockStatusService: StatusServiceProtocol {
+    var status: AppStatus = .default
+    var currentSeason: Int { status.currentSeason }
+    var maxSeason: Int { status.maxSeason }
+    func registerForStatusChanges(_ subscriber: StatusSubscribable) {}
+    func registerForFMSStatusChanges(_ subscriber: FMSStatusSubscribable) {}
+    func registerForEventStatusChanges(_ subscriber: EventStatusSubscribable, eventKey: EventKey) {}
+    func start() {}
+}
+
+final class MockURLOpener: URLOpener {
+    private(set) var opened: [URL] = []
+    func canOpenURL(_ url: URL) -> Bool { true }
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
+    ) {
+        opened.append(url)
+        completion?(true)
+    }
+}
+
+extension Dependencies {
+
+    static func mock(api: MockTBAAPI = MockTBAAPI()) -> Dependencies {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let callLog = CallLog()
+        let authService = MockAuthService(callLog: callLog)
+        let myTBA = MockSessionMyTBA(callLog: callLog)
+        let reporter = MockReporter()
+        let stores = MyTBAStores(
+            favorites: FavoritesStore(fileURL: directory.appendingPathComponent("favorites.json")),
+            subscriptions: SubscriptionsStore(
+                fileURL: directory.appendingPathComponent("subscriptions.json")
+            )
+        )
+        return Dependencies(
+            api: api,
+            appSettings: AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!),
+            authService: authService,
+            myTBA: myTBA,
+            myTBAStores: stores,
+            myTBASession: MyTBASessionService(
+                authService: authService,
+                myTBA: myTBA,
+                myTBAStores: stores,
+                pushService: MockPushService(callLog: callLog),
+                reporter: reporter,
+                applicationState: { .active }
+            ),
+            reporter: reporter,
+            statusService: MockStatusService(),
+            urlOpener: MockURLOpener()
+        )
+    }
+
+}

--- a/TBAUnitTests/ViewControllers/Match/MatchBreakdownViewControllerTests.swift
+++ b/TBAUnitTests/ViewControllers/Match/MatchBreakdownViewControllerTests.swift
@@ -1,0 +1,28 @@
+import Testing
+
+@testable import The_Blue_Alliance
+
+@MainActor
+struct MatchBreakdownViewControllerTests {
+
+    @Test(arguments: [2013, 2014])
+    func yearsWithoutABreakdownDoNotSupportRefreshing(_ year: Int) {
+        let controller = MatchBreakdownViewController(
+            matchKey: "\(year)test_qm1",
+            year: year,
+            dependencies: .mock()
+        )
+        #expect(!controller.supportsRefreshing)
+    }
+
+    @Test(arguments: [2015, 2020, 2021, 2026])
+    func yearsWithABreakdownSupportRefreshing(_ year: Int) {
+        let controller = MatchBreakdownViewController(
+            matchKey: "\(year)test_qm1",
+            year: year,
+            dependencies: .mock()
+        )
+        #expect(controller.supportsRefreshing)
+    }
+
+}

--- a/TBAUnitTests/ViewControllers/Teams/TeamsListViewControllerTests.swift
+++ b/TBAUnitTests/ViewControllers/Teams/TeamsListViewControllerTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import TBAAPI
+import Testing
+
+@testable import The_Blue_Alliance
+
+@MainActor
+struct TeamsListViewControllerTests {
+
+    private static func team(_ number: Int, _ nickname: String) -> TeamSimple {
+        TeamSimple(key: "frc\(number)", teamNumber: number, nickname: nickname, name: nickname)
+    }
+
+    private static func makeController() -> TeamsViewController {
+        let api = MockTBAAPI()
+        api.teams = [team(254, "The Cheesy Poofs"), team(2590, "Nemesis"), team(1114, "Simbotics")]
+        let controller = TeamsViewController(dependencies: .mock(api: api))
+        controller.loadViewIfNeeded()
+        return controller
+    }
+
+    /// The search filter runs off the main actor, so results land a tick later.
+    private static func waitForTeams(
+        _ controller: TeamsViewController,
+        count: Int
+    ) async -> [Int] {
+        for _ in 0..<200 where controller.teams.count != count {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return controller.teams.map(\.teamNumber)
+    }
+
+    @Test func narrowingThenWideningTheQueryRestoresResults() async {
+        let controller = Self.makeController()
+        controller.refresh()
+        #expect(await Self.waitForTeams(controller, count: 3) == [254, 1114, 2590])
+
+        controller.searchController.searchBar.text = "254"
+        controller.updateDataSource()
+        #expect(await Self.waitForTeams(controller, count: 1) == [254])
+
+        controller.searchController.searchBar.text = "25"
+        controller.updateDataSource()
+        #expect(await Self.waitForTeams(controller, count: 2) == [254, 2590])
+
+        controller.searchController.searchBar.text = ""
+        controller.updateDataSource()
+        #expect(await Self.waitForTeams(controller, count: 3) == [254, 1114, 2590])
+    }
+
+    @Test func matchesNumberNicknameAndName() async {
+        let controller = Self.makeController()
+        controller.refresh()
+        _ = await Self.waitForTeams(controller, count: 3)
+
+        controller.searchController.searchBar.text = "nemesis"
+        controller.updateDataSource()
+        #expect(await Self.waitForTeams(controller, count: 1) == [2590])
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */; };
 		5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000001 /* EventSectionTests.swift */; };
 		5EC0D41A2C26060100000004 /* WeekEventsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */; };
+		5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000001 /* DependenciesMocks.swift */; };
+		5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */; };
+		5EC0D41A2C26070100000006 /* TeamsListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */; };
 		5EC0D41A2C26060100000006 /* MatchBreakdownConfigurator2023Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */; };
 		5EC0D41A2C26041B00000002 /* PushNotificationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041B00000001 /* PushNotificationPayload.swift */; };
 		5EC0D41A2C26041B00000004 /* PushNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041B00000003 /* PushNotificationRouter.swift */; };
@@ -232,6 +235,9 @@
 		92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Services/MyTBASessionServiceTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000001 /* EventSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModels/Event/EventSectionTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Events/WeekEventsViewControllerTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26070100000001 /* DependenciesMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/DependenciesMocks.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Match/MatchBreakdownViewControllerTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Teams/TeamsListViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewElements/Match/Breakdown/MatchBreakdownConfigurator2023Tests.swift"; sourceTree = "<group>"; };
 		0A1BA028E14B10A8D954C54B /* TBAUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TBAUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5EC0D41A2C26041B00000001 /* PushNotificationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationPayload.swift; sourceTree = "<group>"; };
@@ -580,6 +586,9 @@
 				92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */,
 				5EC0D41A2C26060100000001 /* EventSectionTests.swift */,
 				5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */,
+				5EC0D41A2C26070100000001 /* DependenciesMocks.swift */,
+				5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */,
+				5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */,
 				5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */,
 			);
 			name = TBAUnitTests;
@@ -1243,6 +1252,9 @@
 				92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */,
 				5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */,
 				5EC0D41A2C26060100000004 /* WeekEventsViewControllerTests.swift in Sources */,
+				5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */,
+				5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */,
+				5EC0D41A2C26070100000006 /* TeamsListViewControllerTests.swift in Sources */,
 				5EC0D41A2C26060100000006 /* MatchBreakdownConfigurator2023Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -50,6 +50,7 @@ class SearchViewController: TBATableViewController {
     }
 
     private var index: SearchIndex?
+    private var searchTask: Task<Void, Never>?
     private var dataSource: TableViewDataSource<SearchSection, SearchItem>!
 
     init(dependencies: Dependencies) {
@@ -120,16 +121,53 @@ class SearchViewController: TBATableViewController {
     }
 
     private func updateSnapshot() {
+        searchTask?.cancel()
         let query = (searchText ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        var snapshot = NSDiffableDataSourceSnapshot<SearchSection, SearchItem>()
 
         guard !query.isEmpty, let index else {
-            dataSource.applySnapshotUsingReloadData(snapshot)
+            dataSource.applySnapshotUsingReloadData(NSDiffableDataSourceSnapshot())
             return
         }
 
-        if scope.shouldShowTeams {
-            let teams = index.teams
+        let showTeams = scope.shouldShowTeams
+        let showEvents = scope.shouldShowEvents
+        searchTask = Task {
+            let (teams, events) = await Self.results(
+                in: index,
+                query: query,
+                teams: showTeams,
+                events: showEvents
+            )
+            guard !Task.isCancelled else { return }
+            show(teams: teams, events: events)
+        }
+    }
+
+    private func show(teams: [SearchItem], events: [SearchItem]) {
+        var snapshot = NSDiffableDataSourceSnapshot<SearchSection, SearchItem>()
+        if !teams.isEmpty {
+            snapshot.appendSections([.teams])
+            snapshot.appendItems(teams, toSection: .teams)
+        }
+        if !events.isEmpty {
+            snapshot.appendSections([.events])
+            snapshot.appendItems(events, toSection: .events)
+        }
+        dataSource.applySnapshotUsingReloadData(snapshot)
+    }
+
+    // `String.contains` across every team and event ever is tens of ms per keystroke; keep it
+    // off the main actor.
+    @concurrent
+    private nonisolated static func results(
+        in index: SearchIndex,
+        query: String,
+        teams showTeams: Bool,
+        events showEvents: Bool
+    ) async -> (teams: [SearchItem], events: [SearchItem]) {
+        let teams =
+            showTeams
+            ? index.teams
                 .filter { matches(team: $0, query: query) }
                 .sorted { lhs, rhs in
                     let l = lhs.key.teamNumber ?? .max
@@ -137,14 +175,10 @@ class SearchViewController: TBATableViewController {
                     return l < r
                 }
                 .map { SearchItem.team(key: $0.key, nickname: $0.nickname) }
-            if !teams.isEmpty {
-                snapshot.appendSections([.teams])
-                snapshot.appendItems(teams, toSection: .teams)
-            }
-        }
-
-        if scope.shouldShowEvents {
-            let events = index.events
+            : []
+        let events =
+            showEvents
+            ? index.events
                 .filter { matches(event: $0, query: query) }
                 .sorted { lhs, rhs in
                     let lYear = lhs.key.year ?? 0
@@ -153,29 +187,28 @@ class SearchViewController: TBATableViewController {
                     return lhs.name < rhs.name
                 }
                 .map { SearchItem.event(key: $0.key, name: $0.name) }
-            if !events.isEmpty {
-                snapshot.appendSections([.events])
-                snapshot.appendItems(events, toSection: .events)
-            }
-        }
-
-        dataSource.applySnapshotUsingReloadData(snapshot)
+            : []
+        return (teams, events)
     }
 
-    private func matches(team: SearchIndex.TeamsPayloadPayload, query: String) -> Bool {
+    private nonisolated static func matches(team: SearchIndex.TeamsPayloadPayload, query: String)
+        -> Bool
+    {
         let number = team.key.trimPrefix
         return number.hasPrefix(query) || team.nickname.lowercased().contains(query)
             || team.key.lowercased().contains(query)
     }
 
-    private func matches(event: SearchIndex.EventsPayloadPayload, query: String) -> Bool {
-        let display = SearchViewController.eventDisplayName(key: event.key, name: event.name)
+    private nonisolated static func matches(event: SearchIndex.EventsPayloadPayload, query: String)
+        -> Bool
+    {
+        let display = eventDisplayName(key: event.key, name: event.name)
         return display.lowercased().contains(query) || event.key.lowercased().contains(query)
     }
 
     // Single source of truth for event row text so the search matcher operates on what the user sees —
     // event names from the API don't include the year, so without this typing "2026 michigan" wouldn't hit.
-    private static func eventDisplayName(key: EventKey, name: String) -> String {
+    private nonisolated static func eventDisplayName(key: EventKey, name: String) -> String {
         guard !name.isEmpty else { return key }
         guard let year = key.year else { return name }
         return "\(year) \(name)"

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -13,6 +13,8 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
     weak var delegate: TeamsListViewControllerDelegate?
 
     private(set) var teams: [APITeam] = []
+    private var loadedTeams: [APITeam] = []
+    private var filterTask: Task<Void, Never>?
 
     private var dataSource: TableViewDataSource<String, APITeam>!
 
@@ -71,11 +73,13 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
         dataSource.statefulDelegate = self
     }
 
-    private func applyTeams(_ teams: [APITeam]) {
-        let narrowed = filter(teams).filter { match in
-            searchMatch(team: match)
-        }.sorted { $0.teamNumber < $1.teamNumber }
-        self.teams = narrowed
+    private func applyTeams(_ loaded: [APITeam]) {
+        loadedTeams = loaded
+        updateDataSource()
+    }
+
+    private func show(_ narrowed: [APITeam]) {
+        teams = narrowed
 
         var snapshot = NSDiffableDataSourceSnapshot<String, APITeam>()
         snapshot.appendSections([""])
@@ -83,13 +87,16 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
         dataSource.applySnapshotUsingReloadData(snapshot)
     }
 
-    private func searchMatch(team: APITeam) -> Bool {
-        guard showSearch,
-            let query = searchController.searchBar.text?.lowercased(),
-            !query.isEmpty
-        else {
-            return true
-        }
+    // `String.contains` over ~10k teams is tens of ms per keystroke; keep it off the main actor.
+    @concurrent
+    private nonisolated static func narrow(_ teams: [APITeam], matching query: String) async
+        -> [APITeam]
+    {
+        let query = query.lowercased()
+        return teams.filter { matches($0, query: query) }.sorted { $0.teamNumber < $1.teamNumber }
+    }
+
+    private nonisolated static func matches(_ team: APITeam, query: String) -> Bool {
         if "\(team.teamNumber)".contains(query) { return true }
         if team.nickname.lowercased().contains(query) { return true }
         if team.name.lowercased().contains(query) { return true }
@@ -109,7 +116,18 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
     // MARK: - SearchableController
 
     override func updateDataSource() {
-        applyTeams(teams)
+        filterTask?.cancel()
+        let candidates = filter(loadedTeams)
+        let query = showSearch ? (searchController.searchBar.text ?? "") : ""
+        guard !query.isEmpty else {
+            show(candidates.sorted { $0.teamNumber < $1.teamNumber })
+            return
+        }
+        filterTask = Task {
+            let narrowed = await Self.narrow(candidates, matching: query)
+            guard !Task.isCancelled else { return }
+            show(narrowed)
+        }
     }
 
     // MARK: - Refreshable


### PR DESCRIPTION
## Summary

- `String.contains` across every team and event in the search index, and across six fields of ~10k teams in the all-teams list, measured ~30ms per keystroke on a Mac (so 2–3× that on a phone), all on the main actor. Pre-lowercasing doesn't help — the cost is `contains` itself. Both filters are now `@concurrent nonisolated static` functions on the concurrent pool, and each keystroke cancels the previous result before applying. (`@concurrent` rather than plain `nonisolated async` because with approachable concurrency on, the latter runs on the *caller's* actor.)
- **Bug fix found on the way:** `TeamsListViewController.applyTeams` wrote the *narrowed* list back into `teams` and `updateDataSource` re-filtered from it, so the all-teams search could only ever narrow until the next refresh — backspacing never widened. Loaded and displayed lists are now separate.
- Adds `Dependencies.mock()` in `TBAUnitTests` with `MockTBAAPI` (generated from `TBAAPIProtocol`, every endpoint throws until stubbed), `MockStatusService`, `MockURLOpener`. This is what lets view controllers be constructed in tests. First consumers: a regression test for the widening bug, and a `supportsRefreshing` test for `MatchBreakdownViewController` (which also caught that 2020 and 2021 share a configurator).

## Test plan

- [x] `TBAUnitTests`: 78 pass (4 new). `TeamsListViewControllerTests` types `254`, then `25`, then empty, and expects 1 → 2 → 3 results; it polls because the filter lands a tick later.
- [x] `scripts/swift-format.sh --strict` clean.
- [ ] Manual: Teams tab — type a team number, backspace, results widen again. Search bar — type quickly; typing stays smooth and results settle on the final query. Match Breakdown on a 2014 match has no pull-to-refresh; 2026 does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
