### PR TITLE
Clear list screens when their year changes

### DIFF
--- a/TBAUnitTests/Mocks/DependenciesMocks.swift
+++ b/TBAUnitTests/Mocks/DependenciesMocks.swift
@@ -15,12 +15,23 @@ final class MockTBAAPI: TBAAPIProtocol {
     var teams: [TeamSimple] = []
     var teamsByKey: [TeamKey: Team] = [:]
     var eventsByKey: [EventKey: Event] = [:]
+    var teamEventsByYear: [Int: [Event]] = [:]
     /// Latency applied to every stubbed endpoint, so tests can interleave work
     /// with in-flight requests the way the network does.
     var latency: Duration = .zero
+    /// Lets a cancelled request still return its result, the way a response
+    /// that has already left the network does.
+    var latencyIgnoresCancellation = false
 
     private func stub<T>(_ value: T?) async throws -> T {
-        if latency > .zero {
+        if latency > .zero, latencyIgnoresCancellation {
+            let latency = latency
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global().asyncAfter(deadline: .now() + latency.timeInterval) {
+                    continuation.resume()
+                }
+            }
+        } else if latency > .zero {
             try await Task.sleep(for: latency)
         }
         guard let value else { throw Unstubbed() }
@@ -37,7 +48,9 @@ final class MockTBAAPI: TBAAPIProtocol {
         try await stub(teamsByKey[teamKey])
     }
     func teamYearsParticipated(key teamKey: TeamKey) async throws -> [Int] { throw Unstubbed() }
-    func teamEventsByYear(key teamKey: TeamKey, year: Int) async throws -> [Event] { throw Unstubbed() }
+    func teamEventsByYear(key teamKey: TeamKey, year: Int) async throws -> [Event] {
+        try await stub(teamEventsByYear[year])
+    }
     func teamEventMatches(teamKey: TeamKey, eventKey: EventKey) async throws -> [Match] { throw Unstubbed() }
     func teamEventAwards(teamKey: TeamKey, eventKey: EventKey) async throws -> [Award] { throw Unstubbed() }
     func teamEventStatus(teamKey: TeamKey, eventKey: EventKey) async throws -> TeamEventStatus { throw Unstubbed() }
@@ -123,4 +136,11 @@ extension Dependencies {
 
 final class MockFCMTokenProvider: FCMTokenProvider {
     var fcmToken: String?
+}
+
+extension Duration {
+    fileprivate var timeInterval: TimeInterval {
+        let (seconds, attoseconds) = components
+        return TimeInterval(seconds) + TimeInterval(attoseconds) / 1e18
+    }
 }

--- a/TBAUnitTests/ViewControllers/Teams/TeamEventsViewControllerTests.swift
+++ b/TBAUnitTests/ViewControllers/Teams/TeamEventsViewControllerTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import TBAAPI
+import Testing
+import UIKit
+
+@testable import The_Blue_Alliance
+
+@MainActor
+struct TeamEventsViewControllerTests {
+
+    private static func event(_ key: String, year: Int) -> Event {
+        Event(
+            key: key,
+            name: key,
+            eventCode: String(key.dropFirst(4)),
+            eventType: ._0,
+            startDate: "\(year)-03-01",
+            endDate: "\(year)-03-03",
+            year: year,
+            eventTypeString: "",
+            week: 0,
+            webcasts: [],
+            divisionKeys: [],
+            parentEventKey: nil
+        )
+    }
+
+    private static func makeController(api: MockTBAAPI) -> TeamEventsViewController {
+        api.teamEventsByYear = [
+            2025: [event("2025miket", year: 2025)],
+            2026: [event("2026miket", year: 2026)],
+        ]
+        let controller = TeamEventsViewController(
+            teamKey: "frc7332",
+            year: 2025,
+            dependencies: .mock(api: api)
+        )
+        controller.loadViewIfNeeded()
+        return controller
+    }
+
+    private static func waitForEvents(
+        _ controller: TeamEventsViewController,
+        keys: [String]
+    ) async -> [String] {
+        for _ in 0..<200 where controller.events.map(\.key) != keys {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return controller.events.map(\.key)
+    }
+
+    @Test func changingYearClearsTheListBeforeTheNewYearLoads() async {
+        let api = MockTBAAPI()
+        let controller = Self.makeController(api: api)
+        controller.refresh()
+        #expect(await Self.waitForEvents(controller, keys: ["2025miket"]) == ["2025miket"])
+
+        api.latency = .milliseconds(200)
+        controller.year = 2026
+        #expect(controller.events.isEmpty)
+        #expect(controller.isRefreshing)
+
+        #expect(await Self.waitForEvents(controller, keys: ["2026miket"]) == ["2026miket"])
+        #expect(!controller.isRefreshing)
+    }
+
+    @Test func aResponseThatOutlivesItsCancelledRefreshDoesNotLand() async {
+        let api = MockTBAAPI()
+        let controller = Self.makeController(api: api)
+        api.latency = .milliseconds(100)
+        api.latencyIgnoresCancellation = true
+        controller.refresh()
+
+        // Switch years while 2025 is in flight. Cancelling can't stop its
+        // response from coming back; the refresh has to drop it instead.
+        try? await Task.sleep(for: .milliseconds(20))
+        controller.year = 2026
+        #expect(await Self.waitForEvents(controller, keys: ["2026miket"]) == ["2026miket"])
+        #expect(!controller.isRefreshing)
+
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(controller.events.map(\.key) == ["2026miket"])
+    }
+
+    @Test func aCancelledRefreshLeavesTheNewerRefreshSpinning() async {
+        let api = MockTBAAPI()
+        let controller = Self.makeController(api: api)
+        api.latency = .milliseconds(200)
+        controller.refresh()
+
+        try? await Task.sleep(for: .milliseconds(20))
+        controller.year = 2026
+        // The 2025 task is cancelled and unwinds here; the 2026 task is still
+        // waiting on the mock's latency and must still own the refresh state.
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(controller.isRefreshing)
+        #expect(controller.events.isEmpty)
+
+        #expect(await Self.waitForEvents(controller, keys: ["2026miket"]) == ["2026miket"])
+        #expect(!controller.isRefreshing)
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000001 /* DependenciesMocks.swift */; };
 		5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */; };
 		5EC0D41A2C26070100000006 /* TeamsListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */; };
+		5EC0D41A2C26090900000002 /* TeamEventsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090900000001 /* TeamEventsViewControllerTests.swift */; };
 		5EC0D41A2C26070100000020 /* SearchContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C2607010000001F /* SearchContainerTests.swift */; };
 		5EC0D41A2C26070100000008 /* MyTBATableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */; };
 		5EC0D41A2C26060100000006 /* MatchBreakdownConfigurator2023Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */; };
