### PR TITLE
Add a Dashboard tab shell behind a feature flag

### DIFF
--- a/TBAUnitTests/LocalStore/FeatureFlagsStoreTests.swift
+++ b/TBAUnitTests/LocalStore/FeatureFlagsStoreTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import The_Blue_Alliance
+
+struct FeatureFlagsStoreTests {
+
+    @Test(arguments: FeatureFlag.allCases)
+    func everyFlagDefaultsOff(flag: FeatureFlag) {
+        let store = FeatureFlagsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+        #expect(store.isEnabled(flag) == false)
+    }
+
+    @Test func flagRoundTripsThroughDefaultsUnderItsKey() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let store = FeatureFlagsStore(defaults: defaults)
+
+        store.setEnabled(true, for: .dashboard)
+        #expect(store.isEnabled(.dashboard) == true)
+        #expect(FeatureFlagsStore(defaults: defaults).isEnabled(.dashboard) == true)
+        #expect(defaults.bool(forKey: "kTBAFeatureFlag.dashboard") == true)
+
+        store.setEnabled(false, for: .dashboard)
+        #expect(FeatureFlagsStore(defaults: defaults).isEnabled(.dashboard) == false)
+    }
+
+    @Test func pruneDropsRetiredFlagsAndLeavesEverythingElse() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let store = FeatureFlagsStore(defaults: defaults)
+        store.setEnabled(true, for: .dashboard)
+        defaults.set(true, forKey: "kTBAFeatureFlag.retiredFeature")
+        defaults.set("bypass", forKey: "kTBACachePolicy")
+
+        store.pruneRetiredFlags()
+
+        #expect(store.isEnabled(.dashboard) == true)
+        #expect(defaults.object(forKey: "kTBAFeatureFlag.retiredFeature") == nil)
+        #expect(defaults.string(forKey: "kTBACachePolicy") == "bypass")
+    }
+
+    @Test func dashboardNeedsARelaunch() {
+        #expect(FeatureFlag.dashboard.requiresRelaunch)
+        #expect(FeatureFlag.dashboard.title == "Dashboard")
+    }
+
+}

--- a/TBAUnitTests/Mocks/DependenciesMocks.swift
+++ b/TBAUnitTests/Mocks/DependenciesMocks.swift
@@ -107,3 +107,7 @@ extension Dependencies {
     }
 
 }
+
+final class MockFCMTokenProvider: FCMTokenProvider {
+    var fcmToken: String?
+}

--- a/TBAUnitTests/ViewControllers/Root/PhoneRootViewControllerTests.swift
+++ b/TBAUnitTests/ViewControllers/Root/PhoneRootViewControllerTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import MyTBAKit
+import Testing
+import UIKit
+
+@testable import The_Blue_Alliance
+
+
+@MainActor
+struct PhoneRootViewControllerTests {
+
+    private static func makeRoot(dashboardEnabled: Bool) -> PhoneRootViewController {
+        let dependencies = Dependencies.mock()
+        dependencies.appSettings.featureFlags.setEnabled(dashboardEnabled, for: .dashboard)
+        return PhoneRootViewController(
+            fcmTokenProvider: MockFCMTokenProvider(),
+            pushService: MockPushService(),
+            dependencies: dependencies
+        )
+    }
+
+    @Test func flagOff_keepsTheOriginalFiveTabs() {
+        let root = Self.makeRoot(dashboardEnabled: false)
+        #expect(
+            root.tabs.map(\.identifier) == [
+                "tab.events", "tab.teams", "tab.districts", "tab.mytba", "tab.settings",
+            ]
+        )
+    }
+
+    @Test func flagOn_dashboardLeadsAndTeamsIsDropped() {
+        let root = Self.makeRoot(dashboardEnabled: true)
+        #expect(
+            root.tabs.map(\.identifier) == [
+                "tab.dashboard", "tab.events", "tab.districts", "tab.mytba", "tab.settings",
+            ]
+        )
+        #expect(root.selectedTab?.identifier == "tab.dashboard")
+    }
+
+    @Test func flagOn_dashboardTabHostsTheContainerWithSearch() {
+        let root = Self.makeRoot(dashboardEnabled: true)
+        let navigationController = root.selectedTab?.viewController as? UINavigationController
+        let container =
+            navigationController?.viewControllers.first as? DashboardContainerViewController
+        #expect(container != nil)
+
+        container?.loadViewIfNeeded()
+        #expect(container?.navigationItem.searchController === container?.searchController)
+        #expect(container?.navigationItem.hidesSearchBarWhenScrolling == false)
+    }
+
+    @Test func tabLists_matchTheRootTypeTable() {
+        #expect(
+            RootType.tabs(dashboardEnabled: false) == [
+                .events, .teams, .districts, .myTBA, .settings,
+            ]
+        )
+        #expect(
+            RootType.tabs(dashboardEnabled: true) == [
+                .dashboard, .events, .districts, .myTBA, .settings,
+            ]
+        )
+    }
+
+}

