### PR TITLE
Bump the OpenAPI spec to v3.26.0 and wrap team event statuses by year

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Client/TBAAPI+Teams.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Client/TBAAPI+Teams.swift
@@ -152,10 +152,33 @@ nonisolated extension TBAAPI {
         }
     }
 
+    // Teams with no status yet (the event hasn't started) come back as `null` and are dropped.
     public func eventTeamsStatuses(key eventKey: EventKey) async throws -> [String: TeamEventStatus]
     {
         let response = try await client.getEventTeamsStatuses(
             path: .init(eventKey: eventKey)
+        )
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json.additionalProperties.compactMapValues { $0 }
+        case .notModified:
+            throw TBAAPIError.notModified
+        case .unauthorized:
+            throw TBAAPIError.unauthorized
+        case .notFound:
+            throw TBAAPIError.notFound
+        case .undocumented(let statusCode, _):
+            throw TBAAPIError.unexpectedStatus(statusCode)
+        }
+    }
+
+    // Keyed by every event the team is registered for that year. A `nil` value means the
+    // event hasn't started, which is how upcoming registrations are discovered.
+    public func teamEventsStatusesByYear(teamKey: TeamKey, year: Int) async throws
+        -> [EventKey: TeamEventStatus?]
+    {
+        let response = try await client.getTeamEventsStatusesByYear(
+            path: .init(teamKey: teamKey, year: year)
         )
         switch response {
         case .ok(let ok):

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Media/APIMedia+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Media/APIMedia+Helpers.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public typealias MediaBase = Components.Schemas.MediaBase
+public typealias MediaType = Components.Schemas.MediaBase._TypePayload
+
+// `Media` is a discriminated union keyed on `type`, and every branch carries the
+// common fields as `value1`. Flatten that so callers read the shared fields directly.
+extension Media {
+
+    public var base: MediaBase {
+        switch self {
+        case .avatar(let payload): return payload.value1
+        case .cdThread(let payload): return payload.value1
+        case .cdphotothread(let payload): return payload.value1
+        case .externalLink(let payload): return payload.value1
+        case .facebookProfile(let payload): return payload.value1
+        case .githubProfile(let payload): return payload.value1
+        case .gitlabProfile(let payload): return payload.value1
+        case .grabcad(let payload): return payload.value1
+        case .imgur(let payload): return payload.value1
+        case .instagramImage(let payload): return payload.value1
+        case .instagramProfile(let payload): return payload.value1
+        case .onshape(let payload): return payload.value1
+        case .periscopeProfile(let payload): return payload.value1
+        case .smugmugAlbum(let payload): return payload.value1
+        case .smugmugPhoto(let payload): return payload.value1
+        case .twitterProfile(let payload): return payload.value1
+        case .youtube(let payload): return payload.value1
+        case .youtubeChannel(let payload): return payload.value1
+        }
+    }
+
+    public var type: MediaType { base._type }
+    public var foreignKey: String { base.foreignKey }
+    public var preferred: Bool? { base.preferred }
+    public var teamKeys: [String] { base.teamKeys }
+    public var directUrl: String? { base.directUrl }
+    public var viewUrl: String? { base.viewUrl }
+
+    public var avatarBase64Image: String? {
+        guard case .avatar(let payload) = self else { return nil }
+        return payload.value2.details?.base64Image
+    }
+
+}

--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
@@ -4,6 +4,7 @@ import Foundation
 // say `Event` instead of `Components.Schemas.Event`. These are public so the
 // main app target picks them up through `import TBAAPI`.
 public typealias APIStatus = Components.Schemas.APIStatus
+public typealias AllianceColor = Components.Schemas.AllianceColor
 public typealias Award = Components.Schemas.Award
 public typealias AwardType = Components.Schemas.AwardType
 public typealias CompLevel = Components.Schemas.CompLevel
@@ -26,6 +27,7 @@ public typealias Team = Components.Schemas.Team
 public typealias TeamEventStatus = Components.Schemas.TeamEventStatus
 public typealias TeamSimple = Components.Schemas.TeamSimple
 public typealias Webcast = Components.Schemas.Webcast
+public typealias WebcastStatus = Components.Schemas.WebcastStatus
 
 public typealias EventKey = String
 public typealias TeamKey = String

--- a/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/TBAAPIProtocol.swift
@@ -20,6 +20,8 @@ public protocol TBAAPIProtocol: Sendable {
     func teamEventMatches(teamKey: TeamKey, eventKey: EventKey) async throws -> [Match]
     func teamEventAwards(teamKey: TeamKey, eventKey: EventKey) async throws -> [Award]
     func teamEventStatus(teamKey: TeamKey, eventKey: EventKey) async throws -> TeamEventStatus
+    func teamEventsStatusesByYear(teamKey: TeamKey, year: Int) async throws
+        -> [EventKey: TeamEventStatus?]
     func teamMediaByYear(teamKey: TeamKey, year: Int) async throws -> [Media]
 
     func eventTeamsStatuses(key eventKey: EventKey) async throws -> [String: TeamEventStatus]

--- a/Packages/TBAAPI/Sources/TBAAPI/openapi.json
+++ b/Packages/TBAAPI/Sources/TBAAPI/openapi.json
@@ -3,9 +3,9 @@
   "info": {
     "title": "The Blue Alliance API v3",
     "description": "# Overview \n\n Information and statistics about FIRST Robotics Competition teams and events. \n\n# Authentication \n\nAll endpoints require an Auth Key to be passed in the header `X-TBA-Auth-Key`. If you do not have an auth key yet, you can obtain one from your [Account Page](/account).",
-    "version": "3.13.0",
+    "version": "3.26.0",
     "x-version-info": "Versions of the API follow the format X.Y.Z, with X being a major version, Y denoting the minor version, and Z the point release. Changes to the spec or API that result in a major version change will significantly impact implementations. Changes to the minor version indicate paths and/or fields in existing models may be added, and any breaking changes will be confined to paths or models listed as in-development in the prior minor version. Changes to the point release indicate no format or structure changes to the paths or models, but updated or clarified documentation. Note that changes to paths and models refer to the actual result from the API, not the documentation.",
-    "x-changes": "3.13.0: Introduce named integer enum schemas (AwardType, EventType, PlayoffType) using OpenAPI 3.1.1's annotated-enumeration pattern (`oneOf` of `const` branches with per-branch titles). The `award_type`, `event_type`, and `playoff_type` fields now reference these schemas. Integer values on the wire are unchanged; clients regenerated against the spec get value constraints, and Swagger UI renders the value->name mapping inline. 3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
+    "x-changes": "3.26.0: Add the /event/{event_key}/playoff_advancement endpoint, returning computed playoff advancement for an event. For round robin (6-alliance) playoffs it returns a Round Robin Semifinals standings level, ranking alliances by Champ Points and per-year score-breakdown tiebreakers and flagging which alliances advance to the finals, followed by a finals bracket level. Adds the Playoff_Advancement, Playoff_Advancement_Alliance_Rank, and Playoff_Advancement_Sort_Order_Info schemas. 3.25.0: Add the /event/{event_key}/media endpoint, returning media attached to an event itself (SmugMug photo galleries and event YouTube videos), as opposed to /event/{event_key}/team_media which returns media belonging to the event's teams. Populates `direct_url`/`direct_url` derived sizes for `smugmug-album` media (previously empty strings) with the album cover image. 3.24.0: Add the `smugmug-photo` and `smugmug-album` media types, for SmugMug photos and galleries. A `smugmug-photo` may be attached to a team; a `smugmug-album` may be attached to a team or an event, but not both. A `smugmug-album`'s details carry `cover_url`/`cover_url_med`/`cover_url_sm` for the album's cover image. Adds the Media_SmugmugPhoto and Media_SmugmugAlbum schemas. 3.23.0: Add `cmp_qualification` to District_Advancement_Cutoffs on /district/{district_key}/advancement, a mapping of team key to CmpQualificationMethod. This is the same data already projected onto each entry in `teams`, surfaced under `cutoffs` as well because it is computed by TBA from rankings, events and awards rather than sourced from the per-team advancement feed, and so is available even when `teams` is empty. 3.22.1: Fix /district/{district_key}/advancement returning `teams: null` for a district whose advancement has been fetched but is empty; it now returns an empty object, and `null` is reserved for advancement that has never been fetched. 3.22.0: Adds CMP/DCMP qualification cutoffs and methods. 3.21.0: Add the `date` value to the InsightV2 timeseries `x_type` enum. When `x_type` is `date`, each data point's `x` is a Unix timestamp (seconds) at UTC midnight of that day. Adds the `cumulative_matches_by_day` timeseries insight (per-year, `x_type` `date`), tracking the running cumulative count of played matches over the course of a season. 3.20.0: Add the `clubs` InsightV2 category, returning cumulative all-time memberships of teams that reached a milestone. Each member has an `event_added_key` (where the team first qualified) and an optional club-specific `extra_context`. The first club is `hall_of_fame` - teams that won the Impact/Chairman's Award at Championship finals, with `extra_context` carrying the Chairman's video, presentation, and essay links. Adds InsightV2_Clubs, InsightV2_Clubs_Extras, InsightV2ClubsData, InsightV2ClubEntry, and InsightV2HallOfFameContext schemas, and adds `clubs` to the InsightV2 category path parameter enum. 3.19.0: Add `kickoff_datetime` to API_Status, an ISO 8601 UTC datetime for the upcoming season's FRC Kickoff. 3.18.0: Rename the InsightV2 `success_rate` category to `game_stats`, and add `qual_averages`/`playoff_averages` to each InsightV2GameStatsScope - non-binary average statistics (e.g. average score, average win margin) for a season overall, per competition week, and per event, alongside the existing count/opportunities statistics. Renames InsightV2_SuccessRate, InsightV2_SuccessRate_Extras, InsightV2SuccessRateData, InsightV2SuccessRateScope, and InsightV2SuccessRateEntry to InsightV2_GameStats, InsightV2_GameStats_Extras, InsightV2GameStatsData, InsightV2GameStatsScope, and InsightV2GameStat respectively, and adds the InsightV2AverageStat schema. 3.17.1: Add success_rate to the InsightV2 category path parameter enum, so /insights/{year}/{category} and its district variant document the category the API already serves. 3.17.0: Add the `success_rate` InsightV2 category, returning count/opportunities statistics (bonus ranking points and game-specific objectives) for a season overall, per competition week, and per event. Adds InsightV2_SuccessRate, InsightV2SuccessRateData, InsightV2SuccessRateScope, and InsightV2SuccessRate schemas. 3.16.0: Add /event/{event_key}/nexus_info endpoint, returning cached live match-queuing info sourced from Nexus (https://frc.nexus/) for an event, or null if unavailable. Adds Nexus_Event_Info, Nexus_Now_Queueing, Nexus_Match_Info, and Nexus_Match_Timing schemas. 3.15.0: Add InsightV2 endpoints and schemas. Introduces /insights/{year}, /insights/{year}/{category}, /insights/{year}/district/{district_abbreviation}, and /insights/{year}/{category}/district/{district_abbreviation} routes returning typed InsightV2 objects with leaderboard, streak, and timeseries categories. Use year=0 for all-time insights. 3.14.0: Introduce named string enum schemas (AllianceColor, WebcastStatus). Webcast.status now references the WebcastStatus schema. AllianceColor includes red, blue, and empty string for no winner or tie; Match.winning_alliance references AllianceColor. Wire values are unchanged; clients regenerated against the spec get correctly-named enum members. 3.13.0: Introduce named integer enum schemas (AwardType, EventType, PlayoffType) using OpenAPI 3.1.1's annotated-enumeration pattern (`oneOf` of `const` branches with per-branch titles). The `award_type`, `event_type`, and `playoff_type` fields now reference these schemas. Integer values on the wire are unchanged; clients regenerated against the spec get value constraints, and Swagger UI renders the value->name mapping inline. 3.12.2: Renames District `highest_qual_scores` tiebreaker to `highest_match_scores` to more accurately reflect district rankings. 3.12.1: Add pit_location to Team_Event_Status. 3.12.0: Add 2026 score breakdowns. 3.11.0: Deprecate Event.lat, Event.lng, Event.gmaps_place_id, Event.gmaps_url. Event models will no longer be geocoded. Moving forward, these fields will return null. Eventually these fields will be removed. Event.address will now return FRC-API address, and Event.location_name will return FRC-API venue. 3.10.1: Add remap_teams to event. 3.10.0: Upgrade to Openapi v3.1.1. 3.9.16: Marked Event.timezone as nullable, renamed District_List to District. 3.9.15: Add onshape to media type. 3.9.14: Adds max_team_page to Status. 3.9.13: Fixes missing 2023 endgame enum. 3.9.12: Updates 2025 match breakdown penalties to be correct for 2025. 3.9.11: Adds tba_botRowCount, tba_midRowCount, and tba_topRowCount to 2025 match breakdown autoReef and teleopReef. 3.9.10: Add 2025 score breakdowns. 3.9.9: Fix nullable fields within Team_Event_Status. 3.9.8: Add district awards endpoint. Add nullable to district rankings. 3.9.7: Add district history endpoint. 3.9.6: Added History endpoint; added NotablesInsight endpoint. 3.9.5: Properly documented that event.district may be null. 3.9.4: Properly documented that a Status may be null (future events). 3.9.3: Proper nullable event rankings/oprs/coprs 3.9.2: Add event/key/team_media endpoint; add team_keys to media objects. 3.9.1: Mark WLT_Record as nullable. 3.8.2-3.9.0: Fixed undefined vs nullable fields. Adds 2024 score breakdown. Links score breakdown types to score_breakdown field. Adds leaderboard insights endpoint and type. 3.8.1-3.8.2: Replace `If-Modified-Since` with `If-None-Match` and `Last-Modified` with `ETag`. 3.8.0-3.8.1: Added Webcast date field. 3.7.0-3.8.0: Added 2020 Match Breakdown. 3.6.0-3.7.0: Added Zebra MotionWorks endpoints and models. 3.5.2-3.6.0: Added `school_name` to the Team model. 3.5.1-3.5.2: Removed `key` from the Media object, set `foreign_key` as a required property. 3.5-3.5.1: Fixed api clients crashing when requesting simple matches resulting in ties. 3.04.1 - 3.5: Updated the spec to follow OpenAPI standards. 3.04.0 - 3.04.1: Team motto will now return null. 3.03.1 - 3.04.0: Add direct_url and view_url to the Media model. 3.03.0 - 3.03.1: Fix model of /team/{team_key}/robots to match API, add min and max for year and add min for page_num. 3.02.1 - 3.03.0: Added Timeseries models and endpoints. 3.02.0 - 3.02.1: Fixed the model for `/team/{team_key}/districts` to match return from API. 3.1.0 - 3.02.0: Added `tba_gameData` to score breakdown and a leading zero to the minor version number to allow for easier sorting later. 3.0.5 - 3.1.0: Version bump for 2018 added fields and endpoints. Models Updated: `Team_Event_Status`, `Media`, 2018 Score Breakdowns. Endpoints Added: `/team/{team_key}/events/{year}/statuses`, `/event/{event_key}/teams/statuses` 3.0.4 - 3.0.5: Minor spelling fixes. Remove 2016 fields from `Match_Score_Breakdown_2017_Alliance` model. Fix `first_event_id` in `Event` model to correct type. Update `Media`.`type` enum. --- 3.0.3 - 3.0.4: Correct syntax in `Team_Event_Status_playoff` object, include descriptions in `Event_District_Points` and fix the path in `Team_Event_Status_playoff.properties.record` in order to more closely match Swagger spec. Fix syntax of `Match.video` to be correct and accurately reflect what is returned by the API. --- 3.0.2 - 3.0.3: `extra_stats` and `extra_stats_info` added to `Event_Ranking` model. Corrected match video property claiming to use the `Media` model, which it doesn't. Added `first_event_code` to the `Event` model. Added `/team/{team_key}/media/tag/{media_tag}` and year endpoints. Added `dq_team_keys` to `Match_alliance` model.  --- 3.0.1 - 3.0.2: `Team_Event_Status` and `Event_Ranking` model documentation changed to reflect actual API return. Changes involved W-L-T and ranking properties. --- 3.0.0 - 3.0.1: Descriptions updated to clarify some terms and improve grammar. The `district` property on the `Event` object now points to the `District_List` model, which was identical. `Required` fields on fully documented models now represent fields that may not be `null`. `District_Ranking` model documented."
   },
   "servers": [
     {
@@ -237,7 +237,7 @@
           "district",
           "team"
         ],
-        "description": "Gets a list of advancement information per team in a district.",
+        "description": "Gets per-team advancement information and the advancement cutoffs for a district.",
         "operationId": "getDistrictAdvancement",
         "parameters": [
           {
@@ -267,14 +267,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "description": "A mapping of team key to District_Advancement",
-                  "additionalProperties": {
-                    "$ref": "#/components/schemas/District_Advancement"
-                  }
+                  "$ref": "#/components/schemas/District_Advancement_Response"
                 }
               }
             }
@@ -1510,6 +1503,123 @@
         ]
       }
     },
