### PR TITLE
Fix the signed-in myTBA crash by dropping the last structured child tasks

### DIFF
--- a/TBAUnitTests/Mocks/DependenciesMocks.swift
+++ b/TBAUnitTests/Mocks/DependenciesMocks.swift
@@ -14,6 +14,18 @@ final class MockTBAAPI: TBAAPIProtocol {
 
     var teams: [TeamSimple] = []
     var teamsByKey: [TeamKey: Team] = [:]
+    var eventsByKey: [EventKey: Event] = [:]
+    /// Latency applied to every stubbed endpoint, so tests can interleave work
+    /// with in-flight requests the way the network does.
+    var latency: Duration = .zero
+
+    private func stub<T>(_ value: T?) async throws -> T {
+        if latency > .zero {
+            try await Task.sleep(for: latency)
+        }
+        guard let value else { throw Unstubbed() }
+        return value
+    }
 
     func setCachePolicy(_ policy: TBAAPI.CachePolicy) async {}
     func clearCache() async {}
@@ -22,8 +34,7 @@ final class MockTBAAPI: TBAAPIProtocol {
     func allTeams() async throws -> [Team] { throw Unstubbed() }
     func allTeamsSimple() async throws -> [TeamSimple] { teams }
     func team(key teamKey: TeamKey) async throws -> Team {
-        guard let team = teamsByKey[teamKey] else { throw Unstubbed() }
-        return team
+        try await stub(teamsByKey[teamKey])
     }
     func teamYearsParticipated(key teamKey: TeamKey) async throws -> [Int] { throw Unstubbed() }
     func teamEventsByYear(key teamKey: TeamKey, year: Int) async throws -> [Event] { throw Unstubbed() }
@@ -34,7 +45,9 @@ final class MockTBAAPI: TBAAPIProtocol {
     func teamMediaByYear(teamKey: TeamKey, year: Int) async throws -> [Media] { throw Unstubbed() }
     func eventTeamsStatuses(key eventKey: EventKey) async throws -> [String: TeamEventStatus] { throw Unstubbed() }
     func eventsByYear(_ year: Int) async throws -> [Event] { throw Unstubbed() }
-    func event(key eventKey: EventKey) async throws -> Event { throw Unstubbed() }
+    func event(key eventKey: EventKey) async throws -> Event {
+        try await stub(eventsByKey[eventKey])
+    }
     func eventTeams(key eventKey: EventKey) async throws -> [Team] { throw Unstubbed() }
     func eventTeamsSimple(key eventKey: EventKey) async throws -> [TeamSimple] { throw Unstubbed() }
     func eventRankings(key eventKey: EventKey) async throws -> EventRanking { throw Unstubbed() }

--- a/TBAUnitTests/Mocks/SessionMocks.swift
+++ b/TBAUnitTests/Mocks/SessionMocks.swift
@@ -138,8 +138,11 @@ final class MockSessionMyTBA: MyTBAProtocol {
         return try Self.baseResponse()
     }
 
-    func fetchFavorites() async throws -> [MyTBAFavorite] { [] }
-    func fetchSubscriptions() async throws -> [MyTBASubscription] { [] }
+    var favorites: [MyTBAFavorite] = []
+    var subscriptions: [MyTBASubscription] = []
+
+    func fetchFavorites() async throws -> [MyTBAFavorite] { favorites }
+    func fetchSubscriptions() async throws -> [MyTBASubscription] { subscriptions }
 
     func updatePreferences(
         modelKey: String,

--- a/TBAUnitTests/ViewControllers/MyTBA/MyTBATableViewControllerTests.swift
+++ b/TBAUnitTests/ViewControllers/MyTBA/MyTBATableViewControllerTests.swift
@@ -9,6 +9,25 @@ import UIKit
 @MainActor
 struct MyTBATableViewControllerTests {
 
+    private static func team(_ number: Int, nickname: String = "") -> Team {
+        Team(key: "frc\(number)", teamNumber: number, nickname: nickname, name: "")
+    }
+
+    private static func event(key: String, startDate: String, endDate: String) -> Event {
+        Event(
+            key: key,
+            name: "",
+            eventCode: String(key.dropFirst(4)),
+            eventType: ._0,
+            startDate: startDate,
+            endDate: endDate,
+            year: Int(key.prefix(4)) ?? 0,
+            eventTypeString: "",
+            webcasts: [],
+            divisionKeys: []
+        )
+    }
+
     private static func rows(in table: UITableView) -> Int {
         (0..<table.numberOfSections).reduce(0) { $0 + table.numberOfRows(inSection: $1) }
     }
@@ -41,6 +60,282 @@ struct MyTBATableViewControllerTests {
 
         store.clear()
         #expect(await Self.waitForRows(controller, count: 0) == 0)
+    }
+
+
+    private static func waitForSections(_ controller: MyTBATableViewController, count: Int) async -> Int {
+        for _ in 0..<200 where controller.tableView.numberOfSections != count {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return controller.tableView.numberOfSections
+    }
+
+    /// The signed-in path: a remote refresh writes the store, which loads every
+    /// backing model and renders an Events section above a Teams section.
+    @Test func signedInRefreshRendersEventsAndTeams() async {
+        let api = MockTBAAPI()
+        api.teamsByKey["frc254"] = Self.team(254, nickname: "The Cheesy Poofs")
+        api.teamsByKey["frc1114"] = Self.team(1114, nickname: "Simbotics")
+        api.eventsByKey["2026casj"] = Self.event(
+            key: "2026casj", startDate: "2026-03-01", endDate: "2026-03-03"
+        )
+        api.eventsByKey["2026miket"] = Self.event(
+            key: "2026miket", startDate: "2026-04-01", endDate: "2026-04-03"
+        )
+
+        let dependencies = Dependencies.mock(api: api)
+        let auth = dependencies.authService as! MockAuthService
+        auth.isSignedIn = true
+        let myTBA = dependencies.myTBA as! MockSessionMyTBA
+        myTBA.favorites = [
+            MyTBAFavorite(modelKey: "frc254", modelType: .team),
+            MyTBAFavorite(modelKey: "2026casj", modelType: .event),
+            MyTBAFavorite(modelKey: "frc1114", modelType: .team),
+            MyTBAFavorite(modelKey: "2026miket", modelType: .event),
+        ]
+
+        let controller = MyTBAFavoritesViewController(dependencies: dependencies)
+        controller.loadViewIfNeeded()
+        controller.refresh()
+
+        #expect(await Self.waitForRows(controller, count: 4) == 4)
+        #expect(await Self.waitForSections(controller, count: 2) == 2)
+    }
+
+    /// Same path for subscriptions, which also carry match keys myTBA can't render.
+    @Test func signedInSubscriptionsRefreshSkipsUnrenderableTypes() async {
+        let api = MockTBAAPI()
+        api.teamsByKey["frc7332"] = Self.team(7332)
+        let dependencies = Dependencies.mock(api: api)
+        (dependencies.authService as! MockAuthService).isSignedIn = true
+        let myTBA = dependencies.myTBA as! MockSessionMyTBA
+        myTBA.subscriptions = [
+            MyTBASubscription(modelKey: "frc7332", modelType: .team, notifications: [.matchScore]),
+            MyTBASubscription(
+                modelKey: "2026casj_qm1", modelType: .match, notifications: [.matchScore]
+            ),
+        ]
+
+        let controller = MyTBASubscriptionsViewController(dependencies: dependencies)
+        controller.loadViewIfNeeded()
+        controller.refresh()
+
+        #expect(await Self.waitForRows(controller, count: 1) == 1)
+    }
+
+
+    /// The real shape: signed in, hosted in a window, with an API that fails
+    /// every model load so the failure banner path runs too.
+    @Test func signedInMyTBAViewInAWindowLoadsFavorites() async {
+        let api = MockTBAAPI()
+        api.teamsByKey["frc254"] = Self.team(254, nickname: "The Cheesy Poofs")
+        api.eventsByKey["2026casj"] = Self.event(
+            key: "2026casj", startDate: "2026-03-01", endDate: "2026-03-03"
+        )
+        let dependencies = Dependencies.mock(api: api)
+        (dependencies.authService as! MockAuthService).isSignedIn = true
+        let myTBA = dependencies.myTBA as! MockSessionMyTBA
+        myTBA.favorites = [
+            MyTBAFavorite(modelKey: "frc254", modelType: .team),
+            MyTBAFavorite(modelKey: "2026casj", modelType: .event),
+            // Nothing stubbed for these, so their loads fail and the banner shows.
+            MyTBAFavorite(modelKey: "frc1114", modelType: .team),
+            MyTBAFavorite(modelKey: "2026miket", modelType: .event),
+        ]
+        myTBA.subscriptions = myTBA.favorites.map {
+            MyTBASubscription(modelKey: $0.modelKey, modelType: $0.modelType, notifications: [])
+        }
+
+        let controller = MyTBAViewController(dependencies: dependencies)
+        let navigation = UINavigationController(rootViewController: controller)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+        window.rootViewController = navigation
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+
+        let favorites = controller.favoritesViewController
+        #expect(await Self.waitForRows(favorites, count: 2) == 2)
+        window.layoutIfNeeded()
+
+        // Switch to Subscriptions the way the segmented control does.
+        controller.subscriptionsViewController.refresh()
+        #expect(await Self.waitForRows(controller.subscriptionsViewController, count: 2) == 2)
+        window.layoutIfNeeded()
+    }
+
+
+    /// A big favorites list where only some models load, then the user taps the
+    /// failure banner so loaded and key-only rows are sorted together.
+    @Test func manyFavoritesWithSomeFailuresRenderAfterTappingTheBanner() async {
+        let api = MockTBAAPI()
+        let numbers = Array(1...60)
+        // Only the even-numbered teams resolve; the odd ones fail to load.
+        for number in numbers where number.isMultiple(of: 2) {
+            api.teamsByKey["frc\(number)"] = Self.team(number)
+        }
+        let dependencies = Dependencies.mock(api: api)
+        (dependencies.authService as! MockAuthService).isSignedIn = true
+        let myTBA = dependencies.myTBA as! MockSessionMyTBA
+        myTBA.favorites = numbers.map { MyTBAFavorite(modelKey: "frc\($0)", modelType: .team) }
+
+        let controller = MyTBAFavoritesViewController(dependencies: dependencies)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.refresh()
+
+        #expect(await Self.waitForRows(controller, count: 30) == 30)
+
+        controller.bannerTapped()
+        #expect(Self.rows(in: controller.tableView) == 60)
+        window.layoutIfNeeded()
+    }
+
+
+    /// A returning signed-in user: the store is already populated off disk before
+    /// the view exists, so the first snapshot, the observation's first emit, and
+    /// the pull-to-refresh all load models at once.
+    @Test func returningSignedInUserWithAPopulatedStore() async {
+        let api = MockTBAAPI()
+        api.teamsByKey["frc254"] = Self.team(254, nickname: "The Cheesy Poofs")
+        api.teamsByKey["frc1114"] = Self.team(1114, nickname: "Simbotics")
+        api.eventsByKey["2026casj"] = Self.event(
+            key: "2026casj", startDate: "2026-03-01", endDate: "2026-03-03"
+        )
+        let dependencies = Dependencies.mock(api: api)
+        (dependencies.authService as! MockAuthService).isSignedIn = true
+
+        let favorites = [
+            MyTBAFavorite(modelKey: "frc254", modelType: .team),
+            MyTBAFavorite(modelKey: "frc1114", modelType: .team),
+            MyTBAFavorite(modelKey: "2026casj", modelType: .event),
+        ]
+        // As if it had been read back off disk at launch.
+        dependencies.myTBAStores.favorites.replaceAll(with: favorites)
+        (dependencies.myTBA as! MockSessionMyTBA).favorites = favorites
+
+        let controller = MyTBAViewController(dependencies: dependencies)
+        let navigation = UINavigationController(rootViewController: controller)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+        window.rootViewController = navigation
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+
+        #expect(await Self.waitForRows(controller.favoritesViewController, count: 3) == 3)
+        window.layoutIfNeeded()
+    }
+
+
+    /// Refreshes that overlap the way they do on a real network: the user lands
+    /// on myTBA, pulls to refresh, and flips between segments while loads are
+    /// still in flight.
+    @Test func overlappingRefreshesWhileSwitchingSegments() async {
+        let api = MockTBAAPI()
+        api.latency = .milliseconds(20)
+        let numbers = Array(1...20)
+        for number in numbers {
+            api.teamsByKey["frc\(number)"] = Self.team(number)
+        }
+        for year in 2024...2026 {
+            api.eventsByKey["\(year)casj"] = Self.event(
+                key: "\(year)casj", startDate: "\(year)-03-01", endDate: "\(year)-03-03"
+            )
+        }
+
+        let dependencies = Dependencies.mock(api: api)
+        (dependencies.authService as! MockAuthService).isSignedIn = true
+        let myTBA = dependencies.myTBA as! MockSessionMyTBA
+        myTBA.favorites =
+            numbers.map { MyTBAFavorite(modelKey: "frc\($0)", modelType: .team) }
+            + (2024...2026).map { MyTBAFavorite(modelKey: "\($0)casj", modelType: .event) }
+        myTBA.subscriptions = myTBA.favorites.map {
+            MyTBASubscription(modelKey: $0.modelKey, modelType: $0.modelType, notifications: [])
+        }
+
+        let controller = MyTBAViewController(dependencies: dependencies)
+        let navigation = UINavigationController(rootViewController: controller)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+        window.rootViewController = navigation
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+
+        // Hammer both children the way the segmented control and pull-to-refresh do.
+        for _ in 0..<8 {
+            controller.favoritesViewController.refresh()
+            controller.subscriptionsViewController.refresh()
+            controller.beginAppearanceTransition(true, animated: false)
+            controller.endAppearanceTransition()
+            window.layoutIfNeeded()
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(await Self.waitForRows(controller.favoritesViewController, count: 23) == 23)
+        window.layoutIfNeeded()
+    }
+
+    /// Sign-out while a refresh is in flight, which cancels both children and
+    /// flips every screen back to the signed-out interface.
+    @Test func signOutWhileRefreshing() async {
+        let api = MockTBAAPI()
+        api.latency = .milliseconds(30)
+        for number in 1...10 {
+            api.teamsByKey["frc\(number)"] = Self.team(number)
+        }
+        let dependencies = Dependencies.mock(api: api)
+        let auth = dependencies.authService as! MockAuthService
+        auth.isSignedIn = true
+        let myTBA = dependencies.myTBA as! MockSessionMyTBA
+        myTBA.favorites = (1...10).map { MyTBAFavorite(modelKey: "frc\($0)", modelType: .team) }
+
+        let controller = MyTBAViewController(dependencies: dependencies)
+        let navigation = UINavigationController(rootViewController: controller)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+        window.rootViewController = navigation
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+
+        controller.favoritesViewController.refresh()
+        try? await Task.sleep(for: .milliseconds(10))
+
+        try? await dependencies.myTBASession.signOut()
+        controller.authStateChanged(isSignedIn: false)
+        window.layoutIfNeeded()
+
+        #expect(await Self.waitForRows(controller.favoritesViewController, count: 0) == 0)
+    }
+
+
+    private static func teamNumbers(in controller: MyTBATableViewController) -> [String] {
+        let table = controller.tableView
+        return (0..<table.numberOfRows(inSection: 0)).compactMap {
+            let cell = table.dataSource?.tableView(table, cellForRowAt: IndexPath(row: $0, section: 0))
+            return (cell as? TeamTableViewCell)?.viewModel?.teamNumber
+        }
+    }
+
+    /// Placeholder rows have to stay in team-number order alongside loaded ones.
+    /// Ordering them as strings instead put 1114 after 254, which is both wrong
+    /// and not a strict weak ordering for `sorted`.
+    @Test func placeholderTeamsSortByNumberAlongsideLoadedTeams() async {
+        let api = MockTBAAPI()
+        // 254 and 1500 load; 1114 does not, so it renders as a placeholder.
+        api.teamsByKey["frc254"] = Self.team(254)
+        api.teamsByKey["frc1500"] = Self.team(1500)
+        let dependencies = Dependencies.mock(api: api)
+        (dependencies.authService as! MockAuthService).isSignedIn = true
+        let myTBA = dependencies.myTBA as! MockSessionMyTBA
+        myTBA.favorites = [254, 1114, 1500].map {
+            MyTBAFavorite(modelKey: "frc\($0)", modelType: .team)
+        }
+
+        let controller = MyTBAFavoritesViewController(dependencies: dependencies)
+        controller.loadViewIfNeeded()
+        controller.refresh()
+
+        #expect(await Self.waitForRows(controller, count: 2) == 2)
+        controller.bannerTapped()
+        #expect(Self.rows(in: controller.tableView) == 3)
+        #expect(Self.teamNumbers(in: controller) == ["254", "1114", "1500"])
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventTeamsViewController.swift
@@ -20,11 +20,16 @@ class EventTeamsViewController: TeamsListViewController<Team> {
     }
 
     override func loadTeams() async throws -> [Team] {
-        async let teams = dependencies.api.eventTeams(key: eventKey)
-        async let statuses = try? dependencies.api.eventTeamsStatuses(key: eventKey)
+        // Unstructured Task handles instead of `async let`: Swift 6.1's
+        // async-let stack allocator trips swift_task_dealloc's LIFO check
+        // here even with reverse-order awaits (#995 didn't fully fix it).
+        // Task handles heap-allocate and sidestep the allocator entirely.
+        // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
+        let teamsHandle = Task { try await dependencies.api.eventTeams(key: eventKey) }
+        let statusesHandle = Task { try? await dependencies.api.eventTeamsStatuses(key: eventKey) }
 
-        let loadedTeams = try await teams
-        let loadedStatuses = await statuses ?? [:]
+        let loadedTeams = try await teamsHandle.value
+        let loadedStatuses = await statusesHandle.value ?? [:]
 
         pitLocations = loadedStatuses.compactMapValues { $0.pitLocation }
         return loadedTeams

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -170,18 +170,20 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
         runRefresh { [weak self] in
             guard let self else { return }
             let key = self.state.key
-            async let matchesTask = self.dependencies.api.eventMatches(key: key)
-            async let alliancesTask: [EliminationAlliance]?? = {
-                try? await self.dependencies.api.eventAlliances(key: key)
-            }()
-            async let eventTask: Event? = {
-                try? await self.dependencies.api.event(key: key)
-            }()
-            self.allMatches = try await matchesTask
-            if let alliancesResult = await alliancesTask {
-                self.allianceLookup = alliancesResult.map(AllianceLookup.init)
+            // Unstructured Task handles instead of `async let`: Swift 6.1's
+            // async-let stack allocator trips swift_task_dealloc's LIFO check
+            // here even with reverse-order awaits (#995 didn't fully fix it).
+            // Task handles heap-allocate and sidestep the allocator entirely.
+            // See https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/996
+            let matchesHandle = Task { try await self.dependencies.api.eventMatches(key: key) }
+            let alliancesHandle = Task { try await self.dependencies.api.eventAlliances(key: key) }
+            let eventHandle = Task { try? await self.dependencies.api.event(key: key) }
+            self.allMatches = try await matchesHandle.value
+            // A failed request keeps the old lookup; a nil payload clears it.
+            if case .success(let alliances) = await alliancesHandle.result {
+                self.allianceLookup = alliances.map(AllianceLookup.init)
             }
-            if let event = await eventTask {
+            if let event = await eventHandle.value {
                 self.state = .event(event)
             }
             self.applyMatches(self.allMatches)

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -304,28 +304,36 @@ class MyTBATableViewController: UIViewController, DataController,
         updateFailureBanner()
     }
 
+    // Both comparators order off the key, which every row has, rather than off
+    // the loaded model, which only some do. Switching rules mid-sort costs
+    // `sorted` its strict weak ordering, and an inconsistent predicate can walk
+    // Swift's sort off the end of the buffer.
     private func sortItems(_ items: [MyTBAItem], in section: MyTBASection) -> [MyTBAItem] {
         switch section {
         case .event:
             return items.sorted { lhs, rhs in
-                guard case .event(let l) = loadedModels[lhs],
-                    case .event(let r) = loadedModels[rhs]
-                else {
+                let lYear = lhs.modelKey.year ?? 0
+                let rYear = rhs.modelKey.year ?? 0
+                if lYear != rYear { return lYear > rYear }
+                // Within a year, rows whose event loaded sort among themselves
+                // first; the key-only placeholders follow in key order.
+                switch (loadedModels[lhs], loadedModels[rhs]) {
+                case (.event(let l), .event(let r)):
+                    return Event.sectionAscending(l, r)
+                case (.event, _):
+                    return true
+                case (_, .event):
+                    return false
+                default:
                     return lhs.modelKey < rhs.modelKey
                 }
-                let lYear = l.key.year ?? 0
-                let rYear = r.key.year ?? 0
-                if lYear != rYear { return lYear > rYear }
-                return Event.sectionAscending(l, r)
             }
         case .team:
             return items.sorted { lhs, rhs in
-                guard case .team(let l) = loadedModels[lhs],
-                    case .team(let r) = loadedModels[rhs]
-                else {
-                    return lhs.modelKey < rhs.modelKey
-                }
-                return l.teamNumber < r.teamNumber
+                let lNumber = lhs.modelKey.teamNumber ?? .max
+                let rNumber = rhs.modelKey.teamNumber ?? .max
+                if lNumber != rNumber { return lNumber < rNumber }
+                return lhs.modelKey < rhs.modelKey
             }
         }
     }
@@ -363,31 +371,37 @@ class MyTBATableViewController: UIViewController, DataController,
         }
     }
 
+    // Unstructured Task handles instead of a task group. Returning
+    // `(MyTBAItem, Result<LoadedModel, any Error>)` from the children routed
+    // the key through the group's child-result buffer, and hashing it back out
+    // read freed memory - the same allocator behind #996. Handles heap-allocate
+    // their result, and each child applies its own so rows still appear in
+    // completion order rather than list order.
     private func fetchMissingItems() async {
-        await withTaskGroup(of: (MyTBAItem, Result<LoadedModel, any Error>).self) { group in
-            for item in currentItems where loadedModels[item] == nil {
-                group.addTask { [self] in
-                    do {
-                        return (item, .success(try await loadModel(for: item)))
-                    } catch {
-                        return (item, .failure(error))
-                    }
-                }
+        let handles =
+            currentItems
+            .filter { loadedModels[$0] == nil }
+            .map { item in Task { await self.loadAndApply(item) } }
+        for handle in handles {
+            // Unstructured handles don't inherit the refresh's cancellation.
+            if Task.isCancelled {
+                handle.cancel()
             }
-            for await (item, result) in group {
-                switch result {
-                case .success(let model):
-                    loadedModels[item] = model
-                    failedKeys.remove(item)
-                    rebuildSnapshot()
-                case .failure(is CancellationError):
-                    // Refresh was cancelled; leave state untouched.
-                    break
-                case .failure:
-                    failedKeys.insert(item)
-                    updateFailureBanner()
-                }
-            }
+            await handle.value
+        }
+    }
+
+    private func loadAndApply(_ item: MyTBAItem) async {
+        do {
+            let model = try await loadModel(for: item)
+            loadedModels[item] = model
+            failedKeys.remove(item)
+            rebuildSnapshot()
+        } catch is CancellationError {
+            // Refresh was cancelled; leave state untouched.
+        } catch {
+            failedKeys.insert(item)
+            updateFailureBanner()
         }
     }
 
@@ -444,7 +458,7 @@ class MyTBATableViewController: UIViewController, DataController,
         return "Failed to load \(parts.joined(separator: ", "))"
     }
 
-    private func bannerTapped() {
+    func bannerTapped() {
         guard !failedKeys.isEmpty else { return }
         inlineFailedKeys = true
         rebuildSnapshot()


### PR DESCRIPTION
## Summary

3.6.0 (3) crashes reliably for signed-in users on the myTBA tab. Two TestFlight reports, identical stacks: `EXC_BAD_ACCESS` at `0x18` on the main thread in `_StringObject.getSharedUTF8Start()`, two app frames below `withTaskGroup` — and `MyTBATableViewController.fetchMissingItems()` is the app's only task group.

Children returned `(MyTBAItem, Result<LoadedModel, any Error>)`; the parent hashed a `MyTBAItem` read back out of the group and segfaulted. Real myTBA keys are ≤15 bytes and stored inline, and inline strings can never reach the `sharedUTF8` path, so the value wasn't a torn key — it was garbage out of the group's child-result buffer. Same task-local allocator as #996 (swiftlang/swift#81771), different shape. The upstream fix is in Swift 6.3.3, which built this beta, so it evidently doesn't cover task-group results.

- **`MyTBATableViewController.fetchMissingItems`** — task group → unstructured `Task` handles, matching every `async let` site. Each child applies its own result, so rows still appear in completion order.
- **`MatchesViewController.refresh`, `EventTeamsViewController.loadTeams`** — the last two `async let`s in the codebase, converted the same way. The app now has zero structured child tasks; #996 lists all sixteen sites for the eventual revert.
- **myTBA sort comparators** — now order off the key for every row. They switched rules by whether a model had loaded, which isn't a strict weak ordering once a placeholder row is mixed in.
- **Tests** — a signed-in myTBA harness (stubbed favorites/subscriptions, API latency) with eight tests over the refresh path, populated-store launch, window-hosted view, partial failures + banner, overlapping refreshes across segments, sign-out mid-refresh, and placeholder sort order.

## Test plan

- [x] `make test-app` — 275/275
- [x] `make lint`
- [x] Sort regression test fails against the old comparator (`1114, 254, 1500`) and passes now
- [ ] Install on a signed-in device with favorites; open the myTBA tab, pull to refresh, flip Favorites ↔ Subscriptions — no crash
- [ ] Open an event → Matches, and event → Teams, confirm both still load with alliance names / pit locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpQPfqLpYgzCj6TCJx6A1X
