### PR TITLE
Format numbers with FormatStyle instead of String(format:) and NumberFormatter

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		929FCD9A1EC7F52700A38E46 /* DistrictsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929FCD991EC7F52700A38E46 /* DistrictsViewController.swift */; };
 		92A321C7214EF83800FDADFB /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A321C6214EF83800FDADFB /* SettingsViewController.swift */; };
 		92A5E5D321A22D550025CC85 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5C821A22D550025CC85 /* UIApplication+URLOpener.swift */; };
+		5EC0D41A2C2607010000000D /* FormatStyle+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C2607010000000C /* FormatStyle+TBA.swift */; };
 		92A5E5D421A22D550025CC85 /* Bundle+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5C921A22D550025CC85 /* Bundle+Version.swift */; };
 		92A5E5DA21A22D550025CC85 /* UIColor+TBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5CF21A22D550025CC85 /* UIColor+TBA.swift */; };
 		92A5E5DD21A22D550025CC85 /* Int16+Suffix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A5E5D221A22D550025CC85 /* Int16+Suffix.swift */; };
@@ -315,6 +316,7 @@
 		929FCD991EC7F52700A38E46 /* DistrictsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DistrictsViewController.swift; sourceTree = "<group>"; };
 		92A321C6214EF83800FDADFB /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		92A5E5C821A22D550025CC85 /* UIApplication+URLOpener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+URLOpener.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C2607010000000C /* FormatStyle+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormatStyle+TBA.swift"; sourceTree = "<group>"; };
 		92A5E5C921A22D550025CC85 /* Bundle+Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Version.swift"; sourceTree = "<group>"; };
 		92A5E5CF21A22D550025CC85 /* UIColor+TBA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+TBA.swift"; sourceTree = "<group>"; };
 		92A5E5D221A22D550025CC85 /* Int16+Suffix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int16+Suffix.swift"; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 			isa = PBXGroup;
 			children = (
 				92A5E5C821A22D550025CC85 /* UIApplication+URLOpener.swift */,
+				5EC0D41A2C2607010000000C /* FormatStyle+TBA.swift */,
 				92A5E5C921A22D550025CC85 /* Bundle+Version.swift */,
 				92A5E5CF21A22D550025CC85 /* UIColor+TBA.swift */,
 				92A5E5D221A22D550025CC85 /* Int16+Suffix.swift */,
@@ -1366,6 +1369,7 @@
 				92C8CE4021AC5D5C00683558 /* MyTBAPreferenceViewController.swift in Sources */,
 				929F57222092B80B00E5313A /* ContainerViewController.swift in Sources */,
 				92A5E5D321A22D550025CC85 /* UIApplication+URLOpener.swift in Sources */,
+				5EC0D41A2C2607010000000D /* FormatStyle+TBA.swift in Sources */,
 				9288BD1623D00BE500157F74 /* MatchBreakdownConfigurator2019.swift in Sources */,
 				14796948215EBD6C0075AF4E /* EventCellViewModel.swift in Sources */,
 				92B55631215FDA9000C1D9A3 /* BasicTableViewCell.swift in Sources */,

--- a/the-blue-alliance-ios/Extensions/FormatStyle+TBA.swift
+++ b/the-blue-alliance-ios/Extensions/FormatStyle+TBA.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+// "12.34" - what `%.2f` gave, with the user's decimal separator.
+extension FormatStyle where Self == FloatingPointFormatStyle<Double> {
+    static var twoDecimals: Self { .number.precision(.fractionLength(2)).grouping(.never) }
+}
+
+extension FormatStyle where Self == FloatingPointFormatStyle<Float> {
+    static var twoDecimals: Self { .number.precision(.fractionLength(2)).grouping(.never) }
+}

--- a/the-blue-alliance-ios/LocalStore/CachePolicyStore.swift
+++ b/the-blue-alliance-ios/LocalStore/CachePolicyStore.swift
@@ -1,9 +1,9 @@
 import Foundation
 import TBAAPI
 
