### PR TITLE
Run TBAAPI and MyTBAKit tests inside the app scheme

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,7 +65,7 @@ platform :ios do
     test_package("TBAAuth")
   end
 
-  desc "Run TBAUnitTests (the main app's Xcode unit-test target)"
+  desc "Run TBAUnitTests plus the TBAAPI and MyTBAKit package tests, all in the app scheme"
   lane :test_app do
     run_tests(
       project: "the-blue-alliance-ios.xcodeproj",
@@ -92,11 +92,12 @@ platform :ios do
     )
   end
 
-  desc "Run the Swift package unit tests"
+  # TBAAPI and MyTBAKit run inside the app scheme. xcodebuild refuses to host
+  # TBAUtilsTests and TBAAuthTests there ("isn't a member of the specified test
+  # plan or scheme") despite identical wiring, so they still run on their own.
+  desc "Run the Swift package unit tests that the app scheme doesn't already cover"
   lane :test_packages do
-    test_mytbakit
     test_tbautils
-    test_tbaapi
     test_tbaauth
   end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -61,7 +61,7 @@ Run TBAAuth unit tests
 [bundle exec] fastlane ios test_app
 ```
 
-Run TBAUnitTests (the main app's Xcode unit-test target)
+Run TBAUnitTests plus the TBAAPI and MyTBAKit package tests, all in the app scheme
 
 ### ios test_packages
 
@@ -69,7 +69,7 @@ Run TBAUnitTests (the main app's Xcode unit-test target)
 [bundle exec] fastlane ios test_packages
 ```
 
-Run the Swift package unit tests
+Run the Swift package unit tests that the app scheme doesn't already cover
 
 ### ios test
 

--- a/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/The Blue Alliance.xcscheme
+++ b/the-blue-alliance-ios.xcodeproj/xcshareddata/xcschemes/The Blue Alliance.xcscheme
@@ -48,6 +48,26 @@
                ReferencedContainer = "container:the-blue-alliance-ios.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TBAAPITests"
+               BuildableName = "TBAAPITests"
+               BlueprintName = "TBAAPITests"
+               ReferencedContainer = "container:Packages/TBAAPI">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MyTBAKitTests"
+               BuildableName = "MyTBAKitTests"
+               BlueprintName = "MyTBAKitTests"
+               ReferencedContainer = "container:Packages/MyTBAKit">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
## Summary

- `TBAAPITests` and `MyTBAKitTests` are added as testables on the **The Blue Alliance** scheme, so one `xcodebuild test` (and `fastlane test_app`) runs TBAUnitTests + 152 + 16 in a single simulator session.
- `test_packages` now runs only `TBAUtils` and `TBAAuth`, so nothing runs twice. **Honest partial:** xcodebuild refuses to host `TBAUtilsTests` and `TBAAuthTests` in the app scheme ("isn't a member of the specified test plan or scheme") regardless of order, and adding a direct `XCLocalSwiftPackageReference` for TBAUtils didn't change that, even though all four packages are wired identically. Xcode's scheme editor may show why; I couldn't find it from the command line. The Fastfile comment says the same.
- `fastlane/README.md` regenerated.

## Test plan

- [x] `xcodebuild test -scheme "The Blue Alliance"` reports three test runs: 74 + 152 + 16, all passing.
- [x] `fastlane test_packages` still covers TBAUtils (13) and TBAAuth (27), run standalone from each package directory.
- [ ] CI: `test-app` should now show the package suites in its results; `test-packages` shortens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