+    "/event/{event_key}/media": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a list of media objects associated with this event itself (e.g. SmugMug photo galleries and event videos), as opposed to media belonging to the event's teams.",
+        "operationId": "getEventMedia",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Media"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/nexus_info": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets live match-queuing info for an event from Nexus (https://frc.nexus/), or `null` if no data is currently available for this event.",
+        "operationId": "getEventNexusInfo",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Nexus_Event_Info"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
     "/event/{event_key}/oprs": {
       "get": {
         "tags": [
@@ -1546,6 +1656,66 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Event_OPRs"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/event/{event_key}/playoff_advancement": {
+      "get": {
+        "tags": [
+          "event"
+        ],
+        "description": "Gets a list of playoff advancement levels for the given Event. For round robin (6-alliance) playoffs the first entry is the Round Robin Semifinals standings; the last entry is the finals bracket. Returns an empty list for events without computed playoff advancement.",
+        "operationId": "getEventPlayoffAdvancement",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/event_key"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Playoff_Advancement"
+                  }
                 }
               }
             }
@@ -2380,6 +2550,258 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/NotablesInsight"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/insights/{year}": {
+      "get": {
+        "tags": [
+          "insight"
+        ],
+        "description": "Gets a list of `InsightV2` objects for the given year across all categories. Use year=0 for all-time insights. Returns only global (non-district-scoped) insights.",
+        "operationId": "getInsightsV2Year",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InsightV2"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/insights/{year}/{category}": {
+      "get": {
+        "tags": [
+          "insight"
+        ],
+        "description": "Gets a list of `InsightV2` objects for the given year filtered by category. Use year=0 for all-time insights. Returns only global (non-district-scoped) insights. Valid categories: leaderboard, streak, timeseries, game_stats, clubs.",
+        "operationId": "getInsightsV2YearCategory",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          },
+          {
+            "$ref": "#/components/parameters/insight_v2_category"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InsightV2"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/insights/{year}/district/{district_abbreviation}": {
+      "get": {
+        "tags": [
+          "insight"
+        ],
+        "description": "Gets a list of `InsightV2` objects for the given year scoped to a specific district, across all categories. Use year=0 for all-time insights.",
+        "operationId": "getInsightsV2YearDistrict",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          },
+          {
+            "$ref": "#/components/parameters/district_abbreviation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InsightV2"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/insights/{year}/{category}/district/{district_abbreviation}": {
+      "get": {
+        "tags": [
+          "insight"
+        ],
+        "description": "Gets a list of `InsightV2` objects for the given year, category, and district. Use year=0 for all-time insights. Valid categories: leaderboard, streak, timeseries, game_stats, clubs.",
+        "operationId": "getInsightsV2YearCategoryDistrict",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/components/parameters/year"
+          },
+          {
+            "$ref": "#/components/parameters/insight_v2_category"
+          },
+          {
+            "$ref": "#/components/parameters/district_abbreviation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "Cache-Control": {
+                "description": "The `Cache-Control` header, in particular the `max-age` value, contains the number of seconds the result should be considered valid for. During this time subsequent calls should return from the local cache directly.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Specifies the version of the most recent response. Used by clients in the `If-None-Match` request header.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InsightV2"
                   }
                 }
               }
@@ -3344,7 +3766,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Match"
+                    "$ref": "#/components/schemas/Match_Simple"
                   }
                 }
               }
@@ -4962,6 +5384,10 @@
           "max_team_page": {
             "type": "integer",
             "description": "Maximum team page number for valid queries."
+          },
+          "kickoff_datetime": {
+            "type": "string",
+            "description": "ISO 8601 datetime (UTC) of FRC Kickoff for the upcoming season."
           }
         }
       },
@@ -4981,6 +5407,21 @@
             "description": "Internal use - Latest application version available."
           }
         }
