### PR TITLE
Make the legacy cleanup a single defaults read after first launch

### DIFF
--- a/TBAUnitTests/LegacyCoreDataCleanupTests.swift
+++ b/TBAUnitTests/LegacyCoreDataCleanupTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import The_Blue_Alliance
+
+struct LegacyCoreDataCleanupTests {
+
+    private static func tempDirectory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test func removesTheStoreAndItsSidecarsOnce() throws {
+        let directory = try Self.tempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(["x"], forKey: "successful_refresh_keys")
+        let files = ["TBA.sqlite", "TBA.sqlite-wal", "TBA.sqlite-shm"].map {
+            directory.appendingPathComponent($0)
+        }
+        for file in files { try Data().write(to: file) }
+
+        LegacyCoreDataCleanup.run(userDefaults: defaults, storeDirectories: [directory])
+
+        #expect(files.allSatisfy { !FileManager.default.fileExists(atPath: $0.path) })
+        #expect(defaults.object(forKey: "successful_refresh_keys") == nil)
+
+        // A second run is a no-op: a store that reappears is left alone.
+        try Data().write(to: files[0])
+        LegacyCoreDataCleanup.run(userDefaults: defaults, storeDirectories: [directory])
+        #expect(FileManager.default.fileExists(atPath: files[0].path))
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		5EC0D41A2C26042100000004 /* JSONFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26042100000003 /* JSONFileStore.swift */; };
 		5EC0D41A2C26041F00000002 /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041F00000001 /* AppGroup.swift */; };
 		5EC0D41A2C26042200000002 /* NotificationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26042200000001 /* NotificationStoreTests.swift */; };
+		5EC0D41A2C26070100000010 /* LegacyCoreDataCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C2607010000000F /* LegacyCoreDataCleanupTests.swift */; };
 		92AA7A072F0100000007AAAA /* SessionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA7A062F0100000006AAAA /* SessionMocks.swift */; };
 		92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */; };
 		5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000001 /* EventSectionTests.swift */; };
@@ -232,6 +233,7 @@
 		5EC0D41A2C26042100000003 /* JSONFileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONFileStore.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041F00000001 /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26042200000001 /* NotificationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStoreTests.swift; sourceTree = "<group>"; };
+		5EC0D41A2C2607010000000F /* LegacyCoreDataCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCoreDataCleanupTests.swift; sourceTree = "<group>"; };
 		92AA7A062F0100000006AAAA /* SessionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/SessionMocks.swift"; sourceTree = "<group>"; };
 		92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Services/MyTBASessionServiceTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000001 /* EventSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModels/Event/EventSectionTests.swift"; sourceTree = "<group>"; };
@@ -584,6 +586,7 @@
 			isa = PBXGroup;
 			children = (
 				5EC0D41A2C26042200000001 /* NotificationStoreTests.swift */,
+				5EC0D41A2C2607010000000F /* LegacyCoreDataCleanupTests.swift */,
 				92AA7A062F0100000006AAAA /* SessionMocks.swift */,
 				92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */,
 				5EC0D41A2C26060100000001 /* EventSectionTests.swift */,
@@ -1251,6 +1254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5EC0D41A2C26042200000002 /* NotificationStoreTests.swift in Sources */,
+				5EC0D41A2C26070100000010 /* LegacyCoreDataCleanupTests.swift in Sources */,
 				92AA7A072F0100000007AAAA /* SessionMocks.swift in Sources */,
 				92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */,
 				5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */,

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -85,7 +85,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        runLegacyCleanup()
+        LegacyCoreDataCleanup.run()
         Self.setupAppearance()
 
         configureFirebase()
