### PR TITLE
Use UIAction instead of target/action where UIKit offers it

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Base/Containers/ContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Containers/ContainerViewController.swift
@@ -127,9 +127,8 @@ class ContainerViewController: UIViewController, Alertable {
 
         super.init(nibName: nil, bundle: nil)
 
-        segmentedControl.addTarget(
-            self,
-            action: #selector(segmentedControlValueChanged),
+        segmentedControl.addAction(
+            UIAction { [weak self] _ in self?.updateSegmentedControlViews() },
             for: .valueChanged
         )
 
@@ -261,10 +260,6 @@ class ContainerViewController: UIViewController, Alertable {
     }
 
     // MARK: - Private Methods
-
-    @objc private func segmentedControlValueChanged() {
-        updateSegmentedControlViews()
-    }
 
     private func updateSegmentedControlViews() {
         if let viewController = currentViewController() {

--- a/the-blue-alliance-ios/ViewControllers/Base/Containers/MyTBAContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Containers/MyTBAContainerViewController.swift
@@ -8,9 +8,7 @@ class MyTBAContainerViewController: ContainerViewController, Subscribable {
     lazy var favoriteBarButtonItem: UIBarButtonItem = {
         return UIBarButtonItem(
             image: UIImage.starIcon,
-            style: .plain,
-            target: self,
-            action: #selector(myTBAPreferencesTapped)
+            primaryAction: UIAction { [weak self] _ in self?.presentMyTBAPreferences() }
         )
     }()
 
@@ -53,10 +51,6 @@ class MyTBAContainerViewController: ContainerViewController, Subscribable {
         } else {
             rightBarButtonItems = []
         }
-    }
-
-    @objc func myTBAPreferencesTapped() {
-        presentMyTBAPreferences()
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -44,9 +44,7 @@ class TeamAtDistrictViewController: ContainerViewController {
         rightBarButtonItems = [
             UIBarButtonItem(
                 image: UIImage.teamIcon,
-                style: .plain,
-                target: self,
-                action: #selector(pushTeam)
+                primaryAction: UIAction { [weak self] _ in self?.pushTeam() }
             )
         ].compactMap({ $0 })
 
@@ -67,7 +65,7 @@ class TeamAtDistrictViewController: ContainerViewController {
 
     // MARK: - Private Methods
 
-    @objc private func pushTeam() {
+    private func pushTeam() {
         let vc = TeamViewController(teamKey: teamKey, year: year, dependencies: dependencies)
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -45,9 +45,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
     lazy private var filerBarButtonItem: UIBarButtonItem = {
         return UIBarButtonItem(
             image: UIImage.sortFilterIcon,
-            style: .plain,
-            target: self,
-            action: #selector(showFilter)
+            primaryAction: UIAction { [weak self] _ in self?.delegate?.filterSelected() }
         )
     }()
 
@@ -144,10 +142,6 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
     }
 
     // MARK: - Interface Actions
-
-    @objc private func showFilter() {
-        delegate?.filterSelected()
-    }
 
     // MARK: - Refreshable
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -25,9 +25,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     lazy var matchQueryBarButtonItem: UIBarButtonItem = {
         return UIBarButtonItem(
             image: UIImage.sortFilterIcon,
-            style: .plain,
-            target: self,
-            action: #selector(showFilter)
+            primaryAction: UIAction { [weak self] _ in self?.delegate?.showFilter() }
         )
     }()
     override var additionalRightBarButtonItems: [UIBarButtonItem] {
@@ -160,10 +158,6 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     }
 
     // MARK: - Interface Methods
-
-    @objc func showFilter(_ sender: UIBarButtonItem) {
-        delegate?.showFilter()
-    }
 
     // MARK: - Refreshable
 

--- a/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
@@ -227,17 +227,18 @@ class SettingsViewController: TBATableViewController {
             case .analytics:
                 cell.textLabel?.text = "Share Analytics"
                 toggle.isOn = dependencies.appSettings.firebaseCollection.analyticsEnabled
-                toggle.addTarget(
-                    self,
-                    action: #selector(analyticsToggleChanged(_:)),
+                toggle.addAction(
+                    UIAction { [weak self, unowned toggle] _ in self?.analyticsToggleChanged(toggle)
+                    },
                     for: .valueChanged
                 )
             case .crashlytics:
                 cell.textLabel?.text = "Share Crash Reports"
                 toggle.isOn = dependencies.appSettings.firebaseCollection.crashlyticsEnabled
-                toggle.addTarget(
-                    self,
-                    action: #selector(crashlyticsToggleChanged(_:)),
+                toggle.addAction(
+                    UIAction { [weak self, unowned toggle] _ in
+                        self?.crashlyticsToggleChanged(toggle)
+                    },
                     for: .valueChanged
                 )
             }
@@ -448,12 +449,12 @@ class SettingsViewController: TBATableViewController {
 
     // MARK: - Privacy Methods
 
-    @objc private func analyticsToggleChanged(_ sender: UISwitch) {
+    private func analyticsToggleChanged(_ sender: UISwitch) {
         dependencies.appSettings.firebaseCollection.analyticsEnabled = sender.isOn
         Analytics.setAnalyticsCollectionEnabled(sender.isOn)
     }
 
-    @objc private func crashlyticsToggleChanged(_ sender: UISwitch) {
+    private func crashlyticsToggleChanged(_ sender: UISwitch) {
         if sender.isOn {
             applyCrashlyticsEnabled(true)
             return


### PR DESCRIPTION
## Summary

- Four `UIBarButtonItem`s, the container's `UISegmentedControl`, and the two Settings `UISwitch`es move from `#selector` target/action to `UIAction` closures. Seven `@objc` methods go away; three of them were one-line trampolines to a delegate call and are inlined into the action.
- Captures: bar-button and segmented-control actions use `[weak self]` because `self` owns the control. The switch actions use `[weak self, unowned toggle]` — the switch owns its action, so a strong `toggle` capture would be a cycle.
- What stays on `#selector`, deliberately: the four tap gesture recognizers and one long-press (UIKit has no closure API for gesture recognizers), and the `willEnterForegroundNotification` observer in `NotificationsViewController`.

## Test plan

- [x] `TBAUnitTests` 78 pass; TBAAPI 152, MyTBAKit 16; `scripts/swift-format.sh --strict` clean.
- [ ] Manual: Team @ District → team icon pushes the team. Matches and Event Team Stats → filter icon opens the filter. A myTBA-capable screen → star opens preferences. Any container (Events tab) → switching segments switches the child. Settings → Privacy → both toggles persist across relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
