### PR TITLE
Drop the last completion-handler and GCD shapes from the app target

### DIFF
--- a/TBAUnitTests/Mocks/DependenciesMocks.swift
+++ b/TBAUnitTests/Mocks/DependenciesMocks.swift
@@ -61,13 +61,8 @@ final class MockStatusService: StatusServiceProtocol {
 final class MockURLOpener: URLOpener {
     private(set) var opened: [URL] = []
     func canOpenURL(_ url: URL) -> Bool { true }
-    func open(
-        _ url: URL,
-        options: [UIApplication.OpenExternalURLOptionsKey: Any],
-        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
-    ) {
+    func open(_ url: URL) {
         opened.append(url)
-        completion?(true)
     }
 }
 

--- a/the-blue-alliance-ios/Extensions/UIApplication+URLOpener.swift
+++ b/the-blue-alliance-ios/Extensions/UIApplication+URLOpener.swift
@@ -1,3 +1,9 @@
 import UIKit
 
-extension UIApplication: URLOpener {}
+extension UIApplication: URLOpener {
+
+    func open(_ url: URL) {
+        Task { await open(url, options: [:]) }
+    }
+
+}

--- a/the-blue-alliance-ios/Protocols/URLOpener.swift
+++ b/the-blue-alliance-ios/Protocols/URLOpener.swift
@@ -3,9 +3,5 @@ import UIKit
 
 protocol URLOpener {
     func canOpenURL(_ url: URL) -> Bool
-    func open(
-        _ url: URL,
-        options: [UIApplication.OpenExternalURLOptionsKey: Any],
-        completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?
-    )
+    func open(_ url: URL)
 }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -240,7 +240,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         }
 
         if let urlString, let url = URL(string: urlString), urlOpener.canOpenURL(url) {
-            urlOpener.open(url, options: [:], completionHandler: nil)
+            urlOpener.open(url)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventPitMapViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventPitMapViewController.swift
@@ -68,9 +68,9 @@ final class EventPitMapViewController: UIViewController, Navigatable, WKNavigati
             return
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self, weak webView] in
-            guard let self, let webView else { return }
-            self.scrollToFocused(webView: webView, selector: selector)
+        Task {
+            try? await Task.sleep(for: .milliseconds(400))
+            scrollToFocused(webView: webView, selector: selector)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
@@ -311,7 +311,7 @@ class SettingsViewController: TBATableViewController {
 
     private func openURL(url: URL) {
         if urlOpener.canOpenURL(url) {
-            urlOpener.open(url, options: [:], completionHandler: nil)
+            urlOpener.open(url)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -191,7 +191,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
         }
 
         if let urlString, let url = URL(string: urlString), urlOpener.canOpenURL(url) {
-            urlOpener.open(url, options: [:], completionHandler: nil)
+            urlOpener.open(url)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -196,7 +196,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         case .image(let photo):
             if photo.isInstagram {
                 if let viewURL = photo.viewURL, urlOpener.canOpenURL(viewURL) {
-                    urlOpener.open(viewURL, options: [:], completionHandler: nil)
+                    urlOpener.open(viewURL)
                 }
             } else {
                 delegate?.mediaSelected(
@@ -244,7 +244,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         if let viewURL = photo.viewURL, urlOpener.canOpenURL(viewURL) {
             actions.append(
                 UIAction(title: "View Online", image: UIImage(systemName: "safari.fill")) { _ in
-                    self.urlOpener.open(viewURL, options: [:], completionHandler: nil)
+                    self.urlOpener.open(viewURL)
                 }
             )
         }
@@ -258,12 +258,11 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
             actions.append(
                 UIAction(title: "Save", image: UIImage(systemName: "square.and.arrow.down.fill")) {
                     _ in
-                    self.photoLibrary.performChanges(
-                        {
+                    Task {
+                        try? await self.photoLibrary.performChanges {
                             PHAssetChangeRequest.creationRequestForAsset(from: image)
-                        },
-                        completionHandler: nil
-                    )
+                        }
+                    }
                 }
             )
         }
@@ -287,7 +286,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
                 title: "View on YouTube",
                 image: UIImage(systemName: "safari.fill")
             ) { _ in
-                self.urlOpener.open(viewURL, options: [:], completionHandler: nil)
+                self.urlOpener.open(viewURL)
             }
             return UIMenu(title: "", children: [viewOnYouTubeAction])
         }
@@ -310,7 +309,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
             )
         case .video(let video):
             if let viewURL = video.viewURL, urlOpener.canOpenURL(viewURL) {
-                urlOpener.open(viewURL, options: [:], completionHandler: nil)
+                urlOpener.open(viewURL)
             }
         }
     }


### PR DESCRIPTION
## Summary


- **`URLOpener`** carried UIKit's completion-handler `open(_:options:completionHandler:)` signature, and all seven callers passed `nil` for the completion. It's now `canOpenURL(_:)` plus a fire-and-forget `open(_:)`. `UIApplication`'s conformance calls the async `open(_:options:)` inside a `Task`, so the last completion-handler use is gone and every call site is `urlOpener.open(url)`.
- **The pit map's `DispatchQueue.main.asyncAfter`** becomes `Task.sleep(for: .milliseconds(400))`. That was the last `DispatchQueue` in the app target.
- **`PHPhotoLibrary.performChanges(_:completionHandler: nil)`** in the media grid's Save action uses the async form. No `completionHandler: nil` remains anywhere in the app.

## Test plan

- [x] `TBAUnitTests` 78 pass; `scripts/swift-format.sh --strict` clean; no new warnings.
- [ ] Manual: Team → Media → long-press a photo → "View Online" opens the browser, "Save" lands in Photos. Team Info / Event Info website rows open. Settings → a link row opens. Event → Pit Map with a focused team still scrolls to it after load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
