### PR TITLE
Remove the implicitly unwrapped stored properties that had a better shape

### DIFF
--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -22,8 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let appSettings = AppSettings()
 
-    // Set in `application(_:didFinishLaunchingWithOptions:)` once `Secrets` are loaded.
-    var api: TBAAPI!
+    lazy var api = TBAAPI(apiKey: Secrets().tbaAPIKey, cachePolicy: appSettings.cachePolicy.current)
 
     lazy var messaging: Messaging = .messaging()
     lazy var myTBAStores: MyTBAStores = MyTBAStores(
@@ -90,7 +89,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Self.setupAppearance()
 
         configureFirebase()
-        configureAPI()
         configurePushNotifications()
         configureAuth()
         configureStatusService()
@@ -153,11 +151,6 @@ private extension AppDelegate {
                 appSettings.firebaseCollection.crashlyticsEnabled
             )
         #endif
-    }
-
-    func configureAPI() {
-        let secrets = Secrets()
-        api = TBAAPI(apiKey: secrets.tbaAPIKey, cachePolicy: appSettings.cachePolicy.current)
     }
 
     func configurePushNotifications() {

--- a/the-blue-alliance-ios/Protocols/SearchContainer.swift
+++ b/the-blue-alliance-ios/Protocols/SearchContainer.swift
@@ -5,24 +5,22 @@ import TBAAPI
 import UIKit
 
 protocol SearchContainer: ContainerViewController {
-    var searchController: UISearchController! { get set }
+    var searchController: UISearchController { get }
 }
 
 extension SearchContainer where Self: SearchViewControllerDelegate {
 
-    func setupSearchController() {
+    func makeSearchController() -> UISearchController {
         let searchViewController = SearchViewController(dependencies: dependencies)
         searchViewController.delegate = self
 
-        searchController = UISearchController(searchResultsController: searchViewController)
+        let searchController = UISearchController(searchResultsController: searchViewController)
         searchController.delegate = searchViewController
 
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.showsSearchResultsController = true
         searchController.searchResultsUpdater = searchViewController
         searchController.scopeBarActivation = .onSearchActivation
-
-        navigationItem.searchController = searchController
 
         // Style our search bar
         searchController.searchBar.backgroundColor = UIColor.navigationBarTintColor
@@ -40,9 +38,12 @@ extension SearchContainer where Self: SearchViewControllerDelegate {
             string: "Search teams and events",
             attributes: [.foregroundColor: UIColor.white.withAlphaComponent(0.7)]
         )
+        return searchController
+    }
 
+    func setupSearchController() {
+        navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
-
         definesPresentationContext = true
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Base/Containers/ContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Containers/ContainerViewController.swift
@@ -89,7 +89,17 @@ class ContainerViewController: UIViewController, Alertable {
 
     private let containerView: UIView = UIView()
     private let viewControllers: [any ContainableViewController]
-    var rootStackView: UIStackView!
+    lazy var rootStackView: UIStackView = {
+        // Skip the segmented control when there's nothing to switch between
+        var arrangedSubviews = [containerView]
+        if segmentedControl.numberOfSegments > 1 {
+            arrangedSubviews.insert(segmentedControlView, at: 0)
+        }
+        let stackView = UIStackView(arrangedSubviews: arrangedSubviews)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        return stackView
+    }()
 
     private lazy var offlineEventView: UIView = {
         let offlineEventLabel = UILabel(forAutoLayout: ())
@@ -151,15 +161,6 @@ class ContainerViewController: UIViewController, Alertable {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Remove segmentedControl if we don't need one
-        var arrangedSubviews = [containerView]
-        if segmentedControl.numberOfSegments > 1 {
-            arrangedSubviews.insert(segmentedControlView, at: 0)
-        }
-
-        rootStackView = UIStackView(arrangedSubviews: arrangedSubviews)
-        rootStackView.translatesAutoresizingMaskIntoConstraints = false
-        rootStackView.axis = .vertical
         view.addSubview(rootStackView)
 
         // Add subviews to view hierarchy in reverse order, so first one is showing automatically

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -12,8 +12,6 @@ class TeamAtDistrictViewController: ContainerViewController {
     private let year: Int
     private var ranking: DistrictRanking
 
-    private var summaryViewController: DistrictTeamSummaryViewController!
-
     // MARK: Init
 
     init(ranking: DistrictRanking, district: District, year: Int, dependencies: Dependencies) {

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
@@ -9,8 +9,6 @@ class EventAlliancesContainerViewController: ContainerViewController {
 
     private(set) var event: Event
 
-    private var alliancesViewController: EventAlliancesViewController!
-
     // MARK: - Init
 
     init(event: Event, dependencies: Dependencies) {

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsContainerViewController.swift
@@ -9,7 +9,7 @@ class EventsContainerViewController: ContainerViewController {
 
     private(set) var eventsViewController: WeekEventsViewController
 
-    var searchController: UISearchController!
+    lazy var searchController: UISearchController = makeSearchController()
 
     // MARK: - Init
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsContainerViewController.swift
@@ -5,9 +5,9 @@ import TBAUtils
 
 class TeamsContainerViewController: ContainerViewController {
 
-    var searchController: UISearchController!
+    lazy var searchController: UISearchController = makeSearchController()
 
-    private(set) var teamsViewController: TeamsViewController!
+    let teamsViewController: TeamsViewController
 
     // MARK: - Init
 


### PR DESCRIPTION
## Summary

The non-outlet implicit unwraps that aren't the 17 data sources in #1157. Each one had a more honest shape:

- **Two were dead.** `TeamAtDistrictViewController.summaryViewController` and `EventAlliancesViewController.alliancesViewController` were never assigned: each init built a same-named local, passed it to `super.init`, and the later `.delegate = self` resolved to the local. Nothing ever read the property, which is the only reason the unwrap never crashed. Deleted.
- `TeamsContainerViewController.teamsViewController` is assigned before `super.init` → `let`.
- `SearchContainer`'s `searchController` was `UISearchController!` on the protocol and assigned by the extension's `setupSearchController()`. The extension now has `makeSearchController()` and the two conformers hold `lazy var searchController = makeSearchController()`; the requirement is a plain `{ get }`. `setupSearchController()` keeps only the three lines that configure the view controller itself.
- `ContainerViewController.rootStackView` builds lazily from the same inputs `viewDidLoad` used (`containerView`, plus the segmented control when there's more than one segment). `ScrollableContainerViewController` still inserts its header after `super.viewDidLoad()`.
- `AppDelegate.api` is `lazy var api = TBAAPI(apiKey: Secrets().tbaAPIKey, …)`, which retires `configureAPI()` and its comment.

**Left as implicit unwraps on purpose:** the 37 `@IBOutlet`s (XIB convention), `MatchSummaryView`'s four alliance views (assigned inside a view-building loop during `init`; un-unwrapping them means restructuring that builder for no behavior gain), and `MyTBATableViewController`'s four, which I'll do after #1157 lands since that file is in it.

## Test plan

- [x] `TBAUnitTests` 79, TBAAPI 152, MyTBAKit 16 pass; `scripts/swift-format.sh --strict` clean; warnings unchanged.
- [x] Launched: Events tab shows the styled search bar and the container layout.
- [ ] Manual: Teams tab search bar present and searching works; Events tab search; Team @ District and Event → Alliances open and their delegates fire (tapping a team/alliance navigates); an event page with a pit map header (`ScrollableContainerViewController`) lays out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