@@ -248,6 +249,7 @@
 		5EC0D41A2C26070100000001 /* DependenciesMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/DependenciesMocks.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Match/MatchBreakdownViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Teams/TeamsListViewControllerTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26090900000001 /* TeamEventsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Teams/TeamEventsViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C2607010000001F /* SearchContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Search/SearchContainerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/MyTBA/MyTBATableViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewElements/Match/Breakdown/MatchBreakdownConfigurator2023Tests.swift"; sourceTree = "<group>"; };
@@ -611,6 +613,7 @@
 				5EC0D41A2C26070100000001 /* DependenciesMocks.swift */,
 				5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */,
 				5EC0D41A2C26070100000005 /* TeamsListViewControllerTests.swift */,
+				5EC0D41A2C26090900000001 /* TeamEventsViewControllerTests.swift */,
 				5EC0D41A2C2607010000001F /* SearchContainerTests.swift */,
 				5EC0D41A2C26070100000007 /* MyTBATableViewControllerTests.swift */,
 				5EC0D41A2C26060100000005 /* MatchBreakdownConfigurator2023Tests.swift */,
@@ -1294,6 +1297,7 @@
 				5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */,
 				5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */,
 				5EC0D41A2C26070100000006 /* TeamsListViewControllerTests.swift in Sources */,
+				5EC0D41A2C26090900000002 /* TeamEventsViewControllerTests.swift in Sources */,
 				5EC0D41A2C26070100000020 /* SearchContainerTests.swift in Sources */,
 				5EC0D41A2C26070100000008 /* MyTBATableViewControllerTests.swift in Sources */,
 				5EC0D41A2C26060100000006 /* MatchBreakdownConfigurator2023Tests.swift in Sources */,