+      },
+      "AllianceColor": {
+        "title": "AllianceColor",
+        "description": "The color of an alliance, or an empty string when there is no winning alliance (e.g. tie or no result). See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/alliance_color.py for red/blue definitions.",
+        "type": "string",
+        "enum": [
+          "red",
+          "blue",
+          ""
+        ],
+        "x-enum-varnames": [
+          "RED",
+          "BLUE",
+          "NO_ALLIANCE"
+        ]
       },
       "AutoChargeStationRobot_2023": {
         "type": "string",
@@ -5328,6 +5769,53 @@
           "CUSTOM"
         ]
       },
+      "CmpQualificationMethod": {
+        "title": "CmpQualificationMethod",
+        "description": "How a team earned its invitation to the FIRST Championship. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/cmp_qualification.py for full definitions.",
+        "type": "string",
+        "enum": [
+          "district_points",
+          "waitlist",
+          "original_and_sustaining",
+          "hall_of_fame",
+          "prior_year_cmp_winner",
+          "prior_year_cmp_impact",
+          "prior_year_cmp_engineering_inspiration",
+          "regional_winner",
+          "regional_impact",
+          "regional_engineering_inspiration",
+          "regional_wildcard",
+          "late_regional_winner",
+          "late_regional_impact",
+          "late_regional_engineering_inspiration",
+          "late_regional_wildcard",
+          "dcmp_winner",
+          "dcmp_impact",
+          "dcmp_engineering_inspiration",
+          "dcmp_rookie_all_star"
+        ],
+        "x-enum-varnames": [
+          "DISTRICT_POINTS",
+          "WAITLIST",
+          "ORIGINAL_AND_SUSTAINING",
+          "HALL_OF_FAME",
+          "PRIOR_YEAR_CMP_WINNER",
+          "PRIOR_YEAR_CMP_IMPACT",
+          "PRIOR_YEAR_CMP_ENGINEERING_INSPIRATION",
+          "REGIONAL_WINNER",
+          "REGIONAL_IMPACT",
+          "REGIONAL_ENGINEERING_INSPIRATION",
+          "REGIONAL_WILDCARD",
+          "LATE_REGIONAL_WINNER",
+          "LATE_REGIONAL_IMPACT",
+          "LATE_REGIONAL_ENGINEERING_INSPIRATION",
+          "LATE_REGIONAL_WILDCARD",
+          "DCMP_WINNER",
+          "DCMP_IMPACT",
+          "DCMP_ENGINEERING_INSPIRATION",
+          "DCMP_ROOKIE_ALL_STAR"
+        ]
+      },
       "District": {
         "required": [
           "abbreviation",
@@ -5433,9 +5921,88 @@
           "cmp": {
             "type": "boolean",
             "description": "Whether or not the team qualified for the FIRST Championship"
+          },
+          "cmp_qualification": {
+            "description": "How the team qualified for the FIRST Championship, or `null` if the team did not qualify.",
+            "$ref": "#/components/schemas/CmpQualificationMethod"
           }
         },
         "description": "Advancement status of a team in a district."
+      },
+      "District_Advancement_Cutoffs": {
+        "required": [
+          "cmp_declines",
+          "cmp_effective",
+          "cmp_original",
+          "cmp_qualification",
+          "dcmp_declines",
+          "dcmp_effective",
+          "dcmp_original"
+        ],
+        "type": "object",
+        "properties": {
+          "dcmp_original": {
+            "type": "integer",
+            "description": "The rank at which the District Championship cutoff would have fallen before any declines were applied."
+          },
+          "dcmp_effective": {
+            "type": "integer",
+            "description": "The rank at which the District Championship cutoff actually fell, after declines were backfilled."
+          },
+          "dcmp_declines": {
+            "type": "array",
+            "description": "TBA team keys for teams that declined their District Championship invitation.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cmp_original": {
+            "type": "integer",
+            "description": "The rank at which the FIRST Championship cutoff would have fallen before any declines were applied."
+          },
+          "cmp_effective": {
+            "type": "integer",
+            "description": "The rank at which the FIRST Championship cutoff actually fell, after declines were backfilled."
+          },
+          "cmp_declines": {
+            "type": "array",
+            "description": "TBA team keys for teams that declined their FIRST Championship invitation.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cmp_qualification": {
+            "type": "object",
+            "description": "A mapping of team key to how that team earned its FIRST Championship invitation. Populated independently of the per-team advancement data, so it is present even when `teams` is empty.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CmpQualificationMethod"
+            }
+          }
+        },
+        "description": "Where the District Championship and FIRST Championship advancement cutoffs fell for a district, and how each qualifying team earned its Championship invitation."
+      },
+      "District_Advancement_Response": {
+        "required": [
+          "teams"
+        ],
+        "type": "object",
+        "properties": {
+          "teams": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "description": "A mapping of team key to District_Advancement. An empty object means advancement has been fetched but no teams are listed yet; `null` means it has never been fetched for this district.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/District_Advancement"
+            }
+          },
+          "cutoffs": {
+            "description": "Where the advancement cutoffs fell for the district, or `null` if they have not been calculated yet.",
+            "$ref": "#/components/schemas/District_Advancement_Cutoffs"
+          }
+        },
+        "description": "Per-team advancement status and the advancement cutoffs for a district."
       },
       "District_Insight": {
         "type": "object",
@@ -6951,7 +7518,7 @@
                 },
                 "qual_average": {
                   "type": [
-                    "integer",
+                    "number",
                     "null"
                   ],
                   "description": "The average match score during qualifications. Year specific. May be null if not relevant for a given year."
@@ -7251,13 +7818,8 @@
             "description": "A list of alliances, the teams on the alliances, and their score."
           },
           "winning_alliance": {
-            "type": "string",
             "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.",
-            "enum": [
-              "red",
-              "blue",
-              ""
-            ]
+            "$ref": "#/components/schemas/AllianceColor"
           },
           "event_key": {
             "type": "string",
@@ -7869,7 +8431,7 @@
             "type": "integer"
           },
           "rp": {
-            "type": "integer"
+            "type": "number"
           },
           "techFoulCount": {
             "type": "integer"
@@ -8128,7 +8690,7 @@
             "$ref": "#/components/schemas/EndgameRobot_2019"
           },
           "rp": {
-            "type": "integer"
+            "type": "number"
           },
           "sandStormBonusPoints": {
             "type": "integer"
@@ -8306,7 +8868,7 @@
             "type": "integer"
           },
           "rp": {
-            "type": "integer"
+            "type": "number"
           },
           "totalPoints": {
             "type": "integer"
@@ -8448,7 +9010,7 @@
           },
           "rp": {
             "type": [
-              "integer",
+              "number",
               "null"
             ]
           },
