### PR TITLE
Style the search field after the navigation item adopts the bar

### DIFF
--- a/TBAUnitTests/ViewControllers/Search/SearchContainerTests.swift
+++ b/TBAUnitTests/ViewControllers/Search/SearchContainerTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+import UIKit
+
+@testable import The_Blue_Alliance
+
+@MainActor
+struct SearchContainerTests {
+
+    /// A container whose search controller has gone through `setupSearchController()` inside a
+    /// navigation controller and a window, which is what resets the field's appearance.
+    private final class Harness {
+        let window: UIWindow
+        let container: TeamsContainerViewController
+
+        init(style: UIUserInterfaceStyle) {
+            container = TeamsContainerViewController(dependencies: .mock())
+            window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+            window.overrideUserInterfaceStyle = style
+            window.rootViewController = UINavigationController(rootViewController: container)
+            window.makeKeyAndVisible()
+            container.loadViewIfNeeded()
+            window.layoutIfNeeded()
+        }
+
+        var searchTextField: UISearchTextField {
+            container.searchController.searchBar.searchTextField
+        }
+    }
+
+    private static func expectStyled(
+        _ harness: Harness,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        let searchTextField = harness.searchTextField
+        let traits = searchTextField.traitCollection
+
+        #expect(searchTextField.textColor == UIColor.white, sourceLocation: sourceLocation)
+        #expect(searchTextField.tintColor == UIColor.white, sourceLocation: sourceLocation)
+        #expect(
+            searchTextField.leftView?.tintColor == UIColor.white,
+            sourceLocation: sourceLocation
+        )
+        #expect(
+            searchTextField.backgroundColor?.resolvedColor(with: traits)
+                == UIColor.searchFieldBackgroundColor.resolvedColor(with: traits),
+            sourceLocation: sourceLocation
+        )
+        let placeholderColor = searchTextField.attributedPlaceholder?.attribute(
+            .foregroundColor,
+            at: 0,
+            effectiveRange: nil
+        ) as? UIColor
+        #expect(
+            placeholderColor == UIColor.white.withAlphaComponent(0.7),
+            sourceLocation: sourceLocation
+        )
+    }
+
+    @Test(arguments: [UIUserInterfaceStyle.light, .dark])
+    func searchFieldKeepsItsStylingOnceTheNavigationItemAdoptsTheBar(style: UIUserInterfaceStyle) {
+        Self.expectStyled(Harness(style: style))
+    }
+
+    @Test func searchFieldKeepsItsStylingAcrossAnAppearanceChange() {
+        let harness = Harness(style: .light)
+        harness.window.overrideUserInterfaceStyle = .dark
+        harness.window.layoutIfNeeded()
+
+        Self.expectStyled(harness)
+
+        // The field carries the dynamic color itself, not a light-mode snapshot of it.
+        let traits = harness.searchTextField.traitCollection
+        #expect(traits.userInterfaceStyle == .dark)
+        #expect(
+            harness.searchTextField.backgroundColor?.resolvedColor(with: traits)
+                == UIColor.systemGray5.resolvedColor(with: traits)
+        )
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000001 /* DependenciesMocks.swift */; };
 		5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */; };
 		5EC0D41A2C26070100000006 /* TeamsListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */; };
+		5EC0D41A2C26070100000020 /* SearchContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C2607010000001F /* SearchContainerTests.swift */; };
 		5EC0D41A2C26070100000008 /* MyTBATableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */; };
 		5EC0D41A2C26060100000006 /* MatchBreakdownConfigurator2023Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */; };
 		5EC0D41A2C26041B00000002 /* PushNotificationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041B00000001 /* PushNotificationPayload.swift */; };
@@ -241,6 +242,7 @@
 		5EC0D41A2C26070100000001 /* DependenciesMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/DependenciesMocks.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Match/MatchBreakdownViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Teams/TeamsListViewControllerTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C2607010000001F /* SearchContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Search/SearchContainerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/MyTBA/MyTBATableViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewElements/Match/Breakdown/MatchBreakdownConfigurator2023Tests.swift"; sourceTree = "<group>"; };
 		0A1BA028E14B10A8D954C54B /* TBAUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TBAUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -594,6 +596,7 @@
 				5EC0D41A2C26070100000001 /* DependenciesMocks.swift */,
 				5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */,
 				5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */,
+				5EC0D41A2C2607010000001F /* SearchContainerTests.swift */,
 				5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */,
 				5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */,
 			);
@@ -1262,6 +1265,7 @@
 				5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */,
 				5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */,
 				5EC0D41A2C26070100000006 /* TeamsListViewControllerTests.swift in Sources */,
+				5EC0D41A2C26070100000020 /* SearchContainerTests.swift in Sources */,
 				5EC0D41A2C26070100000008 /* MyTBATableViewControllerTests.swift in Sources */,
 				5EC0D41A2C26060100000006 /* MatchBreakdownConfigurator2023Tests.swift in Sources */,
 			);