--- a/TBAUnitTests/ViewControllers/Settings/SettingsViewControllerTests.swift
+++ b/TBAUnitTests/ViewControllers/Settings/SettingsViewControllerTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+import UIKit
+
+@testable import The_Blue_Alliance
+
+// The Experimental section only exists in debug simulator builds, which is where these run.
+@MainActor
+struct SettingsViewControllerTests {
+
+    private final class Harness {
+        let window: UIWindow
+        let settings: SettingsViewController
+        let dependencies: Dependencies
+
+        init(dashboardEnabled: Bool) {
+            dependencies = Dependencies.mock()
+            dependencies.appSettings.featureFlags.setEnabled(dashboardEnabled, for: .dashboard)
+            settings = SettingsViewController(
+                fcmTokenProvider: MockFCMTokenProvider(),
+                pushService: MockPushService(),
+                dependencies: dependencies
+            )
+            window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+            window.rootViewController = settings
+            window.makeKeyAndVisible()
+            settings.loadViewIfNeeded()
+        }
+
+        var experimentalToggle: UISwitch? {
+            let tableView = settings.tableView!
+            let section = (0..<tableView.numberOfSections).first {
+                settings.tableView(tableView, titleForHeaderInSection: $0) == "Experimental"
+            }
+            guard let section else { return nil }
+            let cell = settings.tableView(
+                tableView,
+                cellForRowAt: IndexPath(row: 0, section: section)
+            )
+            return cell.accessoryView as? UISwitch
+        }
+    }
+
+    @Test func experimentalSectionReflectsTheFlag() {
+        #expect(Harness(dashboardEnabled: false).experimentalToggle?.isOn == false)
+        #expect(Harness(dashboardEnabled: true).experimentalToggle?.isOn == true)
+    }
+
+    @Test func togglingWritesTheFlagAndAsksForARelaunch() throws {
+        let harness = Harness(dashboardEnabled: false)
+        let toggle = try #require(harness.experimentalToggle)
+
+        toggle.isOn = true
+        toggle.sendActions(for: .valueChanged)
+        #expect(harness.dependencies.appSettings.featureFlags.isEnabled(.dashboard) == true)
+
+        let alert = harness.settings.presentedViewController as? UIAlertController
+        #expect(alert?.title == "Relaunch to Apply")
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -204,6 +204,12 @@
 		AA00000000000000000AA009 /* AllianceBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000AA00A /* AllianceBadgeView.swift */; };
 		BA0000000000000000000002 /* EventSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0000000000000000000001 /* EventSection.swift */; };
 		D105BC4723E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift in Sources */ = {isa = PBXBuildFile; fileRef = D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */; };