@@ -8709,7 +9271,7 @@
             "type": "integer"
           },
           "rp": {
-            "type": "integer"
+            "type": "number"
           },
           "totalPoints": {
             "type": "integer"
@@ -8854,7 +9416,7 @@
             "type": "boolean"
           },
           "rp": {
-            "type": "integer"
+            "type": "number"
           },
           "techFoulCount": {
             "type": "integer"
@@ -9054,7 +9616,7 @@
             "type": "integer"
           },
           "rp": {
-            "type": "integer"
+            "type": "number"
           },
           "techFoulCount": {
             "type": "integer"
@@ -9200,7 +9762,7 @@
             "type": "integer"
           },
           "rp": {
-            "type": "integer"
+            "type": "number"
           },
           "superchargedAchieved": {
             "type": "boolean"
@@ -9269,13 +9831,8 @@
             "description": "A list of alliances, the teams on the alliances, and their score."
           },
           "winning_alliance": {
-            "type": "string",
             "description": "The color (red/blue) of the winning alliance. Will contain an empty string in the event of no winner, or a tie.",
-            "enum": [
-              "red",
-              "blue",
-              ""
-            ]
+            "$ref": "#/components/schemas/AllianceColor"
           },
           "event_key": {
             "type": "string",
@@ -9475,12 +10032,93 @@
         }
       },
       "Media": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Media_Avatar"
+          },
+          {
+            "$ref": "#/components/schemas/Media_CdPhotoThread"
+          },
+          {
+            "$ref": "#/components/schemas/Media_CdThread"
+          },
+          {
+            "$ref": "#/components/schemas/Media_GrabCad"
+          },
+          {
+            "$ref": "#/components/schemas/Media_NoDetails"
+          },
+          {
+            "$ref": "#/components/schemas/Media_Onshape"
+          },
+          {
+            "$ref": "#/components/schemas/Media_SmugmugAlbum"
+          },
+          {
+            "$ref": "#/components/schemas/Media_SmugmugPhoto"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "avatar": "#/components/schemas/Media_Avatar",
+            "cdphotothread": "#/components/schemas/Media_CdPhotoThread",
+            "cd-thread": "#/components/schemas/Media_CdThread",
+            "grabcad": "#/components/schemas/Media_GrabCad",
+            "youtube": "#/components/schemas/Media_NoDetails",
+            "imgur": "#/components/schemas/Media_NoDetails",
+            "facebook-profile": "#/components/schemas/Media_NoDetails",
+            "youtube-channel": "#/components/schemas/Media_NoDetails",
+            "twitter-profile": "#/components/schemas/Media_NoDetails",
+            "github-profile": "#/components/schemas/Media_NoDetails",
+            "instagram-profile": "#/components/schemas/Media_NoDetails",
+            "periscope-profile": "#/components/schemas/Media_NoDetails",
+            "gitlab-profile": "#/components/schemas/Media_NoDetails",
+            "instagram-image": "#/components/schemas/Media_NoDetails",
+            "external-link": "#/components/schemas/Media_NoDetails",
+            "onshape": "#/components/schemas/Media_Onshape",
+            "smugmug-album": "#/components/schemas/Media_SmugmugAlbum",
+            "smugmug-photo": "#/components/schemas/Media_SmugmugPhoto"
+          }
+        },
+        "description": "The `Media` object contains a reference for most any media associated with a team or event on TBA."
+      },
+      "Media_Avatar": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "$ref": "#/components/schemas/Media_Avatar_Extras"
+          }
+        ]
+      },
+      "Media_Avatar_Extras": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "avatar"
+          },
+          "details": {
+            "type": "object",
+            "required": [
+              "base64Image"
+            ],
+            "properties": {
+              "base64Image": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Media_Base": {
+        "type": "object",
         "required": [
           "type",
           "foreign_key",
           "team_keys"
         ],
-        "type": "object",
         "properties": {
           "type": {
             "type": "string",
@@ -9501,164 +10139,14 @@
               "external-link",
               "avatar",
               "onshape",
-              "cd-thread"
+              "cd-thread",
+              "smugmug-photo",
+              "smugmug-album"
             ]
           },
           "foreign_key": {
             "type": "string",
             "description": "The key used to identify this media on the media site."
-          },
-          "details": {
-            "type": "object",
-            "description": "If required, a JSON dict of additional media information.",
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {},
-                "additionalProperties": false
-              },
-              {
-                "properties": {
-                  "base64Image": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "base64Image"
-                ],
-                "type": "object"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "author_id": {
-                    "type": "integer"
-                  },
-                  "author_name": {
-                    "type": "string"
-                  },
-                  "author_url": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "height": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "html": {
-                    "type": "string"
-                  },
-                  "media_id": {
-                    "type": "string"
-                  },
-                  "provider_name": {
-                    "type": "string"
-                  },
-                  "provider_url": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "thumbnail_height": {
-                    "type": "integer"
-                  },
-                  "thumbnail_url": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "thumbnail_width": {
-                    "type": "integer"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string"
-                  },
-                  "version": {
-                    "type": "string"
-                  },
-                  "width": {
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "author_id",
-                  "author_name",
-                  "author_url",
-                  "height",
-                  "html",
-                  "media_id",
-                  "provider_name",
-                  "provider_url",
-                  "thumbnail_height",
-                  "thumbnail_url",
-                  "thumbnail_width",
-                  "title",
-                  "type",
-                  "version",
-                  "width"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "model_created": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "model_description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "model_image": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "model_name": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "model_created",
-                  "model_description",
-                  "model_image",
-                  "model_name"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "image_partial": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "image_partial"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "thread_title": {
-                    "type": "string"
-                  },
-                  "image_url": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "thread_title",
-                  "image_url"
-                ]
-              }
-            ]
           },
           "preferred": {
             "type": "boolean",
@@ -9680,14 +10168,387 @@
             "type": "string",
             "description": "The URL that leads to the full web page for the media, if one exists."
           }
-        },
-        "description": "The `Media` object contains a reference for most any media associated with a team or event on TBA."
+        }
+      },
+      "Media_CdPhotoThread": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "cdphotothread"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "image_partial"
+                ],
+                "properties": {
+                  "image_partial": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Media_CdThread": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "cd-thread"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "thread_title",
+                  "image_url"
+                ],
+                "properties": {
+                  "thread_title": {
+                    "type": "string"
+                  },
+                  "image_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Media_GrabCad": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "grabcad"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "model_created",
+                  "model_description",
+                  "model_image",
+                  "model_name"
+                ],
+                "properties": {
+                  "model_created": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
+                  },
+                  "model_description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "model_image": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "model_name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Media_NoDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "youtube",
+                  "imgur",
+                  "facebook-profile",
+                  "youtube-channel",
+                  "twitter-profile",
+                  "github-profile",
+                  "instagram-profile",
+                  "periscope-profile",
+                  "gitlab-profile",
+                  "instagram-image",
+                  "external-link"
+                ]
+              },
+              "details": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              }
+            }
+          }
+        ]
+      },
+      "Media_Onshape": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "onshape"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "model_created",
+                  "model_description",
+                  "model_image",
+                  "model_name"
+                ],
+                "properties": {
+                  "model_created": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
+                  },
+                  "model_description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "model_image": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "model_name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Media_SmugmugAlbum": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "smugmug-album"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "cover_url",
+                  "cover_url_med",
+                  "cover_url_sm",
+                  "image_count",
+                  "title",
+                  "web_uri"
+                ],
+                "properties": {
+                  "cover_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "cover_url_med": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "cover_url_sm": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "image_count": {
+                    "type": "integer"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "web_uri": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Media_SmugmugPhoto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Media_Base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "smugmug-photo"
+              },
+              "details": {
+                "type": "object",
+                "required": [
+                  "caption",
+                  "image_url",
+                  "image_url_med",
+                  "image_url_sm",
+                  "title",
+                  "web_uri"
+                ],
+                "properties": {
+                  "caption": {
+                    "type": "string"
+                  },
+                  "image_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "image_url_med": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "image_url_sm": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "web_uri": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              }
+            }
+          }
+        ]
       },
       "MobilityRobot_2023": {
         "type": "string",
         "enum": [
           "No",
           "Yes"
+        ]
+      },
+      "Nexus_Match_Timing": {
+        "type": "object",
+        "description": "Estimated timing for a match, as reported by Nexus.",
+        "properties": {
+          "estimated_queue_time_ms": {
+            "description": "Estimated Unix timestamp (in milliseconds) of when the match will be queued, or null if unknown.",
+            "type": "integer"
+          },
+          "estimated_start_time_ms": {
+            "description": "Estimated Unix timestamp (in milliseconds) of when the match will start, or null if unknown.",
+            "type": "integer"
+          }
+        },
+        "required": []
+      },
+      "Nexus_Match_Info": {
+        "type": "object",
+        "description": "Live match-queuing info for a single match, as reported by Nexus.",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "The match label as reported by Nexus, e.g. `Qualification 5`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Queuing soon",
+              "Now queuing",
+              "On deck",
+              "On field"
+            ],
+            "description": "The current queuing status of the match."
+          },
+          "played": {
+            "type": "boolean",
+            "description": "Whether the match has been played."
+          },
+          "times": {
+            "$ref": "#/components/schemas/Nexus_Match_Timing"
+          }
+        },
+        "required": [
+          "label",
+          "status",
+          "played",
+          "times"
+        ]
+      },
+      "Nexus_Now_Queueing": {
+        "type": "object",
+        "description": "The match currently being queued, as reported by Nexus.",
+        "properties": {
+          "match_key": {
+            "type": "string",
+            "description": "TBA match key for the match currently being queued."
+          },
+          "match_name": {
+            "type": "string",
+            "description": "The match name as reported by Nexus, e.g. `Qualification 5`."
+          }
+        },
+        "required": [
+          "match_key",
+          "match_name"
+        ]
+      },
+      "Nexus_Event_Info": {
+        "type": "object",
+        "description": "Live match-queuing info for an event, sourced from Nexus (https://frc.nexus/) and cached by TBA.",
+        "properties": {
+          "data_as_of_ms": {
+            "type": "integer",
+            "description": "Unix timestamp (in milliseconds) of when this data was last fetched from Nexus."
+          },
+          "now_queueing": {
+            "$ref": "#/components/schemas/Nexus_Now_Queueing"
+          },
+          "matches": {
+            "type": "object",
+            "description": "Map of TBA match key to live queuing info for that match.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Nexus_Match_Info"
+            }
+          }
+        },
+        "required": [
+          "data_as_of_ms",
+          "matches"
         ]
       },
       "NotablesInsight": {
@@ -9735,6 +10596,688 @@
           "name",
           "year"
         ]
