### PR TITLE
Narrow ATS to web content only

### DIFF
--- a/the-blue-alliance-ios/Info.plist
+++ b/the-blue-alliance-ios/Info.plist
@@ -53,7 +53,7 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
 		<true/>
 	</dict>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
## Summary

- `NSAllowsArbitraryLoads = true` disabled App Transport Security for every request the app makes. It narrows to `NSAllowsArbitraryLoadsInWebContent`, which keeps the pit map and YouTube web views permissive while everything through `URLSession` requires https.
- Audit behind it: the TBA API and pit map are https; every media `direct_url` host the server emits is https (imgur, youtube, instagram, grabcad, onshape, chiefdelphi, archive.org — from `media_helper.py`); the app fetches no YouTube thumbnails; external links open via `UIApplication.open`, which ATS doesn't govern.
- Removing the blanket exception can't crash anything. The failure mode, if the audit missed a host, is one http image not loading.

## Test plan

- [x] Builds.
- [ ] Manual: Team → Media grid loads photos; Event → Pit Map renders; a match video plays in the embedded player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