-private let kTBACachePolicy = "kTBACachePolicy"
-
 struct CachePolicyStore {
+
+    private static let key = "kTBACachePolicy"
 
     private let defaults: UserDefaults
 
@@ -13,7 +13,7 @@ struct CachePolicyStore {
 
     var current: TBAAPI.CachePolicy {
         get {
-            guard let raw = defaults.string(forKey: kTBACachePolicy),
+            guard let raw = defaults.string(forKey: Self.key),
                 let policy = TBAAPI.CachePolicy(rawValue: raw)
             else {
                 return .default
@@ -21,7 +21,7 @@ struct CachePolicyStore {
             return policy
         }
         nonmutating set {
-            defaults.set(newValue.rawValue, forKey: kTBACachePolicy)
+            defaults.set(newValue.rawValue, forKey: Self.key)
         }
     }
 }

--- a/the-blue-alliance-ios/LocalStore/FirebaseCollectionStore.swift
+++ b/the-blue-alliance-ios/LocalStore/FirebaseCollectionStore.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-private let kAnalyticsCollectionEnabled = "kAnalyticsCollectionEnabled"
-private let kCrashlyticsCollectionEnabled = "kCrashlyticsCollectionEnabled"
-
 struct FirebaseCollectionStore {
+
+    private static let analyticsKey = "kAnalyticsCollectionEnabled"
+    private static let crashlyticsKey = "kCrashlyticsCollectionEnabled"
 
     private let defaults: UserDefaults
 
@@ -12,13 +12,13 @@ struct FirebaseCollectionStore {
     }
 
     var analyticsEnabled: Bool {
-        get { enabled(forKey: kAnalyticsCollectionEnabled) }
-        nonmutating set { defaults.set(newValue, forKey: kAnalyticsCollectionEnabled) }
+        get { enabled(forKey: Self.analyticsKey) }
+        nonmutating set { defaults.set(newValue, forKey: Self.analyticsKey) }
     }
 
     var crashlyticsEnabled: Bool {
-        get { enabled(forKey: kCrashlyticsCollectionEnabled) }
-        nonmutating set { defaults.set(newValue, forKey: kCrashlyticsCollectionEnabled) }
+        get { enabled(forKey: Self.crashlyticsKey) }
+        nonmutating set { defaults.set(newValue, forKey: Self.crashlyticsKey) }
     }
 
     private func enabled(forKey key: String) -> Bool {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
@@ -101,13 +101,8 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
     private static func formattedPairs(values: [Double], info: [(name: String, precision: Int)])
         -> [String]
     {
-        zip(info, values).compactMap { info, value in
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = info.precision
-            formatter.minimumFractionDigits = info.precision
-            guard let valueString = formatter.string(for: value) else { return nil }
-            return "\(info.name): \(valueString)"
+        zip(info, values).map { info, value in
+            "\(info.name): \(value.formatted(.number.precision(.fractionLength(info.precision))))"
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -308,12 +308,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
         let parts: [String] = zip(info, sortOrders).compactMap { info, value in
             guard let name = info.name else { return nil }
             let precision = info.precision ?? 0
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.minimumFractionDigits = precision
-            formatter.maximumFractionDigits = precision
-            guard let valueString = formatter.string(for: value) else { return nil }
-            return "\(name): \(valueString)"
+            return "\(name): \(value.formatted(.number.precision(.fractionLength(precision))))"
         }
         return parts.isEmpty ? nil : parts.joined(separator: ", ")
     }

--- a/the-blue-alliance-ios/ViewElements/Events/EventTeamStatCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/EventTeamStatCellViewModel.swift
@@ -7,7 +7,7 @@ struct EventTeamStatCellViewModel {
 
     init(statName: String, value: Float?) {
         self.statName = statName.uppercased()
-        self.statValue = value.map { String(format: "%.2f", $0) } ?? "----"
+        self.statValue = value?.formatted(.twoDecimals) ?? "----"
     }
 
 }

--- a/the-blue-alliance-ios/ViewElements/Events/RankingCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/RankingCellViewModel.swift
@@ -37,7 +37,8 @@ struct RankingCellViewModel {
         self.rankText = nil
         self.teamNumber = Self.teamNumber(from: teamKey)
         self.teamName = team?.displayNickname ?? "Team \(self.teamNumber ?? teamKey)"
-        self.detailText = String(format: "OPR: %.2f, DPR: %.2f, CCWM: %.2f", opr, dpr, ccwm)
+        self.detailText =
+            "OPR: \(opr.formatted(.twoDecimals)), DPR: \(dpr.formatted(.twoDecimals)), CCWM: \(ccwm.formatted(.twoDecimals))"
         self.wltText = nil
     }
 

--- a/the-blue-alliance-ios/ViewElements/Events/Stats/EventInsightsConfigurator.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/Stats/EventInsightsConfigurator.swift
@@ -56,7 +56,7 @@ extension EventInsightsConfigurator {
         guard let val = dict[key] as? Double else {
             return nil
         }
-        return String(format: "%.2f", val)
+        return val.formatted(.twoDecimals)
     }
 
     static func bonusRow(title: String, key: String, qual: [String: Any]?, playoff: [String: Any]?)
@@ -105,7 +105,7 @@ extension EventInsightsConfigurator {
         }
         let quotient: String = {
             if let val = bonusData.safeItem(at: 2) as? Double {
-                return "\(String(format: "%.2f", val))%"
+                return "\(val.formatted(.twoDecimals))%"
             }
             if bonusData.safeItem(at: 0) as? Int == 0 && bonusData.safeItem(at: 1) as? Int != nil {
                 return "0.00%"
@@ -127,13 +127,13 @@ extension EventInsightsConfigurator {
         }
         let allianceAvg: String = {
             if let val = totalsData.safeItem(at: 1) as? Double {
-                return "\(String(format: "%.2f", val))"
+                return val.formatted(.twoDecimals)
             }
             return ""
         }()
         let teamAvg: String = {
             if let val = totalsData.safeItem(at: 2) as? Double {
-                return "\(String(format: "%.2f", val))"
+                return val.formatted(.twoDecimals)
             }
             return ""
         }()
@@ -149,10 +149,10 @@ extension EventInsightsConfigurator {
                 let raw = dict[k]
             else { return "" }
             if let number = raw as? Double {
-                return String(format: "%.2f", number)
+                return number.formatted(.twoDecimals)
             }
             if let number = raw as? NSNumber {
-                return String(format: "%.2f", number.doubleValue)
+                return number.doubleValue.formatted(.twoDecimals)
             }
             return String(describing: raw)
         }


### PR DESCRIPTION
## Summary

- Nine `String(format: "%.2f", …)` sites (OPR/DPR/CCWM, team stats, event insights) use a shared `.twoDecimals` `FormatStyle`: two fraction digits, no grouping, so output matches what `%.2f` produced — except the decimal separator now follows the user's locale (`12,34` for a German user). That's the one visible change.
- The two `NumberFormatter` blocks (ranking sort-order values with a per-stat precision) become `.number.precision(.fractionLength(precision))`, keeping their grouping.
- The three `k`-prefixed file-scope constants (`kTBACachePolicy`, `kAnalyticsCollectionEnabled`, `kCrashlyticsCollectionEnabled`) become `private static let` keys on their store types. **The persisted string values are unchanged**, so existing UserDefaults keep working.
- Left alone: the four `String(format:)` calls in `MatchBreakdownConfigurator` are the `"+%@ RP"` templating shared by nine configurators — that's #1143's territory.

## Test plan

- [x] `TBAUnitTests` 79, TBAAPI 152, MyTBAKit 16 pass; `scripts/swift-format.sh --strict` clean.
- [ ] Manual: Event → Rankings shows `OPR: 12.34`-style detail and sort-order values with the right precision; Event → Insights numbers render with two decimals; Team @ Event summary shows ranking values. Settings → Cache Policy and Privacy toggles remember their values across relaunch (keys unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