+      },
+      "InsightV2": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/InsightV2_Leaderboard"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_Streak"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_Timeseries"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_GameStats"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_Clubs"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "category",
+          "mapping": {
+            "leaderboard": "#/components/schemas/InsightV2_Leaderboard",
+            "streak": "#/components/schemas/InsightV2_Streak",
+            "timeseries": "#/components/schemas/InsightV2_Timeseries",
+            "game_stats": "#/components/schemas/InsightV2_GameStats",
+            "clubs": "#/components/schemas/InsightV2_Clubs"
+          }
+        },
+        "description": "A typed insight object. Use `category` to discriminate between leaderboard, streak, timeseries, game stats, and clubs shapes."
+      },
+      "InsightV2_Base": {
+        "type": "object",
+        "required": [
+          "name",
+          "display_name",
+          "year",
+          "category",
+          "district_abbreviation"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Programmatic name of the insight, e.g. `blue_banners`."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Human-readable name of the insight, e.g. `Total Blue Banners`."
+          },
+          "year": {
+            "type": "integer",
+            "description": "Year the insight was measured in. Use 0 for all-time insights."
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "leaderboard",
+              "streak",
+              "timeseries",
+              "game_stats",
+              "clubs"
+            ],
+            "description": "Insight category. Discriminates the shape of `data`."
+          },
+          "district_abbreviation": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "District abbreviation if the insight is district-scoped, otherwise null."
+          }
+        }
+      },
+      "InsightV2_Leaderboard": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InsightV2_Base"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_Leaderboard_Extras"
+          }
+        ]
+      },
+      "InsightV2_Leaderboard_Extras": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "category": {
+            "const": "leaderboard"
+          },
+          "data": {
+            "$ref": "#/components/schemas/InsightV2LeaderboardData"
+          }
+        }
+      },
+      "InsightV2_Streak": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InsightV2_Base"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_Streak_Extras"
+          }
+        ]
+      },
+      "InsightV2_Streak_Extras": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "category": {
+            "const": "streak"
+          },
+          "data": {
+            "$ref": "#/components/schemas/InsightV2StreakData"
+          }
+        }
+      },
+      "InsightV2_Timeseries": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InsightV2_Base"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_Timeseries_Extras"
+          }
+        ]
+      },
+      "InsightV2_Timeseries_Extras": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "category": {
+            "const": "timeseries"
+          },
+          "data": {
+            "$ref": "#/components/schemas/InsightV2TimeseriesData"
+          }
+        }
+      },
+      "InsightV2_GameStats": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InsightV2_Base"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_GameStats_Extras"
+          }
+        ]
+      },
+      "InsightV2_GameStats_Extras": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "category": {
+            "const": "game_stats"
+          },
+          "data": {
+            "$ref": "#/components/schemas/InsightV2GameStatsData"
+          }
+        }
+      },
+      "InsightV2_Clubs": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InsightV2_Base"
+          },
+          {
+            "$ref": "#/components/schemas/InsightV2_Clubs_Extras"
+          }
+        ]
+      },
+      "InsightV2_Clubs_Extras": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "category": {
+            "const": "clubs"
+          },
+          "data": {
+            "$ref": "#/components/schemas/InsightV2ClubsData"
+          }
+        }
+      },
+      "InsightV2ClubsData": {
+        "type": "object",
+        "description": "Data for a clubs-category InsightV2. A cumulative all-time membership of teams that reached a milestone.",
+        "required": [
+          "entries",
+          "context_type"
+        ],
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "Club members, sorted ascending by team number.",
+            "items": {
+              "$ref": "#/components/schemas/InsightV2ClubEntry"
+            }
+          },
+          "context_type": {
+            "type": "string",
+            "enum": [
+              "hall_of_fame",
+              "none"
+            ],
+            "description": "Discriminates the shape of each entry's `extra_context`. `none` means entries have no `extra_context`."
+          }
+        }
+      },
+      "InsightV2ClubEntry": {
+        "type": "object",
+        "description": "A single club member.",
+        "required": [
+          "team_key",
+          "event_added_key"
+        ],
+        "properties": {
+          "team_key": {
+            "type": "string",
+            "description": "Team key of the club member, e.g. `frc254`."
+          },
+          "event_added_key": {
+            "type": "string",
+            "description": "Key of the event where the team first qualified for the club."
+          },
+          "extra_context": {
+            "$ref": "#/components/schemas/InsightV2HallOfFameContext",
+            "description": "Club-specific extra material for this member. Present when the club's `context_type` is `hall_of_fame`."
+          }
+        }
+      },
+      "InsightV2HallOfFameContext": {
+        "type": "object",
+        "description": "Chairman's Award material for a Hall of Fame team, scraped from the FIRST resource library.",
+        "required": [
+          "year",
+          "video",
+          "presentation",
+          "essay"
+        ],
+        "properties": {
+          "year": {
+            "type": "integer",
+            "description": "Year the team was inducted (year of `event_added_key`)."
+          },
+          "video": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URL of the team's Chairman's video, or null."
+          },
+          "presentation": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URL of the team's Chairman's presentation, or null."
+          },
+          "essay": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URL of the team's Chairman's essay, or null."
+          }
+        }
+      },
+      "InsightV2LeaderboardData": {
+        "type": "object",
+        "description": "Data for a leaderboard-category InsightV2. Rankings of teams, events, or matches by a numeric value.",
+        "required": [
+          "rankings",
+          "key_type",
+          "context_type"
+        ],
+        "properties": {
+          "key_type": {
+            "type": "string",
+            "enum": [
+              "team",
+              "event",
+              "match",
+              "team_pair",
+              "alliance"
+            ],
+            "description": "What kind of keys appear in the rankings."
+          },
+          "context_type": {
+            "type": "string",
+            "enum": [
+              "event_list",
+              "none",
+              "match_alliance"
+            ],
+            "description": "Whether rankings include per-entry context."
+          },
+          "rankings": {
+            "type": "array",
+            "description": "Ranked entries, ordered from highest to lowest value.",
+            "items": {
+              "type": "object",
+              "required": [
+                "keys",
+                "value"
+              ],
+              "properties": {
+                "keys": {
+                  "description": "Team/event/match keys sharing this rank. For team_pair, a list of two-element lists.",
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "value": {
+                  "type": "number",
+                  "description": "The numeric value for this rank."
+                },
+                "contexts": {
+                  "type": "array",
+                  "description": "Present when context_type is event_list or match_alliance. Parallel to keys. For event_list, each entry lists event_keys. For match_alliance, each entry has match_key and alliance (team keys).",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "description": "event_list context",
+                        "properties": {
+                          "event_keys": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "description": "match_alliance context",
+                        "required": [
+                          "match_key",
+                          "alliance"
+                        ],
+                        "properties": {
+                          "match_key": {
+                            "type": "string"
+                          },
+                          "alliance": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "InsightV2StreakData": {
+        "type": "object",
+        "description": "Data for a streak-category InsightV2. Records of consecutive achievement by teams.",
+        "required": [
+          "entries"
+        ],
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "key",
+                "key_type",
+                "streak_length",
+                "start",
+                "end",
+                "is_active"
+              ],
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "description": "Team or entity key."
+                },
+                "key_type": {
+                  "type": "string",
+                  "enum": [
+                    "team",
+                    "event",
+                    "match",
+                    "team_pair"
+                  ]
+                },
+                "streak_length": {
+                  "type": "integer",
+                  "description": "Length of the streak."
+                },
+                "start": {
+                  "type": "string",
+                  "description": "Event key or year string where the streak began."
+                },
+                "end": {
+                  "type": "string",
+                  "description": "Event key or year string where the streak ended (or is ongoing)."
+                },
+                "is_active": {
+                  "type": "boolean",
+                  "description": "Whether this streak is still ongoing."
+                }
+              }
+            }
+          }
+        }
+      },
+      "InsightV2TimeseriesData": {
+        "type": "object",
+        "description": "Data for a timeseries-category InsightV2. One or more named series of (x, y) data points over time.",
+        "required": [
+          "series",
+          "x_type",
+          "x_label",
+          "y_label",
+          "point_context_type"
+        ],
+        "properties": {
+          "x_type": {
+            "type": "string",
+            "enum": [
+              "week",
+              "year",
+              "event",
+              "date"
+            ],
+            "description": "What the x-axis represents. For `date`, each point's `x` is a Unix timestamp (seconds) at UTC midnight of that day."
+          },
+          "x_label": {
+            "type": "string",
+            "description": "Human-readable label for the x-axis."
+          },
+          "y_label": {
+            "type": "string",
+            "description": "Human-readable label for the y-axis."
+          },
+          "point_context_type": {
+            "type": "string",
+            "enum": [
+              "none",
+              "match_record"
+            ],
+            "description": "Whether data points include additional context."
+          },
+          "series": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "label",
+                "points"
+              ],
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable series name."
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "x",
+                      "y"
+                    ],
+                    "properties": {
+                      "x": {
+                        "description": "X-axis value (week string, year integer, event key, or Unix timestamp in seconds when x_type is date).",
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
+                      },
+                      "y": {
+                        "type": "number",
+                        "description": "Y-axis value."
+                      },
+                      "context": {
+                        "type": "object",
+                        "description": "Present when point_context_type is match_record.",
+                        "properties": {
+                          "match_key": {
+                            "type": "string"
+                          },
+                          "alliance": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Team keys on the record-setting alliance."
+                          },
+                          "post_result_time": {
+                            "type": "integer",
+                            "description": "Unix timestamp when the record was set."
+                          },
+                          "is_current": {
+                            "type": "boolean",
+                            "description": "Whether this is still the current world record."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "InsightV2GameStatsData": {
+        "type": "object",
+        "description": "Count/opportunities and average-value statistics for a year, broken out by scope: the season overall, each competition week, and each event.",
+        "required": [
+          "scopes"
+        ],
+        "properties": {
+          "scopes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InsightV2GameStatsScope"
+            }
+          }
+        }
+      },
+      "InsightV2GameStatsScope": {
+        "type": "object",
+        "required": [
+          "scope_type",
+          "label",
+          "key",
+          "week",
+          "qual",
+          "playoff",
+          "qual_averages",
+          "playoff_averages"
+        ],
+        "properties": {
+          "scope_type": {
+            "type": "string",
+            "enum": [
+              "overall",
+              "week",
+              "event"
+            ],
+            "description": "What slice of the season this scope covers."
+          },
+          "label": {
+            "type": "string",
+            "description": "Display name of the scope, e.g. `Overall`, `Week 3`, or an event's short name."
+          },
+          "key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Event key when `scope_type` is `event`, otherwise null."
+          },
+          "week": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Zero-indexed competition week, or null for the overall and championship scopes."
+          },
+          "qual": {
+            "type": "array",
+            "description": "Count/opportunities statistics over qualification matches in this scope.",
+            "items": {
+              "$ref": "#/components/schemas/InsightV2GameStat"
+            }
+          },
+          "playoff": {
+            "type": "array",
+            "description": "Count/opportunities statistics over playoff matches in this scope.",
+            "items": {
+              "$ref": "#/components/schemas/InsightV2GameStat"
+            }
+          },
+          "qual_averages": {
+            "type": "array",
+            "description": "Average-value statistics over qualification matches in this scope.",
+            "items": {
+              "$ref": "#/components/schemas/InsightV2AverageStat"
+            }
+          },
+          "playoff_averages": {
+            "type": "array",
+            "description": "Average-value statistics over playoff matches in this scope.",
+            "items": {
+              "$ref": "#/components/schemas/InsightV2AverageStat"
+            }
+          }
+        }
+      },
+      "InsightV2GameStat": {
+        "type": "object",
+        "description": "How many times an objective was achieved, out of how many chances there were to achieve it.",
+        "required": [
+          "name",
+          "label",
+          "count",
+          "opportunities"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Programmatic name of the statistic, e.g. `rp_1` or `auto_climb`."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable name of the statistic, e.g. `Energized RP`."
+          },
+          "count": {
+            "type": "integer",
+            "description": "Times the objective was achieved."
+          },
+          "opportunities": {
+            "type": "integer",
+            "description": "Chances there were to achieve the objective."
+          }
+        }
+      },
+      "InsightV2AverageStat": {
+        "type": "object",
+        "description": "The average value of a numeric match statistic, e.g. average score or average win margin.",
+        "required": [
+          "name",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Programmatic name of the statistic, e.g. `average_score`."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable name of the statistic, e.g. `Average Score`."
+          },
+          "value": {
+            "type": "number",
+            "description": "The average value of the statistic over matches in this scope."
+          }
+        }
       },
       "Position_2016": {
         "type": "string",
@@ -10153,7 +11696,10 @@
         }
       },
       "Team_Event_Status": {
-        "type": "object",
+        "type": [
+          "object",
+          "null"
+        ],
         "properties": {
           "qual": {
             "$ref": "#/components/schemas/Team_Event_Status_rank"
@@ -10457,6 +12003,142 @@
           "Unknown"
         ]
       },
+      "Playoff_Advancement_Sort_Order_Info": {
+        "required": [
+          "name",
+          "type",
+          "precision"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the sort order or extra stat."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "int",
+              "bool"
+            ],
+            "description": "Data type of the corresponding value."
+          },
+          "precision": {
+            "type": "integer",
+            "description": "Number of decimal places to display for the value."
+          }
+        },
+        "description": "Describes one entry in an advancement level's `sort_orders` or `extra_stats` arrays."
+      },
+      "Playoff_Advancement_Alliance_Rank": {
+        "required": [
+          "team_keys",
+          "alliance_name",
+          "matches_played",
+          "sort_orders",
+          "extra_stats"
+        ],
+        "type": "object",
+        "properties": {
+          "team_keys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Team keys (eg `frc254`) making up the alliance."
+          },
+          "alliance_name": {
+            "type": "string",
+            "description": "Name of the alliance (eg `Turing`, `Alliance 1`)."
+          },
+          "alliance_color": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "For bracket levels, `red` or `blue`. Absent for round robin standings."
+          },
+          "rank": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "1-indexed rank within the advancement level. Absent for bracket levels."
+          },
+          "record": {
+            "description": "Win-loss-tie record for the alliance at this level.",
+            "$ref": "#/components/schemas/WLT_Record"
+          },
+          "matches_played": {
+            "type": "integer",
+            "description": "Number of matches the alliance played at this level."
+          },
+          "sort_orders": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Values used to rank alliances, described by the level's `sort_order_info`. For round robin: Champ Points followed by per-year tiebreakers."
+          },
+          "extra_stats": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Additional per-alliance values, described by the level's `extra_stats_info`. For round robin: `1` if the alliance advances to the finals, else `0`."
+          }
+        },
+        "description": "One alliance's standing within a playoff advancement level."
+      },
+      "Playoff_Advancement": {
+        "required": [
+          "level",
+          "level_name",
+          "type",
+          "sort_order_info",
+          "extra_stats_info"
+        ],
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "string",
+            "description": "Machine-readable level identifier (eg `sf`, `f1`)."
+          },
+          "level_name": {
+            "type": "string",
+            "description": "Human-readable level name (eg `Round Robin Semifinals`, `Finals`)."
+          },
+          "type": {
+            "type": "string",
+            "description": "Advancement level type (eg `round_robin`, `best_of_3`, `double_elim`, `average_score`)."
+          },
+          "rankings": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Playoff_Advancement_Alliance_Rank"
+            },
+            "description": "Ranked alliances for this level."
+          },
+          "sort_order_info": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Playoff_Advancement_Sort_Order_Info"
+            },
+            "description": "Describes each element of every ranking's `sort_orders` array, in order."
+          },
+          "extra_stats_info": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Playoff_Advancement_Sort_Order_Info"
+            },
+            "description": "Describes each element of every ranking's `extra_stats` array, in order."
+          }
+        },
+        "description": "A single level of computed playoff advancement for an event."
+      },
       "WLT_Record": {
         "required": [
           "losses",
@@ -10479,6 +12161,21 @@
           }
         },
         "description": "A Win-Loss-Tie record for a team, or an alliance."
