### PR TITLE
Remove UIDesignRequiresCompatibility from Info.plist

### DIFF
--- a/the-blue-alliance-ios/Info.plist
+++ b/the-blue-alliance-ios/Info.plist
@@ -108,7 +108,5 @@
 	<false/>
 	<key>FirebaseCrashlyticsCollectionEnabled</key>
 	<false/>
-	<key>UIDesignRequiresCompatibility</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Drops the `UIDesignRequiresCompatibility` key so the app takes the current system design instead of opting out of it. Removing the key is the same as setting it to `NO`; there's no reason to carry it.

## Check out locally

```
git fetch origin
git worktree add ../tba-ios-compat origin/zach/remove-design-compatibility
cd ../tba-ios-compat
ln -s ../../../../the-blue-alliance-ios/Secrets.plist the-blue-alliance-ios/Secrets.plist
open the-blue-alliance-ios.xcodeproj
```

Clean up with `git worktree remove ../tba-ios-compat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgvPixSF6TZehdQqvmL57D