--- a/the-blue-alliance-ios/Protocols/Refreshable.swift
+++ b/the-blue-alliance-ios/Protocols/Refreshable.swift
@@ -44,11 +44,13 @@ extension Refreshable {
         currentRefreshTask = Task { [weak self] in
             guard let self else { return }
             self.updateRefresh()
-            defer {
-                self.currentRefreshTask = nil
-                self.updateRefresh()
-            }
             try? await body()
+            // A newer refresh cancelled this one and now owns the task handle
+            // and the indicator - clearing them here would stop the spinner
+            // and flash the no-data view while that refresh is still loading.
+            guard !Task.isCancelled else { return }
+            self.currentRefreshTask = nil
+            self.updateRefresh()
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
@@ -11,6 +11,8 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
     weak var delegate: (any DistrictsViewControllerDelegate)?
     var year: Int {
         didSet {
+            if oldValue == year { return }
+            apply([])
             refresh()
         }
     }
@@ -79,7 +81,9 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
     func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            self.apply(try await self.dependencies.api.districtsByYear(self.year))
+            let districts = try await self.dependencies.api.districtsByYear(self.year)
+            guard !Task.isCancelled else { return }
+            self.apply(districts)
         }
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
@@ -106,6 +106,7 @@ class EventsListViewController: TBATableViewController, Refreshable, Stateful {
         runRefresh { [weak self] in
             guard let self else { return }
             let loaded = try await self.loadEvents()
+            guard !Task.isCancelled else { return }
             self.applyEvents(loaded)
         }
     }

--- a/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/WeekEventsViewController.swift
@@ -21,6 +21,8 @@ class WeekEventsViewController: EventsListViewController {
                 // Switched years — the cached allEvents are for the previous
                 // year, so filtering would drop everything. Refetch; the
                 // refresh path will call applyEvents once the new data lands.
+                allEvents = []
+                applyEvents([])
                 refresh()
             } else {
                 applyEvents(allEvents)
@@ -84,7 +86,9 @@ class WeekEventsViewController: EventsListViewController {
     override func refresh() {
         runRefresh { [weak self] in
             guard let self else { return }
-            self.allEvents = try await self.dependencies.api.eventsByYear(self.currentYear)
+            let events = try await self.dependencies.api.eventsByYear(self.currentYear)
+            guard !Task.isCancelled else { return }
+            self.allEvents = events
             if self.weekEvent == nil {
                 self.weekEvent = WeekEventsViewController.initialWeekEvent(
                     for: self.currentYear,

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamEventsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamEventsViewController.swift
@@ -7,6 +7,7 @@ class TeamEventsViewController: EventsListViewController {
     var year: Int? {
         didSet {
             if oldValue == year { return }
+            applyEvents([])
             refresh()
         }
     }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamMediaCollectionViewController.swift
@@ -386,6 +386,7 @@ extension TeamMediaCollectionViewController: Refreshable {
                 teamKey: self.teamKey,
                 year: year
             )
+            guard !Task.isCancelled else { return }
             let items: [TeamMediaItem] = apiMedia.compactMap { Self.makeItem(from: $0) }
             self.imageErrors.removeAll()
             self.applyMedia(items)


### PR DESCRIPTION
Fixes #1089.

Team Events, Districts, and the Events tab kept the previous year's rows on screen until the new year's request finished, and a slow response for the old year could land on top of the new one. Each screen now drops its rows when its driver changes and ignores the response from a cancelled refresh. Team Media already cleared itself and only gains the cancelled-response guard.

`runRefresh` also no longer lets a cancelled refresh nil out the newer refresh's task handle on its way out. That stopped the spinner early and, now that lists clear, would have flashed the no-data view mid-load.

Re-selecting the same year in Districts no longer refetches, matching Team Events.

New `TeamEventsViewControllerTests` cover the clear, the dropped stale response, and the spinner staying up.

## Check out locally

```
git fetch origin
git worktree add ../tba-ios-lists origin/zach/clear-lists-on-year-change
cd ../tba-ios-lists
ln -s ../../../../the-blue-alliance-ios/Secrets.plist the-blue-alliance-ios/Secrets.plist
open the-blue-alliance-ios.xcodeproj
```

Clean up with `git worktree remove ../tba-ios-lists`.

## Test plan

- Team → Events tab → change year: the list empties immediately with the spinner up, then fills with the new year.
- Set Settings → Cache Policy to ignore cache, then flip years quickly on a team with many events. The list should settle on the last year picked.
- Districts tab: change year; same behavior. Events tab: pick a different year in the picker; same behavior.
- Airplane mode, change year: list stays empty and shows the no-data text rather than the old year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgvPixSF6TZehdQqvmL57D