### PR TITLE
Post-Swift 6 cleanups: Alertable in Notifications, comment trim, beta note fix

### DIFF
--- a/Packages/MyTBAKit/Sources/MyTBAKit/Classes/MyTBA.swift
+++ b/Packages/MyTBAKit/Sources/MyTBAKit/Classes/MyTBA.swift
@@ -33,9 +33,8 @@ public protocol MyTBAURLSession: Sendable {
 
 extension URLSession: MyTBAURLSession {}
 
-/// Main-actor on purpose. Every caller is a view controller or a main-actor service, the
-/// payloads are small, and it pins the `Messaging.fcmToken` read to the thread Firebase
-/// delivers on - that getter reads an unsynchronized ivar.
+/// Main-actor on purpose: every caller already is, and it keeps the `Messaging.fcmToken`
+/// read on the thread Firebase delivers on - that getter reads an unsynchronized ivar.
 @MainActor
 open class MyTBA {
 

--- a/fastlane/release_notes/beta.md
+++ b/fastlane/release_notes/beta.md
@@ -14,7 +14,7 @@ Please poke at:
 - Tap a push notification and confirm it opens the right screen — this is the one runtime path the Swift 6 move changes
 - myTBA favorites and subscriptions tabs, pull-to-refresh, and star/subscribe from a team or event
 - Settings → App Icon, Settings → Cache Policy, Settings → Delete Network Cache
-- Match Breakdown on a 2020 or 2021 match (no pull-to-refresh expected) and on a 2026 match (pull-to-refresh expected)
+- Match Breakdown on a 2014 match (no pull-to-refresh expected) and on a 2026 match (pull-to-refresh expected)
 
 Under the hood:
 - The app and all four packages now build in Swift 6 language mode with strict concurrency checking and main-actor isolation by default; packages are iOS-only and tested on the simulator

--- a/the-blue-alliance-ios/LocalStore/JSONFileStore.swift
+++ b/the-blue-alliance-ios/LocalStore/JSONFileStore.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-/// One JSON file's disk operations, run off the main actor in the order they were
-/// requested, so a slow write can never land after a later `delete()` and resurrect the
-/// file. Encoding happens on the caller's actor - it's microseconds for these payloads,
-/// and it means the stored types keep their default isolation. Loading stays synchronous:
-/// the stores read once at init and callers read the in-memory value.
+/// Disk operations for one JSON file, run off the main actor in request order so a slow
+/// write can't land after a later `delete()`. Encoding stays on the caller's actor: it's
+/// microseconds, and it keeps the stored types' default isolation.
 final class JSONFileStore<Value: Codable> {
 
     let url: URL
@@ -35,8 +33,7 @@ final class JSONFileStore<Value: Codable> {
         }
     }
 
-    /// Completes once every operation requested so far has finished. Tests call this
-    /// before reading the file back.
+    /// For tests that read the file back.
     func flush() async {
         await lastOperation?.value
     }

--- a/the-blue-alliance-ios/LocalStore/MyTBALocalStore.swift
+++ b/the-blue-alliance-ios/LocalStore/MyTBALocalStore.swift
@@ -72,7 +72,6 @@ final class FavoritesStore {
         favorites.filter { $0.modelType == .team }.map { $0.modelKey }
     }
 
-    /// Waits for pending disk writes; for tests that read the file back.
     func flush() async {
         await file.flush()
     }
@@ -125,7 +124,6 @@ final class SubscriptionsStore {
         subscriptions.first { $0.modelKey == modelKey && $0.modelType == modelType }
     }
 
-    /// Waits for pending disk writes; for tests that read the file back.
     func flush() async {
         await file.flush()
     }

--- a/the-blue-alliance-ios/LocalStore/NotificationStore.swift
+++ b/the-blue-alliance-ios/LocalStore/NotificationStore.swift
@@ -44,7 +44,6 @@ final class NotificationStore {
         file.delete()
     }
 
-    /// Waits for pending disk writes; for tests that read the file back.
     func flush() async {
         await file.flush()
     }

--- a/the-blue-alliance-ios/Services/PushService.swift
+++ b/the-blue-alliance-ios/Services/PushService.swift
@@ -44,10 +44,8 @@ class PushService: NSObject, PushServiceProtocol {
         super.init()
     }
 
-    // Registering needs both a signed-in user and an FCM token, and either can
-    // arrive first, so both events land here. Restarting replaces any attempt
-    // already in flight, which is what a refreshed token needs anyway. Retries
-    // once a minute until the server accepts it.
+    // Both triggers (auth state, FCM token) land here and either can come first.
+    // Restarting an in-flight attempt is deliberate: a refreshed token must win.
     fileprivate func registerPushToken() {
         registerTask?.cancel()
         guard authService.isSignedIn else {
@@ -107,9 +105,7 @@ extension PushService: AuthStateObserving {
 
 extension PushService: MessagingDelegate {
 
-    // Firebase always delivers this on the main thread (it hops in
-    // -[FIRMessaging notifyDelegateOfFCMTokenAvailability]), which is why a
-    // main-actor method can witness this nonisolated requirement directly.
+    // Firebase delivers this on the main thread (-[FIRMessaging notifyDelegateOfFCMTokenAvailability]).
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         registerPushToken()
     }

--- a/the-blue-alliance-ios/Services/StatusService.swift
+++ b/the-blue-alliance-ios/Services/StatusService.swift
@@ -83,7 +83,6 @@ final class StatusService: StatusServiceProtocol {
         self.api = api
     }
 
-    /// Fetches now, then every five minutes for as long as the app runs.
     func start() {
         pollTask?.cancel()
         pollTask = Task { [weak self] in

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -210,7 +210,6 @@ class MyTBATableViewController: UIViewController, DataController,
         fatalError("Subclasses must override performRemoteRefresh()")
     }
 
-    /// The name the backing store posts when it changes.
     var storeChangeNotification: Notification.Name {
         fatalError("Subclasses must override storeChangeNotification")
     }

--- a/the-blue-alliance-ios/ViewControllers/Settings/Notifications/NotificationsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Settings/Notifications/NotificationsViewController.swift
@@ -228,10 +228,11 @@ class NotificationsViewController: TBATableViewController {
         switch row {
         case .registration:
             if let error = remoteNotificationRegistrationError {
-                showError(error.localizedDescription)
+                showErrorAlert(with: error.localizedDescription)
             } else {
-                showError(
-                    "Unknown error registering for remote notifications - try force quitting and re-launching the app."
+                showErrorAlert(
+                    with:
+                        "Unknown error registering for remote notifications - try force quitting and re-launching the app."
                 )
             }
         case .device:
@@ -244,27 +245,30 @@ class NotificationsViewController: TBATableViewController {
                     await checkDeviceAuthorization()
                 }
             } else {
-                showError(
-                    "Unable to resolve device settings - check push notification settings in Settings.app"
+                showErrorAlert(
+                    with:
+                        "Unable to resolve device settings - check push notification settings in Settings.app"
                 )
             }
         case .firebase:
-            showError("No FCM token from Firebase - try force quitting and re-launching the app.")
+            showErrorAlert(
+                with: "No FCM token from Firebase - try force quitting and re-launching the app."
+            )
         case .myTBA:
             let status = myTBARegistrationNotificationStatus()
             switch status {
             case .invalid(let str):
-                showError("Error registering with myTBA - \(str)")
+                showErrorAlert(with: "Error registering with myTBA - \(str)")
             default:
-                showError("Unknown error registering with myTBA")
+                showErrorAlert(with: "Unknown error registering with myTBA")
             }
         case .ping:
             let status = myTBAPingNotificationStatus()
             switch status {
             case .invalid(let str):
-                showError("Error pinging device - \(str)")
+                showErrorAlert(with: "Error pinging device - \(str)")
             default:
-                showError("Unknown error pinging device")
+                showErrorAlert(with: "Unknown error pinging device")
             }
         }
     }
@@ -441,14 +445,6 @@ class NotificationsViewController: TBATableViewController {
     }
 
     // MARK: - UI Methods
-
-    // TODO: Use Alertable instead...
-    private func showError(_ error: String) {
-        let alert = UIAlertController(title: "Error", message: error, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "Okay", style: .default, handler: nil))
-
-        present(alert, animated: true, completion: nil)
-    }
 
     @objc func showCopyFCMToken() {
         guard let fcmToken = fcmTokenProvider.fcmToken else {

--- a/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
@@ -378,8 +378,8 @@ class SettingsViewController: TBATableViewController {
             )
     }
 
-    /// `nil` selects the primary icon. `setAlternateIconName` can fail without the icon
-    /// visibly changing, so record the error, then reload from what the system actually has.
+    // `nil` is the primary icon. Reload after either outcome: a failed change leaves the
+    // system's icon unchanged and the row has to show that.
     private func setAppIcon(_ alternateName: String?) {
         guard UIApplication.shared.supportsAlternateIcons,
             UIApplication.shared.alternateIconName != alternateName


### PR DESCRIPTION
## Summary

- `NotificationsViewController` closes its `// TODO: Use Alertable instead`. It already conformed through the base class; the hand-rolled `showError` is deleted and its eight callers use `showErrorAlert(with:)`.
- Comments added during the Swift 6 arc trimmed to the non-obvious *why* only, across the stores, services, and `SettingsViewController`.
- `beta.md`: the breakdown smoke-test line named 2020/2021 as years without a configurator; they share the 2020 one. 2014 is the right example.

## Test plan

- [x] `TBAUnitTests` pass; `scripts/swift-format.sh --strict` clean.
- [ ] Manual: Settings → Notifications → trigger an error row (e.g. register while signed out) — the alert still appears with an Okay button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