+		5EC0D41A2C26090100000002 /* FeatureFlagsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090100000001 /* FeatureFlagsStore.swift */; };
+		5EC0D41A2C26090200000002 /* DashboardContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090200000001 /* DashboardContainerViewController.swift */; };
+		5EC0D41A2C26090300000002 /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090300000001 /* DashboardViewController.swift */; };
+		5EC0D41A2C26090400000002 /* FeatureFlagsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090400000001 /* FeatureFlagsStoreTests.swift */; };
+		5EC0D41A2C26090500000002 /* PhoneRootViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090500000001 /* PhoneRootViewControllerTests.swift */; };
+		5EC0D41A2C26090700000002 /* SettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090700000001 /* SettingsViewControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -399,6 +405,12 @@
 		AA00000000000000000AA00A /* AllianceBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllianceBadgeView.swift; sourceTree = "<group>"; };
 		BA0000000000000000000001 /* EventSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSection.swift; sourceTree = "<group>"; };
 		D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2020.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26090100000001 /* FeatureFlagsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsStore.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26090200000001 /* DashboardContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardContainerViewController.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26090300000001 /* DashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26090400000001 /* FeatureFlagsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalStore/FeatureFlagsStoreTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26090500000001 /* PhoneRootViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Root/PhoneRootViewControllerTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26090700000001 /* SettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Settings/SettingsViewControllerTests.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXContainerItemProxy section */
@@ -589,6 +601,9 @@
 			children = (
 				5EC0D41A2C26042200000001 /* NotificationStoreTests.swift */,
 				5EC0D41A2C2607010000000F /* LegacyCoreDataCleanupTests.swift */,
+				5EC0D41A2C26090400000001 /* FeatureFlagsStoreTests.swift */,
+				5EC0D41A2C26090500000001 /* PhoneRootViewControllerTests.swift */,
+				5EC0D41A2C26090700000001 /* SettingsViewControllerTests.swift */,
 				92AA7A062F0100000006AAAA /* SessionMocks.swift */,
 				92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */,
 				5EC0D41A2C26060100000001 /* EventSectionTests.swift */,
@@ -639,6 +654,7 @@
 				92942DB51E215B34008E79CA /* MyTBA */,
 				92A321C5214EF81700FDADFB /* Settings */,
 				92FF10F221A61AC2003BC5C4 /* Match */,
+				5EC0D41A2C26090600000001 /* Dashboard */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -802,6 +818,7 @@
 				5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */,
 				5EC0D41A2C26042100000001 /* NotificationStore.swift */,
 				5EC0D41A2C26042100000003 /* JSONFileStore.swift */,
+				5EC0D41A2C26090100000001 /* FeatureFlagsStore.swift */,
 			);
 			path = LocalStore;
 			sourceTree = "<group>";
