### PR TITLE
Observe the myTBA stores with Observations instead of NotificationCenter

### DIFF
--- a/TBAUnitTests/Mocks/DependenciesMocks.swift
+++ b/TBAUnitTests/Mocks/DependenciesMocks.swift
@@ -13,6 +13,7 @@ struct Unstubbed: Error {}
 final class MockTBAAPI: TBAAPIProtocol {
 
     var teams: [TeamSimple] = []
+    var teamsByKey: [TeamKey: Team] = [:]
 
     func setCachePolicy(_ policy: TBAAPI.CachePolicy) async {}
     func clearCache() async {}
@@ -20,7 +21,10 @@ final class MockTBAAPI: TBAAPIProtocol {
     func getSearchIndex() async throws -> SearchIndex { throw Unstubbed() }
     func allTeams() async throws -> [Team] { throw Unstubbed() }
     func allTeamsSimple() async throws -> [TeamSimple] { teams }
-    func team(key teamKey: TeamKey) async throws -> Team { throw Unstubbed() }
+    func team(key teamKey: TeamKey) async throws -> Team {
+        guard let team = teamsByKey[teamKey] else { throw Unstubbed() }
+        return team
+    }
     func teamYearsParticipated(key teamKey: TeamKey) async throws -> [Int] { throw Unstubbed() }
     func teamEventsByYear(key teamKey: TeamKey, year: Int) async throws -> [Event] { throw Unstubbed() }
     func teamEventMatches(teamKey: TeamKey, eventKey: EventKey) async throws -> [Match] { throw Unstubbed() }

--- a/TBAUnitTests/ViewControllers/MyTBA/MyTBATableViewControllerTests.swift
+++ b/TBAUnitTests/ViewControllers/MyTBA/MyTBATableViewControllerTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import MyTBAKit
+import TBAAPI
+import Testing
+import UIKit
+
+@testable import The_Blue_Alliance
+
+@MainActor
+struct MyTBATableViewControllerTests {
+
+    private static func rows(in table: UITableView) -> Int {
+        (0..<table.numberOfSections).reduce(0) { $0 + table.numberOfRows(inSection: $1) }
+    }
+
+    /// Store changes arrive through `Observations`, a tick after the mutation.
+    private static func waitForRows(_ controller: MyTBATableViewController, count: Int) async -> Int {
+        for _ in 0..<200 where rows(in: controller.tableView) != count {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return rows(in: controller.tableView)
+    }
+
+    @Test func favoritesTableFollowsTheStore() async {
+        let api = MockTBAAPI()
+        for (key, number, name) in [("frc254", 254, "The Cheesy Poofs"), ("frc1114", 1114, "Simbotics")] {
+            api.teamsByKey[key] = Team(key: key, teamNumber: number, nickname: name, name: name)
+        }
+        let dependencies = Dependencies.mock(api: api)
+        let controller = MyTBAFavoritesViewController(dependencies: dependencies)
+        controller.loadViewIfNeeded()
+        #expect(Self.rows(in: controller.tableView) == 0)
+
+        // A row appears once the store changes *and* the item's model has loaded.
+        let store = dependencies.myTBAStores.favorites
+        store.upsert(MyTBAFavorite(modelKey: "frc254", modelType: .team))
+        #expect(await Self.waitForRows(controller, count: 1) == 1)
+
+        store.upsert(MyTBAFavorite(modelKey: "frc1114", modelType: .team))
+        #expect(await Self.waitForRows(controller, count: 2) == 2)
+
+        store.clear()
+        #expect(await Self.waitForRows(controller, count: 0) == 0)
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000001 /* DependenciesMocks.swift */; };
 		5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */; };
 		5EC0D41A2C26070100000006 /* TeamsListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */; };
+		5EC0D41A2C26070100000008 /* MyTBATableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */; };
 		5EC0D41A2C26060100000006 /* MatchBreakdownConfigurator2023Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */; };
 		5EC0D41A2C26041B00000002 /* PushNotificationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041B00000001 /* PushNotificationPayload.swift */; };
 		5EC0D41A2C26041B00000004 /* PushNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041B00000003 /* PushNotificationRouter.swift */; };
@@ -238,6 +239,7 @@
 		5EC0D41A2C26070100000001 /* DependenciesMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/DependenciesMocks.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Match/MatchBreakdownViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Teams/TeamsListViewControllerTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/MyTBA/MyTBATableViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewElements/Match/Breakdown/MatchBreakdownConfigurator2023Tests.swift"; sourceTree = "<group>"; };
 		0A1BA028E14B10A8D954C54B /* TBAUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TBAUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5EC0D41A2C26041B00000001 /* PushNotificationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationPayload.swift; sourceTree = "<group>"; };
@@ -589,6 +591,7 @@
 				5EC0D41A2C26070100000001 /* DependenciesMocks.swift */,
 				5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */,
 				5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */,
+				5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */,
 				5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */,
 			);
 			name = TBAUnitTests;
@@ -1255,6 +1258,7 @@
 				5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */,
 				5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */,
 				5EC0D41A2C26070100000006 /* TeamsListViewControllerTests.swift in Sources */,
