### PR TITLE
Build diffable data sources lazily instead of through implicitly unwrapped vars

### DIFF
--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -12,7 +12,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
 
     private let districtKey: String
 
-    private var dataSource: TableViewDataSource<String, DistrictRanking>!
+    private lazy var dataSource: TableViewDataSource<String, DistrictRanking> = makeDataSource()
     private var allRankings: [DistrictRanking] = []
     private var teamsByKey: [String: TeamSimple] = [:]
 
@@ -36,7 +36,6 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
         setupSearch()
 
         tableView.registerReusableCell(RankingTableViewCell.self)
-        setupDataSource()
         tableView.dataSource = dataSource
     }
 
@@ -49,8 +48,8 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
 
     // MARK: Table View Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<String, DistrictRanking>(tableView: tableView) {
+    private func makeDataSource() -> TableViewDataSource<String, DistrictRanking> {
+        let dataSource = TableViewDataSource<String, DistrictRanking>(tableView: tableView) {
             [weak self] tableView, indexPath, ranking in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as RankingTableViewCell
             let team = self?.teamsByKey[ranking.teamKey]
@@ -59,6 +58,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     override func updateDataSource() {

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
@@ -16,7 +16,7 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
     }
 
     private var districts: [District] = []
-    private var dataSource: TableViewDataSource<String, District>!
+    private lazy var dataSource: TableViewDataSource<String, District> = makeDataSource()
 
     // MARK: - Init
 
@@ -35,7 +35,6 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupDataSource()
         tableView.dataSource = dataSource
     }
 
@@ -48,8 +47,8 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: Table View Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<String, District>(tableView: tableView) {
+    private func makeDataSource() -> TableViewDataSource<String, District> {
+        let dataSource = TableViewDataSource<String, District>(tableView: tableView) {
             tableView,
             indexPath,
             district in
@@ -60,6 +59,7 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func apply(_ districts: [District]) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -68,7 +68,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
     private let eventKey: EventKey
     private let teamKey: String?
 
-    private var dataSource: TableViewDataSource<String, Award>!
+    private lazy var dataSource: TableViewDataSource<String, Award> = makeDataSource()
     private var awards: [Award] = []
     private var teamsByKey: [String: TeamSimple] = [:]
 
@@ -91,14 +91,13 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
         super.viewDidLoad()
 
         tableView.registerReusableCell(AwardTableViewCell.self)
-        setupDataSource()
         tableView.dataSource = dataSource
     }
 
     // MARK: Table View Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<String, Award>(tableView: tableView) {
+    private func makeDataSource() -> TableViewDataSource<String, Award> {
+        let dataSource = TableViewDataSource<String, Award>(tableView: tableView) {
             [weak self] tableView, indexPath, award in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as AwardTableViewCell
             cell.selectionStyle = .none
@@ -109,6 +108,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func applyAwards(_ awards: [Award]) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
@@ -71,7 +71,8 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
 
     private let eventKey: EventKey
 
-    private var dataSource: TableViewDataSource<String, TeamDistrictPointsRow>!
+    private lazy var dataSource: TableViewDataSource<String, TeamDistrictPointsRow> =
+        makeDataSource()
     private var rows: [TeamDistrictPointsRow] = []
     private var teamsByKey: [String: TeamSimple] = [:]
 
@@ -92,7 +93,6 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
         super.viewDidLoad()
 
         tableView.registerReusableCell(RankingTableViewCell.self)
-        setupDataSource()
         tableView.dataSource = dataSource
     }
 
@@ -105,8 +105,8 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
 
     // MARK: Table View Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<String, TeamDistrictPointsRow>(tableView: tableView) {
+    private func makeDataSource() -> TableViewDataSource<String, TeamDistrictPointsRow> {
+        let dataSource = TableViewDataSource<String, TeamDistrictPointsRow>(tableView: tableView) {
             [weak self] tableView, indexPath, row in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as RankingTableViewCell
             let team = self?.teamsByKey[row.teamKey]
@@ -119,6 +119,7 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func apply(points: EventDistrictPoints?) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -33,7 +33,8 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
     private var state: EventState
     private let eventName: String?
 
-    private var dataSource: TableViewDataSource<EventInfoSection, EventInfoItem>!
+    private lazy var dataSource: TableViewDataSource<EventInfoSection, EventInfoItem> =
+        makeDataSource()
 
     weak var delegate: (any EventInfoViewControllerDelegate)?
 
@@ -69,7 +70,6 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         tableView.registerReusableCell(InfoTableViewCell.self)
 
         tableView.dataSource = dataSource
-        setupDataSource()
 
         updateEventInfo()
     }
@@ -87,8 +87,8 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
         hasPitMap = true
     }
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<EventInfoSection, EventInfoItem>(
+    private func makeDataSource() -> TableViewDataSource<EventInfoSection, EventInfoItem> {
+        let dataSource = TableViewDataSource<EventInfoSection, EventInfoItem>(
             tableView: tableView,
             cellProvider: { (tableView, indexPath, item) -> UITableViewCell? in
                 switch item {
@@ -132,6 +132,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
                 }
             }
         )
+        return dataSource
     }
 
     private func updateEventInfo() {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
@@ -12,7 +12,8 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
 
     private let eventKey: EventKey
 
-    private var dataSource: TableViewDataSource<String, EventRanking.RankingsPayloadPayload>!
+    private lazy var dataSource: TableViewDataSource<String, EventRanking.RankingsPayloadPayload> =
+        makeDataSource()
     private var rankings: [EventRanking.RankingsPayloadPayload] = []
     private var extraStatsInfo: [EventRanking.ExtraStatsInfoPayloadPayload] = []
     private var sortOrderInfo: [EventRanking.SortOrderInfoPayloadPayload] = []
@@ -35,7 +36,6 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
         super.viewDidLoad()
 
         tableView.registerReusableCell(RankingTableViewCell.self)
-        setupDataSource()
         tableView.dataSource = dataSource
     }
 
@@ -48,8 +48,10 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
 
     // MARK: Table View Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<String, EventRanking.RankingsPayloadPayload>(
+    private func makeDataSource() -> TableViewDataSource<
+        String, EventRanking.RankingsPayloadPayload
+    > {
+        let dataSource = TableViewDataSource<String, EventRanking.RankingsPayloadPayload>(
             tableView: tableView
         ) {
             [weak self] tableView, indexPath, ranking in
@@ -64,6 +66,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func applyRanking(_ response: EventRanking?) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsViewController.swift
@@ -31,7 +31,7 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
     private let year: Int
     private let eventStatsConfigurator: (any EventInsightsConfigurator.Type)?
 
-    private var dataSource: EventInsightsDataSource!
+    private lazy var dataSource: EventInsightsDataSource = makeDataSource()
 
     init(eventKey: EventKey, year: Int, dependencies: Dependencies) {
         self.eventKey = eventKey
@@ -73,7 +73,6 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
         tableView.insetsContentViewsToSafeArea = false
 
         tableView.dataSource = dataSource
-        setupDataSource()
     }
 
     // MARK: - UITableViewDelegate
@@ -101,8 +100,8 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
 
     // MARK: - Private Methods
 
-    private func setupDataSource() {
-        dataSource = EventInsightsDataSource(tableView: tableView) {
+    private func makeDataSource() -> EventInsightsDataSource {
+        let dataSource = EventInsightsDataSource(tableView: tableView) {
             (tableView, indexPath, row) -> UITableViewCell? in
             if indexPath.section == 0 {
                 let cell =
@@ -141,6 +140,7 @@ class EventInsightsViewController: TBATableViewController, Refreshable, Stateful
             }
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func configureDataSource(qual: [String: Any]?, playoff: [String: Any]?) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -32,7 +32,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
 
     private let eventKey: EventKey
 
-    private var dataSource: TableViewDataSource<String, TeamStatRow>!
+    private lazy var dataSource: TableViewDataSource<String, TeamStatRow> = makeDataSource()
     private var rows: [TeamStatRow] = []
     private var teamsByKey: [String: TeamSimple] = [:]
 
@@ -71,7 +71,6 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
         super.viewDidLoad()
 
         tableView.registerReusableCell(RankingTableViewCell.self)
-        setupDataSource()
         tableView.dataSource = dataSource
     }
 
@@ -85,8 +84,8 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
 
     // MARK: Table View Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<String, TeamStatRow>(tableView: tableView) {
+    private func makeDataSource() -> TableViewDataSource<String, TeamStatRow> {
+        let dataSource = TableViewDataSource<String, TeamStatRow>(tableView: tableView) {
             [weak self] tableView, indexPath, row in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as RankingTableViewCell
             let team = self?.teamsByKey[row.teamKey]
@@ -100,6 +99,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func apply(oprs response: EventOPRs?) {

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
@@ -31,7 +31,7 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
     weak var delegate: (any EventsListViewControllerDelegate)?
 
     private(set) var events: [APIEvent] = []
-    private var dataSource: EventsListDataSource!
+    private lazy var dataSource: EventsListDataSource = makeDataSource()
 
     // MARK: - View Lifecycle
 
@@ -39,7 +39,6 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
         super.viewDidLoad()
 
         tableView.registerReusableCell(EventTableViewCell.self)
-        setupDataSource()
     }
 
     // MARK: - Subclass override points
@@ -57,8 +56,8 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Data Source
 
-    private func setupDataSource() {
-        dataSource = EventsListDataSource(tableView: tableView) {
+    private func makeDataSource() -> EventsListDataSource {
+        let dataSource = EventsListDataSource(tableView: tableView) {
             [weak self] tableView, indexPath, event in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
             cell.viewModel = EventCellViewModel(
@@ -73,6 +72,7 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
         dataSource.statefulDelegate = self
         dataSource.titleOverride = { [weak self] event in self?.delegate?.title(for: event) }
         tableView.dataSource = dataSource
+        return dataSource
     }
 
     func applyEvents(_ apiEvents: [APIEvent]) {

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -34,7 +34,7 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
     private let year: Int
     private let breakdownConfigurator: (any MatchBreakdownConfigurator.Type)?
 
-    private var dataSource: TableViewDataSource<String?, BreakdownRow>!
+    private lazy var dataSource: TableViewDataSource<String?, BreakdownRow> = makeDataSource()
 
     // MARK: - Init
 
@@ -81,7 +81,6 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
         tableView.registerReusableCell(MatchBreakdownTableViewCell.self)
         tableView.insetsContentViewsToSafeArea = false
 
-        setupDataSource()
         tableView.dataSource = dataSource
 
         configureDataSource(state.match?.breakdownDict, state.match?.compLevel)
@@ -89,8 +88,8 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
 
     // MARK: - Methods
 
-    func setupDataSource() {
-        dataSource = TableViewDataSource<String?, BreakdownRow>(tableView: tableView) {
+    func makeDataSource() -> TableViewDataSource<String?, BreakdownRow> {
+        let dataSource = TableViewDataSource<String?, BreakdownRow>(tableView: tableView) {
             (tableView, indexPath, row) -> UITableViewCell? in
             let cell =
                 tableView.dequeueReusableCell(indexPath: indexPath)
@@ -102,6 +101,7 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     func configureDataSource(

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -16,7 +16,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     private var state: EventState
     private let teamKey: String?
 
-    private var dataSource: TableViewDataSource<MatchSection, Match>!
+    private lazy var dataSource: TableViewDataSource<MatchSection, Match> = makeDataSource()
 
     private var allMatches: [Match] = []
     private var favoriteTeamKeys: [String] = []
@@ -63,7 +63,6 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
         super.viewDidLoad()
 
         tableView.registerReusableCell(MatchTableViewCell.self)
-        setupDataSource()
         tableView.dataSource = dataSource
 
         updateInterface()
@@ -79,8 +78,8 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: Table View Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<MatchSection, Match>(tableView: tableView) {
+    private func makeDataSource() -> TableViewDataSource<MatchSection, Match> {
+        let dataSource = TableViewDataSource<MatchSection, Match>(tableView: tableView) {
             [weak self] tableView, indexPath, match in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
 
@@ -110,6 +109,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func applyMatches(_ matches: [Match]) {

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -91,7 +91,7 @@ class MyTBATableViewController: UIViewController, DataController,
     private var failureBannerView: FailureBannerView!
     private var failureBannerContainer: UIView!
     private var failureBannerHeightConstraint: NSLayoutConstraint!
-    private var dataSource: TableViewDataSource<MyTBASection, MyTBAItem>!
+    private lazy var dataSource: TableViewDataSource<MyTBASection, MyTBAItem> = makeDataSource()
 
     // MARK: - State
 
@@ -174,7 +174,6 @@ class MyTBATableViewController: UIViewController, DataController,
         stack.autoPinEdge(toSuperviewSafeArea: .top)
         stack.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .top)
 
-        setupDataSource()
         tableView.dataSource = dataSource
 
         storeObservation = Task { [weak self] in
@@ -223,8 +222,8 @@ class MyTBATableViewController: UIViewController, DataController,
 
     // MARK: - Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<MyTBASection, MyTBAItem>(
+    private func makeDataSource() -> TableViewDataSource<MyTBASection, MyTBAItem> {
+        let dataSource = TableViewDataSource<MyTBASection, MyTBAItem>(
             tableView: tableView,
             cellProvider: { [weak self] tableView, indexPath, item in
                 guard let self = self else { return UITableViewCell() }
@@ -237,6 +236,7 @@ class MyTBATableViewController: UIViewController, DataController,
                 return UITableViewCell()
             }
         )
+        return dataSource
     }
 
     private func makeCell(

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -51,7 +51,7 @@ class SearchViewController: TBATableViewController {
 
     private var index: SearchIndex?
     private var searchTask: Task<Void, Never>?
-    private var dataSource: TableViewDataSource<SearchSection, SearchItem>!
+    private lazy var dataSource: TableViewDataSource<SearchSection, SearchItem> = makeDataSource()
 
     init(dependencies: Dependencies) {
         super.init(dependencies: dependencies)
@@ -72,7 +72,6 @@ class SearchViewController: TBATableViewController {
         tableView.registerReusableCell(EventTableViewCell.self)
         tableView.registerReusableCell(TeamTableViewCell.self)
 
-        setupDataSource()
         tableView.dataSource = dataSource
 
         enableRefreshing()
@@ -82,8 +81,8 @@ class SearchViewController: TBATableViewController {
 
     // MARK: Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<SearchSection, SearchItem>(tableView: tableView) {
+    private func makeDataSource() -> TableViewDataSource<SearchSection, SearchItem> {
+        let dataSource = TableViewDataSource<SearchSection, SearchItem>(tableView: tableView) {
             tableView,
             indexPath,
             item in
@@ -108,6 +107,7 @@ class SearchViewController: TBATableViewController {
             }
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     // MARK: - Search

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -58,7 +58,8 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
     private var nextMatch: Match?
     private var lastMatch: Match?
 
-    private var dataSource: TableViewDataSource<TeamSummarySection, TeamSummaryItem>!
+    private lazy var dataSource: TableViewDataSource<TeamSummarySection, TeamSummaryItem> =
+        makeDataSource()
 
     init(teamKey: String, eventKey: EventKey, dependencies: Dependencies) {
         self.teamKey = teamKey
@@ -82,13 +83,12 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
         tableView.registerReusableCell(MatchTableViewCell.self)
 
         tableView.dataSource = dataSource
-        setupDataSource()
     }
 
     // MARK: - Private Methods
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<TeamSummarySection, TeamSummaryItem>(
+    private func makeDataSource() -> TableViewDataSource<TeamSummarySection, TeamSummaryItem> {
+        let dataSource = TableViewDataSource<TeamSummarySection, TeamSummaryItem>(
             tableView: tableView,
             cellProvider: { [weak self] (tableView, indexPath, item) -> UITableViewCell? in
                 guard let self else { return nil }
@@ -165,6 +165,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
             }
         )
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func rebuildSnapshot() {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -18,7 +18,8 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
 
     private var state: TeamState
 
-    private var dataSource: TableViewDataSource<TeamInfoSection, TeamInfoItem>!
+    private lazy var dataSource: TableViewDataSource<TeamInfoSection, TeamInfoItem> =
+        makeDataSource()
 
     private var sponsorsExpanded: Bool = false
 
@@ -51,15 +52,14 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
         tableView.registerReusableCell(ReverseSubtitleTableViewCell.self)
 
         tableView.dataSource = dataSource
-        setupDataSource()
 
         updateTeamInfo()
     }
 
     // MARK: - Private Methods
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<TeamInfoSection, TeamInfoItem>(
+    private func makeDataSource() -> TableViewDataSource<TeamInfoSection, TeamInfoItem> {
+        let dataSource = TableViewDataSource<TeamInfoSection, TeamInfoItem>(
             tableView: tableView,
             cellProvider: { [weak self] (tableView, indexPath, item) -> UITableViewCell? in
                 guard let self = self else { return nil }
@@ -77,6 +77,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
                 }
             }
         )
+        return dataSource
     }
 
     private func updateTeamInfo() {

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -53,7 +53,8 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
 
     weak var delegate: (any TeamMediaCollectionViewControllerDelegate)?
 
-    private var dataSource: CollectionViewDataSource<MediaSection, TeamMediaItem>!
+    private lazy var dataSource: CollectionViewDataSource<MediaSection, TeamMediaItem> =
+        makeDataSource()
     private var media: [TeamMediaItem] = []
     private var imageCache: [String: UIImage] = [:]
     private var imageErrors: [String: any Error] = [:]
@@ -88,7 +89,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
     private func makeLayout() -> UICollectionViewLayout {
         UICollectionViewCompositionalLayout { [weak self] sectionIndex, env in
             guard let self else { return nil }
-            let section = self.dataSource?.sectionIdentifier(for: sectionIndex) ?? .images
+            let section = self.dataSource.sectionIdentifier(for: sectionIndex) ?? .images
             switch section {
             case .videos:
                 return Self.makeVideoSection(env: env)
@@ -174,7 +175,6 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
         collectionView.registerReusableCell(MediaCollectionViewCell.self)
         collectionView.registerReusableCell(PlayerCollectionViewCell.self)
 
-        setupDataSource()
         collectionView.dataSource = dataSource
         collectionView.setCollectionViewLayout(makeLayout(), animated: false)
     }
@@ -316,8 +316,8 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
 
     // MARK: Data Source
 
-    private func setupDataSource() {
-        dataSource = CollectionViewDataSource<MediaSection, TeamMediaItem>(
+    private func makeDataSource() -> CollectionViewDataSource<MediaSection, TeamMediaItem> {
+        let dataSource = CollectionViewDataSource<MediaSection, TeamMediaItem>(
             collectionView: collectionView
         ) { [weak self] collectionView, indexPath, item in
             guard let self else { return UICollectionViewCell() }
@@ -345,6 +345,7 @@ class TeamMediaCollectionViewController: TBACollectionViewController {
             }
         }
         dataSource.delegate = self
+        return dataSource
     }
 
     private func applyMedia(_ items: [TeamMediaItem]) {

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -16,7 +16,7 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
     private var loadedTeams: [APITeam] = []
     private var filterTask: Task<Void, Never>?
 
-    private var dataSource: TableViewDataSource<String, APITeam>!
+    private lazy var dataSource: TableViewDataSource<String, APITeam> = makeDataSource()
 
     private let showSearch: Bool
 
@@ -39,7 +39,6 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
         }
 
         tableView.registerReusableCell(TeamTableViewCell.self)
-        setupDataSource()
         tableView.dataSource = dataSource
     }
 
@@ -55,8 +54,8 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
 
     // MARK: - Data Source
 
-    private func setupDataSource() {
-        dataSource = TableViewDataSource<String, APITeam>(tableView: tableView) {
+    private func makeDataSource() -> TableViewDataSource<String, APITeam> {
+        let dataSource = TableViewDataSource<String, APITeam>(tableView: tableView) {
             tableView,
             indexPath,
             team in
@@ -71,6 +70,7 @@ class TeamsListViewController<APITeam: TeamDisplayable & Hashable & Sendable>:
             return cell
         }
         dataSource.statefulDelegate = self
+        return dataSource
     }
 
     private func applyTeams(_ loaded: [APITeam]) {


### PR DESCRIPTION
## Summary

- Seventeen view controllers declared `var dataSource: TableViewDataSource<…>!` (or the collection-view twin) and assigned it from a `setupDataSource()` call in `viewDidLoad`. Each becomes `private lazy var dataSource = makeDataSource()`, with `setupDataSource()` renamed to `makeDataSource()` and returning the value. The cell-provider closures are untouched.
- Why: `lazy` states what was always true — built once, on first use, after the view exists — and removes the crash an early access to the implicit unwrap would cause. One site (`TeamMediaCollectionViewController`'s layout provider) had a defensive `dataSource?.` that only existed because of the unwrap; it's a plain access now.
- Purely mechanical (one script, same edit in every file). The remaining 15 non-outlet implicit unwraps are a mixed bag and come as a separate PR; the 37 `@IBOutlet`s stay, that's the XIB convention.

## Test plan

- [x] `TBAUnitTests` 79, TBAAPI 152, MyTBAKit 16 pass; `scripts/swift-format.sh --strict` clean; warnings unchanged.
- [x] Launched: Events tab renders through the lazily built data source.
- [ ] Manual: open one screen of each kind — Events, Districts, a Team, a Match breakdown, Event Rankings/Awards/Insights, myTBA, Search — and confirm the tables populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