@@ -1039,6 +1056,15 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		5EC0D41A2C26090600000001 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				5EC0D41A2C26090200000001 /* DashboardContainerViewController.swift */,
+				5EC0D41A2C26090300000001 /* DashboardViewController.swift */,
+			);
+			path = Dashboard;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1258,6 +1284,9 @@
 			files = (
 				5EC0D41A2C26042200000002 /* NotificationStoreTests.swift in Sources */,
 				5EC0D41A2C26070100000010 /* LegacyCoreDataCleanupTests.swift in Sources */,
+				5EC0D41A2C26090400000002 /* FeatureFlagsStoreTests.swift in Sources */,
+				5EC0D41A2C26090500000002 /* PhoneRootViewControllerTests.swift in Sources */,
+				5EC0D41A2C26090700000002 /* SettingsViewControllerTests.swift in Sources */,
 				92AA7A072F0100000007AAAA /* SessionMocks.swift in Sources */,
 				92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */,
 				5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */,
@@ -1278,6 +1307,9 @@
 				5EC0D41A2C26041600000002 /* LegacyCoreDataCleanup.swift in Sources */,
 				5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */,
 				5EC0D41A2C26042100000002 /* NotificationStore.swift in Sources */,
+				5EC0D41A2C26090100000002 /* FeatureFlagsStore.swift in Sources */,
+				5EC0D41A2C26090200000002 /* DashboardContainerViewController.swift in Sources */,
+				5EC0D41A2C26090300000002 /* DashboardViewController.swift in Sources */,
 				5EC0D41A2C26042100000004 /* JSONFileStore.swift in Sources */,
 				5EC0D41A2C26041F00000002 /* AppGroup.swift in Sources */,
 				5EC0D41A2C26041B00000002 /* PushNotificationPayload.swift in Sources */,

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -86,6 +86,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         LegacyCoreDataCleanup.run()
+        appSettings.featureFlags.pruneRetiredFlags()
         Self.setupAppearance()
 
         configureFirebase()

--- a/the-blue-alliance-ios/Extensions/UIImage+TBA.swift
+++ b/the-blue-alliance-ios/Extensions/UIImage+TBA.swift
@@ -3,6 +3,10 @@ import UIKit
 
 extension UIImage {
 
+    static var homeIcon: UIImage? {
+        return UIImage(systemName: "house.fill")
+    }
+
     static var eventIcon: UIImage? {
         return UIImage(systemName: "calendar")
     }

--- a/the-blue-alliance-ios/LocalStore/AppSettings.swift
+++ b/the-blue-alliance-ios/LocalStore/AppSettings.swift
@@ -3,10 +3,12 @@ import Foundation
 struct AppSettings {
 
     let cachePolicy: CachePolicyStore
+    let featureFlags: FeatureFlagsStore
     let firebaseCollection: FirebaseCollectionStore
 
     init(defaults: UserDefaults = .standard) {
         self.cachePolicy = CachePolicyStore(defaults: defaults)
+        self.featureFlags = FeatureFlagsStore(defaults: defaults)
         self.firebaseCollection = FirebaseCollectionStore(defaults: defaults)
     }
 }

--- a/the-blue-alliance-ios/LocalStore/FeatureFlagsStore.swift
+++ b/the-blue-alliance-ios/LocalStore/FeatureFlagsStore.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum FeatureFlag: String, CaseIterable {
+    case dashboard
+
+    var title: String {
+        switch self {
+        case .dashboard: return "Dashboard"
+        }
+    }
+
+    var requiresRelaunch: Bool {
+        switch self {
+        case .dashboard: return true
+        }
+    }
+}
+
+struct FeatureFlagsStore {
+
+    private static let keyPrefix = "kTBAFeatureFlag."
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func isEnabled(_ flag: FeatureFlag) -> Bool {
+        defaults.bool(forKey: Self.key(for: flag))
+    }
+
+    func setEnabled(_ enabled: Bool, for flag: FeatureFlag) {
+        defaults.set(enabled, forKey: Self.key(for: flag))
+    }
+
+    func pruneRetiredFlags() {
+        let live = Set(FeatureFlag.allCases.map(Self.key(for:)))
+        for key in defaults.dictionaryRepresentation().keys
+        where key.hasPrefix(Self.keyPrefix) && !live.contains(key) {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    private static func key(for flag: FeatureFlag) -> String {
+        keyPrefix + flag.rawValue
+    }
+}

--- a/the-blue-alliance-ios/ViewControllers/Dashboard/DashboardContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Dashboard/DashboardContainerViewController.swift
@@ -1,0 +1,50 @@
+import Foundation
+import MyTBAKit
+import TBAAPI
+import TBAUtils
+import UIKit
+
+class DashboardContainerViewController: ContainerViewController {
+
+    private(set) var dashboardViewController: DashboardViewController
+
+    lazy var searchController: UISearchController = makeSearchController()
+
+    // MARK: - Init
+
+    init(dependencies: Dependencies) {
+        dashboardViewController = DashboardViewController(dependencies: dependencies)
+
+        super.init(
+            viewControllers: [dashboardViewController],
+            navigationTitle: RootType.dashboard.title,
+            dependencies: dependencies
+        )
+
+        title = RootType.dashboard.title
+        tabBarItem.image = RootType.dashboard.icon
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupSearchController()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        dependencies.reporter.log("Dashboard")
+    }
+
+}
+
+extension DashboardContainerViewController: SearchContainer, SearchContainerDelegate,
+    SearchViewControllerDelegate
+{}

--- a/the-blue-alliance-ios/ViewControllers/Dashboard/DashboardViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Dashboard/DashboardViewController.swift
@@ -1,0 +1,29 @@
+import Foundation
+import TBAAPI
+import UIKit
+
+class DashboardViewController: TBATableViewController, Refreshable, Stateful {
+
+    init(dependencies: Dependencies) {
+        super.init(style: .insetGrouped, dependencies: dependencies)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Refreshable
+
+    var isDataSourceEmpty: Bool { true }
+
+    var supportsRefreshing: Bool { false }
+
+    func refresh() {
+        noDataReload()
+    }
+
+    // MARK: - Stateful
+
+    var noDataText: String? { "Nothing to show yet. Search for teams and events above." }
+
+}

--- a/the-blue-alliance-ios/ViewControllers/Root/PhoneRootViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Root/PhoneRootViewController.swift
@@ -19,53 +19,13 @@ class PhoneRootViewController: UITabBarController, RootController {
 
         super.init(nibName: nil, bundle: nil)
 
-        let deps = dependencies
-        let fcm = fcmTokenProvider
-        let push = pushService
-
-        tabs = [
-            UITab(
-                title: RootType.events.title,
-                image: RootType.events.icon,
-                identifier: "tab.events"
-            ) { _ in
-                UINavigationController(
-                    rootViewController: EventsContainerViewController(dependencies: deps)
-                )
-            },
-            UITab(title: RootType.teams.title, image: RootType.teams.icon, identifier: "tab.teams")
-            { _ in
-                UINavigationController(
-                    rootViewController: TeamsContainerViewController(dependencies: deps)
-                )
-            },
-            UITab(
-                title: RootType.districts.title,
-                image: RootType.districts.icon,
-                identifier: "tab.districts"
-            ) { _ in
-                UINavigationController(
-                    rootViewController: DistrictsContainerViewController(dependencies: deps)
-                )
-            },
-            UITab(title: RootType.myTBA.title, image: RootType.myTBA.icon, identifier: "tab.mytba")
-            { _ in
-                UINavigationController(rootViewController: MyTBAViewController(dependencies: deps))
-            },
-            UITab(
-                title: RootType.settings.title,
-                image: RootType.settings.icon,
-                identifier: "tab.settings"
-            ) { _ in
-                UINavigationController(
-                    rootViewController: SettingsViewController(
-                        fcmTokenProvider: fcm,
-                        pushService: push,
-                        dependencies: deps
-                    )
-                )
-            },
-        ]
+        let dashboardEnabled = dependencies.appSettings.featureFlags.isEnabled(.dashboard)
+        tabs = RootType.tabs(dashboardEnabled: dashboardEnabled).map { type in
+            UITab(title: type.title, image: type.icon, identifier: type.tabIdentifier) {
+                [unowned self] _ in
+                UINavigationController(rootViewController: self.makeRootViewController(for: type))
+            }
+        }
 
         mode = .tabSidebar
     }

--- a/the-blue-alliance-ios/ViewControllers/Root/RootController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Root/RootController.swift
@@ -3,6 +3,7 @@ import MyTBAKit
 import UIKit
 
 enum RootType: CaseIterable {
+    case dashboard
     case events
     case teams
     case districts
@@ -11,6 +12,8 @@ enum RootType: CaseIterable {
 
     var title: String {
         switch self {
+        case .dashboard:
+            return "Home"
         case .events:
             return "Events"
         case .teams:
@@ -26,6 +29,8 @@ enum RootType: CaseIterable {
 
     var icon: UIImage? {
         switch self {
+        case .dashboard:
+            return UIImage.homeIcon
         case .events:
             return UIImage.eventIcon
         case .teams:
@@ -39,6 +44,31 @@ enum RootType: CaseIterable {
         }
     }
 
+    var tabIdentifier: String {
+        switch self {
+        case .dashboard:
+            return "tab.dashboard"
+        case .events:
+            return "tab.events"
+        case .teams:
+            return "tab.teams"
+        case .districts:
+            return "tab.districts"
+        case .myTBA:
+            return "tab.mytba"
+        case .settings:
+            return "tab.settings"
+        }
+    }
+
+    // Dashboard takes the Teams slot; teams are reachable through search.
+    static func tabs(dashboardEnabled: Bool) -> [RootType] {
+        if dashboardEnabled {
+            return [.dashboard, .events, .districts, .myTBA, .settings]
+        }
+        return [.events, .teams, .districts, .myTBA, .settings]
+    }
+
 }
 
 protocol RootController {
@@ -48,6 +78,10 @@ protocol RootController {
 }
 
 extension RootController {
+
+    var dashboardViewController: DashboardContainerViewController {
+        return DashboardContainerViewController(dependencies: dependencies)
+    }
 
     var eventsViewController: EventsContainerViewController {
         return EventsContainerViewController(dependencies: dependencies)
@@ -71,6 +105,23 @@ extension RootController {
 
     var myTBAViewController: MyTBAViewController {
         return MyTBAViewController(dependencies: dependencies)
+    }
+
+    func makeRootViewController(for type: RootType) -> UIViewController {
+        switch type {
+        case .dashboard:
+            return dashboardViewController
+        case .events:
+            return eventsViewController
+        case .teams:
+            return teamsViewController
+        case .districts:
+            return districtsViewController
+        case .myTBA:
+            return myTBAViewController
+        case .settings:
+            return settingsViewController
+        }
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Settings/SettingsViewController.swift
@@ -10,6 +10,7 @@ private enum SettingsSection: Int, CaseIterable {
     case networking
     case icons
     case privacy
+    case experimental
     case debug
 }
 
@@ -98,8 +99,23 @@ class SettingsViewController: TBATableViewController {
     private lazy var visibleSections: [SettingsSection] = {
         let canSwitchIcons =
             UIApplication.shared.supportsAlternateIcons && !alternateAppIconNames.isEmpty
-        return SettingsSection.allCases.filter { $0 != .icons || canSwitchIcons }
+        return SettingsSection.allCases.filter { section in
+            switch section {
+            case .icons: return canSwitchIcons
+            case .experimental: return Self.showsExperimentalFeatures
+            default: return true
+            }
+        }
     }()
+
+    // Nothing behind a flag is ready for testers yet.
+    private static var showsExperimentalFeatures: Bool {
+        #if DEBUG && targetEnvironment(simulator)
+            return true
+        #else
+            return false
+        #endif
+    }
 
     private func section(at index: Int) -> SettingsSection? {
         guard visibleSections.indices.contains(index) else {
@@ -126,6 +142,8 @@ class SettingsViewController: TBATableViewController {
             return appIconOptions.count
         case .privacy:
             return PrivacyRow.allCases.count
+        case .experimental:
+            return FeatureFlag.allCases.count
         case .debug:
             return DebugRow.allCases.count
         }
@@ -147,6 +165,8 @@ class SettingsViewController: TBATableViewController {
             return "App Icon"
         case .privacy:
             return "Privacy"
+        case .experimental:
+            return "Experimental"
         case .debug:
             return "Debug"
         }
@@ -159,6 +179,8 @@ class SettingsViewController: TBATableViewController {
         case .privacy:
             return
                 "Analytics helps us understand how the app is used. Crash reports help us find and fix bugs. Both are sent to Firebase."
+        case .experimental:
+            return "Early looks at features still in progress."
         case .debug:
             return "The Blue Alliance for iOS - \(Bundle.main.displayVersionString)"
         default:
@@ -229,7 +251,9 @@ class SettingsViewController: TBATableViewController {
                 cell.textLabel?.text = "Share Analytics"
                 toggle.isOn = dependencies.appSettings.firebaseCollection.analyticsEnabled
                 toggle.addAction(
-                    UIAction { [weak self, unowned toggle] _ in self?.analyticsToggleChanged(toggle)
+                    UIAction { [weak self] action in
+                        guard let toggle = action.sender as? UISwitch else { return }
+                        self?.analyticsToggleChanged(toggle)
                     },
                     for: .valueChanged
                 )
@@ -237,12 +261,29 @@ class SettingsViewController: TBATableViewController {
                 cell.textLabel?.text = "Share Crash Reports"
                 toggle.isOn = dependencies.appSettings.firebaseCollection.crashlyticsEnabled
                 toggle.addAction(
-                    UIAction { [weak self, unowned toggle] _ in
+                    UIAction { [weak self] action in
+                        guard let toggle = action.sender as? UISwitch else { return }
                         self?.crashlyticsToggleChanged(toggle)
                     },
                     for: .valueChanged
                 )
             }
+            cell.accessoryView = toggle
+            cell.selectionStyle = .none
+            return cell
+        case .experimental:
+            let flag = FeatureFlag.allCases[indexPath.row]
+            let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+            let toggle = UISwitch()
+            cell.textLabel?.text = flag.title
+            toggle.isOn = dependencies.appSettings.featureFlags.isEnabled(flag)
+            toggle.addAction(
+                UIAction { [weak self] action in
+                    guard let toggle = action.sender as? UISwitch else { return }
+                    self?.experimentalToggleChanged(toggle, flag: flag)
+                },
+                for: .valueChanged
+            )
             cell.accessoryView = toggle
             cell.selectionStyle = .none
             return cell
@@ -296,7 +337,7 @@ class SettingsViewController: TBATableViewController {
             }
         case .icons:
             setAppIcon(appIconOptions[indexPath.row].alternateName)
-        case .privacy:
+        case .privacy, .experimental:
             break
         case .debug:
             let debugRow = DebugRow.allCases[indexPath.row]
@@ -446,6 +487,21 @@ class SettingsViewController: TBATableViewController {
         alertController.addAction(cancelAction)
 
         self.present(alertController, animated: true, completion: nil)
+    }
+
+    // MARK: - Experimental Methods
+
+    private func experimentalToggleChanged(_ sender: UISwitch, flag: FeatureFlag) {
+        dependencies.appSettings.featureFlags.setEnabled(sender.isOn, for: flag)
+        guard flag.requiresRelaunch else { return }
+
+        let alert = UIAlertController(
+            title: "Relaunch to Apply",
+            message: "Quit and reopen The Blue Alliance to see this change.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Okay", style: .default))
+        present(alert, animated: true)
     }
 
     // MARK: - Privacy Methods


### PR DESCRIPTION
## Summary

First slice of the zero-tap landing screen. Nothing changes for users unless the flag is on, and the flag can only be flipped from a debug simulator build.

- **Feature flags.** `FeatureFlagsStore` on `AppSettings`, with a `FeatureFlag` enum carrying each flag's title and whether it needs a relaunch. Keys share the `kTBAFeatureFlag.` prefix, so removing a flag is deleting its case: `pruneRetiredFlags()` runs at launch beside the legacy Core Data cleanup and drops any stored value that no longer matches a case.
- **Settings.** New Experimental section listing the flags, compiled in for `DEBUG && targetEnvironment(simulator)` only. Toggling a flag with `requiresRelaunch` presents a "Relaunch to Apply" alert.
- **Tabs.** `RootType.dashboard` (label "Home", `house.fill`). The root controller builds its tabs from `RootType.tabs(dashboardEnabled:)`. Flag off is the same five tabs as today. Flag on is Home, Events, Districts, myTBA, Settings; Dashboard takes the Teams slot since teams are reachable through search from every tab that has it.
- **Shell.** `DashboardContainerViewController` adopts the same search protocols as the Events container, so the search field sits in the Home bar with `hidesSearchBarWhenScrolling = false`. The child is an inset-grouped `TBATableViewController` with an empty-state message, ready for cards in the next PR.

The three Settings switches now read the sender from the `UIAction` instead of capturing the switch, which matches every other `UIAction` in the app.

## Test plan

- [x] `make test-app`: 267/267 (92 app, 159 TBAAPI, 16 MyTBAKit)
- [x] `make lint` clean
- [x] New tests: every flag defaults off; a flag round-trips under its prefixed key; prune drops a retired key and leaves both a live flag and an unrelated key; both tab lists; the Home tab hosts the container with the search controller attached; the Settings switch reflects the flag, writes it, and presents the relaunch alert
- [x] Simulator, flag on: launches to Home with search in the bar, Teams tab gone, empty state shown
- [x] Simulator, flag off: launch is identical to main
- [ ] Manual: flip the switch in Settings on a debug simulator build, confirm the alert, relaunch, confirm the Home tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZtTR44bFNAF64GWmgzFAe