+				5EC0D41A2C26070100000008 /* MyTBATableViewControllerTests.swift in Sources */,
 				5EC0D41A2C26060100000006 /* MatchBreakdownConfigurator2023Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/the-blue-alliance-ios/LocalStore/MyTBALocalStore.swift
+++ b/the-blue-alliance-ios/LocalStore/MyTBALocalStore.swift
@@ -20,11 +20,6 @@ enum MyTBALocalStore {
     }
 }
 
-extension Notification.Name {
-    static let favoritesStoreDidChange = Notification.Name("favoritesStoreDidChange")
-    static let subscriptionsStoreDidChange = Notification.Name("subscriptionsStoreDidChange")
-}
-
 // Passed explicitly to the handful of view controllers that care about myTBA
 // state. Kept out of `Dependencies` since only myTBA-adjacent screens use it.
 struct MyTBAStores {
@@ -65,7 +60,6 @@ final class FavoritesStore {
     func clear() {
         favorites = []
         file.delete()
-        NotificationCenter.default.post(name: .favoritesStoreDidChange, object: self)
     }
 
     func favoriteTeamKeys() -> [String] {
@@ -78,7 +72,6 @@ final class FavoritesStore {
 
     private func persist() {
         file.save(favorites)
-        NotificationCenter.default.post(name: .favoritesStoreDidChange, object: self)
     }
 }
 
@@ -117,7 +110,6 @@ final class SubscriptionsStore {
     func clear() {
         subscriptions = []
         file.delete()
-        NotificationCenter.default.post(name: .subscriptionsStoreDidChange, object: self)
     }
 
     func subscription(modelKey: String, modelType: MyTBAModelType) -> MyTBASubscription? {
@@ -130,6 +122,5 @@ final class SubscriptionsStore {
 
     private func persist() {
         file.save(subscriptions)
-        NotificationCenter.default.post(name: .subscriptionsStoreDidChange, object: self)
     }
 }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -99,6 +99,7 @@ class MyTBATableViewController: UIViewController, DataController,
         case event(Event)
         case team(Team)
     }
+    private var storeObservation: Task<Void, Never>?
     private var loadedModels: [MyTBAItem: LoadedModel] = [:]
     private var failedKeys: Set<MyTBAItem> = []
     /// When true, failed items render inline as key-only placeholder cells and
@@ -176,13 +177,16 @@ class MyTBATableViewController: UIViewController, DataController,
         setupDataSource()
         tableView.dataSource = dataSource
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(storeDidChange),
-            name: storeChangeNotification,
-            object: nil
-        )
+        storeObservation = Task { [weak self] in
+            for await _ in Observations({ [weak self] in self?.currentItems ?? [] }) {
+                self?.storeDidChange()
+            }
+        }
         rebuildSnapshot()
+    }
+
+    isolated deinit {
+        storeObservation?.cancel()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -208,10 +212,6 @@ class MyTBATableViewController: UIViewController, DataController,
     /// Kicks off a remote refresh, writes the result into the backing store.
     func performRemoteRefresh() async throws {
         fatalError("Subclasses must override performRemoteRefresh()")
-    }
-
-    var storeChangeNotification: Notification.Name {
-        fatalError("Subclasses must override storeChangeNotification")
     }
 
     // MARK: - Refreshable default
@@ -345,7 +345,7 @@ class MyTBATableViewController: UIViewController, DataController,
 
     // MARK: - Refresh
 
-    @objc func storeDidChange() {
+    private func storeDidChange() {
         rebuildSnapshot()
         // Locally added favorites/subscriptions need their backing models loaded
         // even when the user hasn't pulled to refresh.
@@ -554,8 +554,6 @@ class MyTBAFavoritesViewController: MyTBATableViewController, Refreshable, State
         }
     }
 
-    override var storeChangeNotification: Notification.Name { .favoritesStoreDidChange }
-
     override func performRemoteRefresh() async throws {
         favoritesStore.replaceAll(with: try await myTBA.fetchFavorites())
     }
@@ -587,8 +585,6 @@ class MyTBASubscriptionsViewController: MyTBATableViewController, Refreshable, S
             MyTBAItem(modelType: $0.modelType, key: $0.modelKey)
         }
     }
-
-    override var storeChangeNotification: Notification.Name { .subscriptionsStoreDidChange }
 
     override func performRemoteRefresh() async throws {
         subscriptionsStore.replaceAll(with: try await myTBA.fetchSubscriptions())


### PR DESCRIPTION
## Summary

- `FavoritesStore` and `SubscriptionsStore` are already `@Observable`, but they also posted NotificationCenter notifications on every change and `MyTBATableViewController` listened with a selector. That channel duplicated Observation. Gone: both `Notification.Name`s, the four `post` calls, the `@objc` selector, and the `storeChangeNotification` subclass override point.
- The base controller iterates `Observations { currentItems }` (iOS 26, SE-0475). Each subclass already overrides `currentItems` to read its store, so that's exactly what gets tracked and there's nothing left for subclasses to wire. The task is cancelled in `isolated deinit`.
- **No `dropFirst()`**, deliberately. The first emission arrives a tick after `viewDidLoad`, so a store change landing before that tick would be swallowed — the new test caught exactly that. Letting the first emission call `storeDidChange()` just front-loads the model fetches that `viewWillAppear`'s refresh does anyway.
- `MyTBATableViewControllerTests` mutates the favorites store and expects the table to follow with no notification involved. `MockTBAAPI` gains a `team(key:)` stub since a row only appears once its model has loaded.

## Test plan

- [x] `TBAUnitTests` 79 pass (1 new); TBAAPI 152, MyTBAKit 16 unchanged. `scripts/swift-format.sh --strict` clean.
- [ ] Manual: star a team from its page → it appears on the myTBA Favorites tab without a pull-to-refresh; unstar → it disappears. Same for a subscription on the Subscriptions tab. Sign out → both tabs empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