@@ -133,12 +133,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - Launch setup
 
 private extension AppDelegate {
-
-    func runLegacyCleanup() {
-        LegacyCoreDataCleanup.run()
-        // Old Refreshable cache key, no longer used.
-        UserDefaults.standard.removeObject(forKey: "successful_refresh_keys")
-    }
 
     func configureFirebase() {
         FirebaseApp.configure()

--- a/the-blue-alliance-ios/AppDelegate/LegacyCoreDataCleanup.swift
+++ b/the-blue-alliance-ios/AppDelegate/LegacyCoreDataCleanup.swift
@@ -12,39 +12,45 @@ enum LegacyCoreDataCleanup {
     private static let storeFilename = "TBA.sqlite"
     private static let completedFlagKey = "has_removed_legacy_core_data_store_v1"
 
+    /// One defaults read on every launch after the first; everything else runs once.
     static func run(
         userDefaults: UserDefaults = .standard,
-        fileManager: FileManager = .default
+        storeDirectories: [URL] = legacyStoreDirectories()
     ) {
         guard !userDefaults.bool(forKey: completedFlagKey) else { return }
 
-        for baseURL in legacyStoreBaseURLs(fileManager: fileManager) {
-            removeStoreFiles(at: baseURL, fileManager: fileManager)
+        for directory in storeDirectories {
+            removeStoreFiles(in: directory)
         }
+        // Old Refreshable cache key, no longer used.
+        userDefaults.removeObject(forKey: "successful_refresh_keys")
 
         userDefaults.set(true, forKey: completedFlagKey)
     }
 
-    private static func legacyStoreBaseURLs(fileManager: FileManager) -> [URL] {
+    private static func legacyStoreDirectories() -> [URL] {
         var urls: [URL] = []
-        if let groupURL = fileManager.containerURL(
+        if let groupURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: AppGroup.identifier
         ) {
             urls.append(groupURL)
         }
         urls.append(
-            contentsOf: fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            contentsOf: FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            )
         )
         return urls
     }
 
-    private static func removeStoreFiles(at baseURL: URL, fileManager: FileManager) {
-        let storeURL = baseURL.appendingPathComponent(storeFilename)
+    private static func removeStoreFiles(in directory: URL) {
+        let storeURL = directory.appendingPathComponent(storeFilename)
         let sidecarURLs = ["-wal", "-shm"].map {
-            baseURL.appendingPathComponent(storeFilename + $0)
+            directory.appendingPathComponent(storeFilename + $0)
         }
-        for url in [storeURL] + sidecarURLs where fileManager.fileExists(atPath: url.path) {
-            try? fileManager.removeItem(at: url)
+        for url in [storeURL] + sidecarURLs where FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.removeItem(at: url)
         }
     }
 }


### PR DESCRIPTION
## Summary

- `LegacyCoreDataCleanup.run()` already short-circuited on its completion flag, so the store removal only ever ran once. The `successful_refresh_keys` defaults removal beside it did **not** — it ran every launch. It now sits under the same flag, so a cleaned install pays exactly one `UserDefaults.bool` read at launch and does nothing else.
- Safe to gate: that key's removal shipped in **v3.3.0** and the flag in **v3.4.2**, so any install that has the flag set already ran the unconditional removal at least once. Fresh installs never had the key.
- `run()` takes `storeDirectories:` (default: the app group + Application Support, as before) instead of a `FileManager`, so the new `LegacyCoreDataCleanupTests` can prove the guarantee against a temp directory: first run deletes `TBA.sqlite` and its `-wal`/`-shm` sidecars and clears the key; a store that reappears before the second run is left alone.
- `AppDelegate.runLegacyCleanup()` collapses to the one call.

For the record, the cleanup itself has shipped since v3.4.2 (May 16); removing it entirely is a May 2027 item.

## Test plan

- [x] `TBAUnitTests` 80 pass (1 new); TBAAPI 152, MyTBAKit 16; `scripts/swift-format.sh --strict` clean.
- [ ] Manual: none needed — an already-cleaned device takes the early return; a fresh install runs the removal once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEGDNb3CHj4ff9Hjx7YYQT