--- a/the-blue-alliance-ios/AppDelegate/LegacyCoreDataCleanup.swift
+++ b/the-blue-alliance-ios/AppDelegate/LegacyCoreDataCleanup.swift
@@ -15,11 +15,11 @@ enum LegacyCoreDataCleanup {
     /// One defaults read on every launch after the first; everything else runs once.
     static func run(
         userDefaults: UserDefaults = .standard,
-        storeDirectories: [URL] = legacyStoreDirectories()
+        storeDirectories: [URL]? = nil
     ) {
         guard !userDefaults.bool(forKey: completedFlagKey) else { return }
 
-        for directory in storeDirectories {
+        for directory in storeDirectories ?? legacyStoreDirectories() {
             removeStoreFiles(in: directory)
         }
         // Old Refreshable cache key, no longer used.

--- a/the-blue-alliance-ios/Protocols/SearchContainer.swift
+++ b/the-blue-alliance-ios/Protocols/SearchContainer.swift
@@ -22,22 +22,10 @@ extension SearchContainer where Self: SearchViewControllerDelegate {
         searchController.searchResultsUpdater = searchViewController
         searchController.scopeBarActivation = .onSearchActivation
 
-        // Style our search bar
-        searchController.searchBar.backgroundColor = UIColor.navigationBarTintColor
         searchController.searchBar.autocapitalizationType = .words
         searchController.searchBar.scopeButtonTitles = SearchScope.allCases.map { $0.title }
         searchController.searchBar.delegate = searchViewController
 
-        // Style our search bar text field
-        searchController.searchBar.searchTextField.textColor = UIColor.white
-        searchController.searchBar.searchTextField.tintColor = UIColor.white
-        searchController.searchBar.searchTextField.leftView?.tintColor = UIColor.white
-        searchController.searchBar.searchTextField.backgroundColor =
-            UIColor.searchFieldBackgroundColor
-        searchController.searchBar.searchTextField.attributedPlaceholder = NSAttributedString(
-            string: "Search teams and events",
-            attributes: [.foregroundColor: UIColor.white.withAlphaComponent(0.7)]
-        )
         return searchController
     }
 
@@ -45,6 +33,19 @@ extension SearchContainer where Self: SearchViewControllerDelegate {
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
         definesPresentationContext = true
+
+        // Adopting the search bar resets its text field to UIKit's own appearance, so the
+        // colors only stick when they go on after the hand-off.
+        let searchBar = searchController.searchBar
+        searchBar.backgroundColor = UIColor.navigationBarTintColor
+        searchBar.searchTextField.textColor = UIColor.white
+        searchBar.searchTextField.tintColor = UIColor.white
+        searchBar.searchTextField.leftView?.tintColor = UIColor.white
+        searchBar.searchTextField.backgroundColor = UIColor.searchFieldBackgroundColor
+        searchBar.searchTextField.attributedPlaceholder = NSAttributedString(
+            string: "Search teams and events",
+            attributes: [.foregroundColor: UIColor.white.withAlphaComponent(0.7)]
+        )
     }
 
 }


### PR DESCRIPTION
### Search field styling

`#1158` moved `navigationItem.searchController = searchController` ahead of the styling block. UIKit re-applies its own appearance to the search bar's text field as the navigation item takes it over, so every color set beforehand was wiped — `textColor` came back as `labelColor` (dark text on the blue bar) and the magnifier lost its white tint.

`makeSearchController()` now only wires the controller up; the appearance block goes back after the hand-off in `setupSearchController()`, where it lived before `#1158`.

### Legacy cleanup launch-path lookup

`#1161`'s `storeDirectories: [URL] = legacyStoreDirectories()` is a default argument, which Swift evaluates at the call site before the body runs. The app-group `containerURL` lookup — an XPC round-trip that creates the container if it's missing — therefore ran on every launch, including after the completion flag was set, which is the work that PR set out to skip. It's `nil` now and resolved past the `guard`. `LegacyCoreDataCleanupTests` is unchanged and still passes, since it passes directories explicitly.

## Test plan

- `SearchContainerTests` reproduces the regression against the pre-fix code:
  `✘ Expectation failed: (searchTextField.textColor → labelColor) == (UIColor.white → 1 1)`
- New tests are parameterized over `[.light, .dark]`, plus a third that builds in light, flips the window to dark, and re-checks — a trait change is the other event that could re-clobber the field. They assert `textColor`, `tintColor`, the magnifier's `leftView.tintColor`, the placeholder foreground, and that the field carries the dynamic `searchFieldBackgroundColor` (resolving to `systemGray5` under dark traits) rather than a light-mode snapshot.
- `xcodebuild ... -only-testing:TBAUnitTests test` → 82 tests in 10 suites pass.
- Verified in the iPhone 17 Pro simulator in both appearances: white magnifier and 70% white placeholder over the translucent field in light, same over `systemGray5` in dark.
- `./scripts/swift-format.sh --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZtTR44bFNAF64GWmgzFAe