+      },
+      "WebcastStatus": {
+        "title": "WebcastStatus",
+        "description": "Online status of a webcast. See https://github.com/the-blue-alliance/the-blue-alliance/blob/main/src/backend/common/consts/webcast_status.py for full definitions.",
+        "type": "string",
+        "enum": [
+          "unknown",
+          "online",
+          "offline"
+        ],
+        "x-enum-varnames": [
+          "UNKNOWN",
+          "ONLINE",
+          "OFFLINE"
+        ]
       },
       "Webcast": {
         "required": [
@@ -10524,16 +12221,8 @@
             "description": "File identification as may be required for some types. May be null."
           },
           "status": {
-            "type": [
-              "string",
-              "null"
-            ],
             "description": "The online status of the webcast, fetched from the streaming provider's API. May be null if not available.",
-            "enum": [
-              "unknown",
-              "online",
-              "offline"
-            ]
+            "$ref": "#/components/schemas/WebcastStatus"
           },
           "stream_title": {
             "type": [
@@ -10738,6 +12427,22 @@
         "required": true,
         "schema": {
           "type": "string"
+        }
+      },
+      "insight_v2_category": {
+        "name": "category",
+        "in": "path",
+        "description": "InsightV2 category. One of: leaderboard, streak, timeseries, game_stats, clubs.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "leaderboard",
+            "streak",
+            "timeseries",
+            "game_stats",
+            "clubs"
+          ]
         }
       },
       "year": {

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Matches/APIMatch+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Matches/APIMatch+HelpersTests.swift
@@ -216,7 +216,7 @@ struct APIMatchHelpersTests {
         blue: [String] = [],
         redDQ: [String] = [],
         blueDQ: [String] = [],
-        winningAlliance: Match.WinningAlliancePayload = ._empty_,
+        winningAlliance: AllianceColor = ._empty_,
         time: Int64? = nil,
         actualTime: Int64? = nil,
         predictedTime: Int64? = nil

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Media/APIMedia+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Media/APIMedia+HelpersTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import TBAAPI
+
+// `Media` is a discriminated union in the spec, so these decode the wire shape the
+// API emits rather than constructing payloads by hand.
+struct APIMediaHelpersTests {
+
+    @Test func avatar_flattensBaseAndExposesImage() throws {
+        let media = try decode(
+            """
+            {
+              "type": "avatar",
+              "foreign_key": "avatar_2026_frc254",
+              "team_keys": ["frc254"],
+              "preferred": false,
+              "direct_url": "",
+              "view_url": "",
+              "details": { "base64Image": "aGVsbG8=" }
+            }
+            """
+        )
+        #expect(media.type == .avatar)
+        #expect(media.foreignKey == "avatar_2026_frc254")
+        #expect(media.teamKeys == ["frc254"])
+        #expect(media.avatarBase64Image == "aGVsbG8=")
+    }
+
+    @Test func imgur_hasNoAvatarImage() throws {
+        let media = try decode(
+            """
+            {
+              "type": "imgur",
+              "foreign_key": "abc123",
+              "team_keys": ["frc254"],
+              "preferred": true,
+              "direct_url": "https://i.imgur.com/abc123.jpg",
+              "view_url": "https://imgur.com/abc123",
+              "details": {}
+            }
+            """
+        )
+        #expect(media.type == .imgur)
+        #expect(media.preferred == true)
+        #expect(media.directUrl == "https://i.imgur.com/abc123.jpg")
+        #expect(media.viewUrl == "https://imgur.com/abc123")
+        #expect(media.avatarBase64Image == nil)
+    }
+
+    @Test func youtube_decodesAsNoDetails() throws {
+        let media = try decode(
+            """
+            {
+              "type": "youtube",
+              "foreign_key": "dQw4w9WgXcQ",
+              "team_keys": ["frc254"],
+              "details": {}
+            }
+            """
+        )
+        #expect(media.type == .youtube)
+        #expect(media.foreignKey == "dQw4w9WgXcQ")
+        #expect(media.directUrl == nil)
+    }
+
+    private func decode(_ json: String) throws -> Media {
+        try JSONDecoder().decode(Media.self, from: Data(json.utf8))
+    }
+
+}

--- a/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Webcasts/APIWebcast+HelpersTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/Extensions/Webcasts/APIWebcast+HelpersTests.swift
@@ -148,7 +148,7 @@ struct APIWebcastHelpersTests {
         type: Webcast._TypePayload,
         channel: String,
         date: String? = nil,
-        status: Webcast.StatusPayload? = nil,
+        status: WebcastStatus? = nil,
         viewerCount: Int? = nil
     ) -> Webcast {
         Webcast(

--- a/Packages/TBAAPI/Tests/TBAAPITests/WireShapeDecodingTests.swift
+++ b/Packages/TBAAPI/Tests/TBAAPITests/WireShapeDecodingTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@testable import TBAAPI
+
+// Pins the wire shapes that `scripts/update-apiv3-spec.py` patches the spec for, so a
+// regeneration that loses a patch fails here instead of at runtime.
+struct WireShapeDecodingTests {
+
+    // The backend sends `null` for a team's status at an event that hasn't started.
+    @Test func teamEventsStatusesByYear_decodesNullStatusAsNil() throws {
+        let payload = try JSONDecoder().decode(
+            Operations.GetTeamEventsStatusesByYear.Output.Ok.Body.JsonPayload.self,
+            from: Data(
+                """
+                {
+                  "2026casj": null,
+                  "2026cc": { "pit_location": "A12", "last_match_key": "2026cc_qm12" }
+                }
+                """.utf8
+            )
+        )
+        let statuses = payload.additionalProperties
+        #expect(statuses.count == 2)
+        #expect(statuses["2026casj"] == .some(nil))
+        #expect(statuses["2026cc"]??.pitLocation == "A12")
+        #expect(statuses["2026cc"]??.lastMatchKey == "2026cc_qm12")
+    }
+
+    @Test func eventTeamsStatuses_decodesNullStatusAsNil() throws {
+        let payload = try JSONDecoder().decode(
+            Operations.GetEventTeamsStatuses.Output.Ok.Body.JsonPayload.self,
+            from: Data(#"{ "frc254": null, "frc1678": { "pit_location": "B3" } }"#.utf8)
+        )
+        #expect(payload.additionalProperties.compactMapValues { $0 }.keys.sorted() == ["frc1678"])
+    }
+
+    // `winning_alliance` is an `allOf` wrapper around `AllianceColor` upstream; the spec
+    // script collapses it so the field decodes straight to the enum.
+    @Test func match_winningAllianceDecodesToAllianceColor() throws {
+        for (raw, expected) in [("red", AllianceColor.red), ("blue", .blue), ("", ._empty_)] {
+            let match = try JSONDecoder().decode(
+                Match.self,
+                from: Data(
+                    """
+                    {
+                      "key": "2026casj_qm1", "comp_level": "qm", "set_number": 1,
+                      "match_number": 1, "event_key": "2026casj",
+                      "alliances": {
+                        "red": {
+                          "score": 10, "team_keys": ["frc254"],
+                          "surrogate_team_keys": [], "dq_team_keys": []
+                        },
+                        "blue": {
+                          "score": 5, "team_keys": ["frc1678"],
+                          "surrogate_team_keys": [], "dq_team_keys": []
+                        }
+                      },
+                      "winning_alliance": "\(raw)",
+                      "time": null, "actual_time": null, "predicted_time": null,
+                      "post_result_time": null, "videos": []
+                    }
+                    """.utf8
+                )
+            )
+            #expect(match.winningAlliance == expected)
+            #expect(match.winningAllianceString == raw)
+        }
+    }
+
+    @Test func status_decodesKickoffDatetime() throws {
+        let status = try JSONDecoder().decode(
+            APIStatus.self,
+            from: Data(
+                """
+                {
+                  "current_season": 2026, "max_season": 2027, "is_datafeed_down": false,
+                  "down_events": [], "max_team_page": 21,
+                  "ios": { "min_app_version": -1, "latest_app_version": -1 },
+                  "android": { "min_app_version": 1, "latest_app_version": 2 },
+                  "kickoff_datetime": "2027-01-09T17:00:00+00:00"
+                }
+                """.utf8
+            )
+        )
+        #expect(status.kickoffDatetime == "2027-01-09T17:00:00+00:00")
+    }
+
+}

--- a/TBAUnitTests/Mocks/DependenciesMocks.swift
+++ b/TBAUnitTests/Mocks/DependenciesMocks.swift
@@ -30,6 +30,7 @@ final class MockTBAAPI: TBAAPIProtocol {
     func teamEventMatches(teamKey: TeamKey, eventKey: EventKey) async throws -> [Match] { throw Unstubbed() }
     func teamEventAwards(teamKey: TeamKey, eventKey: EventKey) async throws -> [Award] { throw Unstubbed() }
     func teamEventStatus(teamKey: TeamKey, eventKey: EventKey) async throws -> TeamEventStatus { throw Unstubbed() }
+    func teamEventsStatusesByYear(teamKey: TeamKey, year: Int) async throws -> [EventKey: TeamEventStatus?] { throw Unstubbed() }
     func teamMediaByYear(teamKey: TeamKey, year: Int) async throws -> [Media] { throw Unstubbed() }
     func eventTeamsStatuses(key eventKey: EventKey) async throws -> [String: TeamEventStatus] { throw Unstubbed() }
     func eventsByYear(_ year: Int) async throws -> [Event] { throw Unstubbed() }

--- a/scripts/update-apiv3-spec.py
+++ b/scripts/update-apiv3-spec.py
@@ -14,6 +14,10 @@ https://www.thebluealliance.com/swagger/api_v3.json and patches out
 swift-openapi-generator (see apple/swift-openapi-generator#817, which
 endorses dropping the null branch as the proper workaround).
 
+Also collapses single-branch `allOf` wrappers (the idiom for attaching a
+`description` to a `$ref`), which the generator would otherwise turn into a
+`<Field>Payload` struct with a lone `value1` instead of the referenced type.
+
 Run: uv run scripts/update-apiv3-spec.py
 """
 
@@ -93,6 +97,23 @@ def _strip_null_compositions(
     return node
 
 
+def _collapse_single_allof(node: object, path: list[str], patches: list[str]) -> object:
+    """Replace `allOf: [X]` with `X` merged over the node's other keys."""
+    if isinstance(node, dict):
+        branches = node.get("allOf")
+        if isinstance(branches, list) and len(branches) == 1 and isinstance(branches[0], dict):
+            patches.append("/".join(path) + " (allOf)")
+            siblings = {k: v for k, v in node.items() if k != "allOf"}
+            return _collapse_single_allof({**siblings, **branches[0]}, path, patches)
+        return {k: _collapse_single_allof(v, path + [k], patches) for k, v in node.items()}
+    if isinstance(node, list):
+        return [
+            _collapse_single_allof(item, path + [str(i)], patches)
+            for i, item in enumerate(node)
+        ]
+    return node
+
+
 def _drop_nullified_required(
     spec: dict, nullified: set[tuple[str, ...]]
 ) -> list[str]:
@@ -141,6 +162,27 @@ def _flatten_score_breakdown_oneof(spec: dict) -> bool:
     return True
 
 
+def _mark_team_event_status_nullable(spec: dict) -> bool:
+    """Declare Team_Event_Status itself nullable.
+
+    The API returns `null` for a team's status at an event that hasn't started
+    (documented since 3.9.4), both as the `/team/{key}/event/{key}/status`
+    body and as values in the `.../statuses` maps. The upstream spec only
+    says so at the reference sites via `oneOf` null branches, which the
+    null-stripping above removes. swift-openapi-generator derives optionality
+    from the referenced schema, so flagging the component is the one place
+    that makes every use (including dictionary values) decode `null` as nil.
+    """
+    try:
+        status = spec["components"]["schemas"]["Team_Event_Status"]
+    except (KeyError, TypeError):
+        return False
+    if status.get("type") != "object":
+        return False
+    status["type"] = ["object", "null"]
+    return True
+
+
 def _find_residual_null_compositions(node: object, path: list[str]) -> list[str]:
     """Return paths where a `oneOf`/`anyOf` still contains a null branch."""
     hits: list[str] = []
@@ -183,8 +225,18 @@ def main() -> int:
         for r in required_removals:
             print(f"  - {r}")
 
+    allof_patches: list[str] = []
+    patched = _collapse_single_allof(patched, [], allof_patches)
+    if allof_patches:
+        print(f"Collapsed {len(allof_patches)} single-branch allOf wrapper(s):")
+        for p in allof_patches:
+            print(f"  - {p}")
+
     if _flatten_score_breakdown_oneof(patched):
         print("Flattened Match.score_breakdown oneOf to free-form nullable object.")
+
+    if _mark_team_event_status_nullable(patched):
+        print("Marked Team_Event_Status nullable.")
 
     OUT_PATH.write_text(json.dumps(patched, indent=2) + "\n")
     print(f"Wrote {OUT_PATH}")

--- a/the-blue-alliance-ios/Services/StatusService.swift
+++ b/the-blue-alliance-ios/Services/StatusService.swift
@@ -9,6 +9,9 @@ struct AppStatus {
     let latestAppVersion: Int
     let isDatafeedDown: Bool
     let downEventKeys: [String]
+    /// Kickoff for the upcoming season, as the server computes it. `nil` until `/status` has
+    /// loaded or if the server omits it.
+    let kickoffDate: Date?
 
     static var `default`: AppStatus {
         let year = Calendar.current.component(.year, from: Date())
@@ -18,7 +21,8 @@ struct AppStatus {
             minAppVersion: -1,
             latestAppVersion: -1,
             isDatafeedDown: false,
-            downEventKeys: []
+            downEventKeys: [],
+            kickoffDate: nil
         )
     }
 
@@ -28,7 +32,8 @@ struct AppStatus {
         minAppVersion: Int,
         latestAppVersion: Int,
         isDatafeedDown: Bool,
-        downEventKeys: [String]
+        downEventKeys: [String],
+        kickoffDate: Date?
     ) {
         self.currentSeason = currentSeason
         self.maxSeason = maxSeason
@@ -36,6 +41,7 @@ struct AppStatus {
         self.latestAppVersion = latestAppVersion
         self.isDatafeedDown = isDatafeedDown
         self.downEventKeys = downEventKeys
+        self.kickoffDate = kickoffDate
     }
 
     init(apiStatus: APIStatus) {
@@ -45,6 +51,7 @@ struct AppStatus {
         self.latestAppVersion = apiStatus.ios.latestAppVersion
         self.isDatafeedDown = apiStatus.isDatafeedDown
         self.downEventKeys = apiStatus.downEvents
+        self.kickoffDate = apiStatus.kickoffDatetime.flatMap { try? Date($0, strategy: .iso8601) }
     }
 }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -398,7 +398,7 @@ extension TeamMediaCollectionViewController: Refreshable {
     }
 
     private static func makeItem(from media: Media) -> TeamMediaItem? {
-        let type = media._type.rawValue
+        let type = media.type.rawValue
         if Self.imageTypes.contains(type) {
             return .image(
                 .init(

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -306,13 +306,12 @@ class TeamViewController: HeaderContainerViewController {
             return
         }
         guard self.year == year else { return }
-        let avatar = media.first(where: { $0._type == .avatar })
+        let avatar = media.first(where: { $0.type == .avatar })
         avatarImage = Self.decodeAvatar(from: avatar)
     }
 
     private static func decodeAvatar(from media: Media?) -> UIImage? {
-        guard case let .case2(payload) = media?.details,
-            let data = Data(base64Encoded: payload.base64Image)
+        guard let base64 = media?.avatarBase64Image, let data = Data(base64Encoded: base64)
         else { return nil }
         return UIImage(data: data)
     }


### PR DESCRIPTION
## Summary

Refreshes `Packages/TBAAPI` from prod (3.13.0 → 3.26.0) via `scripts/update-apiv3-spec.py`. New surface we'll use next: `kickoff_datetime` on `/status`, `/event/{key}/nexus_info`, `/event/{key}/playoff_advancement`, event media, and the InsightV2 routes. Groundwork for the Dashboard landing tab.

Three upstream shape changes needed handling:

- **`Match.winning_alliance`** is now `allOf: [$ref AllianceColor]` (the "description on a `$ref`" idiom). swift-openapi-generator turns a single-branch `allOf` into a `<Field>Payload` struct with a lone `value1`, which would have leaked into `MatchViewModel` and the package tests. The spec script now collapses that idiom (two hits, both `winning_alliance`), so the field decodes straight to the enum.
- **`Media`** is a discriminated union on `type`, generated as an enum with a payload struct per media type, each carrying the shared fields as `value1: MediaBase`. New `APIMedia+Helpers` flattens that (`base`, `type`, `foreignKey`, `directUrl`, `viewUrl`, `avatarBase64Image`), so the avatar loader and media grid each change by one line.
- **Null statuses.** The backend sends `null` for a team's status at an event that hasn't started (documented since 3.9.4), both as `/team/{key}/event/{key}/status` and as values in the `.../statuses` maps. The generated `[String: TeamEventStatus]` threw on `null`, so the existing `eventTeamsStatuses` call was silently failing for any event with an unstarted team. The script now marks `Team_Event_Status` nullable at the component, which is where the generator reads optionality from; the maps become `[String: TeamEventStatus?]`. `eventTeamsStatuses` drops the nils (its only caller wants pit locations). The new `teamEventsStatusesByYear` keeps them, because a nil there means "registered, not started".

Also: `AppStatus.kickoffDate` parsed from the new status field; `AllianceColor` and `WebcastStatus` typealiases for the named enums introduced in 3.14.

## Test plan

- [x] `make test-app`: 257/257 (82 app, 159 TBAAPI, 16 MyTBAKit)
- [x] `make lint` clean
- [x] New `WireShapeDecodingTests` decode the exact wire shapes for the null status map (both endpoints), `winning_alliance` for red/blue/empty, and `kickoff_datetime`; new `APIMediaHelpersTests` decode avatar, imgur, and youtube media payloads
- [ ] Manual: open a team page and confirm the avatar and Media tab still render (the `Media` decode path changed)
- [ ] Manual: open an upcoming event's Teams tab and confirm pit locations show where FIRST has published them (this call was silently failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZtTR44bFNAF64GWmgzFAe
