### PR TITLE
Show match times on the match Info tab

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/APIEvent+Helpers.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/Events/APIEvent+Helpers.swift
@@ -29,6 +29,10 @@ extension Event {
         return shortName
     }
 
+    public var timeZone: TimeZone? {
+        timezone.flatMap { TimeZone(identifier: $0) }
+    }
+
     public var safeNameYear: String {
         name.isEmpty ? key : "\(year) \(name)"
     }

--- a/TBAUnitTests/ViewModels/Match/MatchTimesViewModelTests.swift
+++ b/TBAUnitTests/ViewModels/Match/MatchTimesViewModelTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import TBAAPI
+import Testing
+
+@testable import The_Blue_Alliance
+
+struct MatchTimesViewModelTests {
+
+    // 2026-03-07 14:30:00 UTC — 9:30 AM in Detroit, 6:30 AM in Los Angeles.
+    private static let scheduled: Int64 = 1_772_893_800
+    private static let detroit = TimeZone(identifier: "America/Detroit")!
+    private static let losAngeles = TimeZone(identifier: "America/Los_Angeles")!
+    private static let newYork = TimeZone(identifier: "America/New_York")!
+    private static let locale = Locale(identifier: "en_US")
+
+    // Foundation separates the hour from AM with a narrow no-break space.
+    private static func am(_ time: String) -> String { "\(time)\u{202F}AM" }
+
+    private static func makeViewModel(
+        time: Int64? = nil,
+        actualTime: Int64? = nil,
+        predictedTime: Int64? = nil,
+        eventTimeZone: TimeZone? = detroit,
+        showsDeviceTimeZone: Bool = false,
+        deviceTimeZone: TimeZone = losAngeles
+    ) -> MatchTimesViewModel {
+        MatchTimesViewModel(
+            match: makeMatch(time: time, actualTime: actualTime, predictedTime: predictedTime),
+            eventTimeZone: eventTimeZone,
+            showsDeviceTimeZone: showsDeviceTimeZone,
+            deviceTimeZone: deviceTimeZone,
+            locale: locale
+        )
+    }
+
+    @Test func noTimesMeansNoRows() {
+        let viewModel = Self.makeViewModel()
+        #expect(viewModel.isEmpty)
+        #expect(viewModel.rows.isEmpty)
+    }
+
+    @Test func rowsFollowTheEventClockByDefault() {
+        let viewModel = Self.makeViewModel(
+            time: Self.scheduled,
+            actualTime: Self.scheduled + 120,
+            predictedTime: Self.scheduled + 60
+        )
+        #expect(viewModel.canToggleTimeZone)
+        #expect(
+            viewModel.rows == [
+                .init(title: "Date", value: "Sat, Mar 7", detail: nil),
+                .init(title: "Actual", value: Self.am("9:32"), detail: "2m late"),
+                .init(title: "Scheduled", value: Self.am("9:30"), detail: nil),
+                .init(title: "Predicted", value: Self.am("9:31"), detail: nil),
+            ]
+        )
+    }
+
+    @Test func toggleMovesRowsToTheDeviceClock() {
+        let viewModel = Self.makeViewModel(time: Self.scheduled, showsDeviceTimeZone: true)
+        #expect(viewModel.rows.map(\.value) == ["Sat, Mar 7", Self.am("6:30")])
+    }
+
+    @Test func onlyTheRowsWithTimesAppear() {
+        let viewModel = Self.makeViewModel(predictedTime: Self.scheduled)
+        #expect(viewModel.rows.map(\.title) == ["Date", "Predicted"])
+        #expect(viewModel.rows.last?.detail == nil)
+    }
+
+    @Test func actualWithoutScheduledHasNoOffScheduleDetail() {
+        let viewModel = Self.makeViewModel(actualTime: Self.scheduled)
+        #expect(viewModel.rows.map(\.title) == ["Date", "Actual"])
+        #expect(viewModel.rows.last?.detail == nil)
+    }
+
+    @Test func noEventTimeZoneStaysOnTheDeviceClockWithoutAToggle() {
+        let viewModel = Self.makeViewModel(time: Self.scheduled, eventTimeZone: nil)
+        #expect(!viewModel.canToggleTimeZone)
+        #expect(viewModel.rows.map(\.value) == ["Sat, Mar 7", Self.am("6:30")])
+    }
+
+    @Test func sameClockInADifferentZoneOffersNoToggle() {
+        let viewModel = Self.makeViewModel(time: Self.scheduled, deviceTimeZone: Self.newYork)
+        #expect(!viewModel.canToggleTimeZone)
+        #expect(viewModel.rows.map(\.value) == ["Sat, Mar 7", Self.am("9:30")])
+    }
+
+    @Test func offScheduleWording() {
+        let scheduled = Self.scheduled
+        #expect(MatchTimesViewModel.offSchedule(actual: scheduled, scheduled: scheduled) == "on time")
+        #expect(MatchTimesViewModel.offSchedule(actual: scheduled + 20, scheduled: scheduled) == "on time")
+        #expect(MatchTimesViewModel.offSchedule(actual: scheduled + 720, scheduled: scheduled) == "12m late")
+        #expect(MatchTimesViewModel.offSchedule(actual: scheduled - 720, scheduled: scheduled) == "12m early")
+        #expect(MatchTimesViewModel.offSchedule(actual: scheduled + 3600, scheduled: scheduled) == "1h late")
+        #expect(MatchTimesViewModel.offSchedule(actual: scheduled - 3900, scheduled: scheduled) == "1h 5m early")
+    }
+
+    // MARK: - Test helpers
+
+    private static func makeMatch(time: Int64?, actualTime: Int64?, predictedTime: Int64?) -> Match {
+        Match(
+            key: "2026miket_qm1",
+            compLevel: .qm,
+            setNumber: 1,
+            matchNumber: 1,
+            alliances: Match.AlliancesPayload(
+                red: MatchAlliance(score: -1, teamKeys: [], surrogateTeamKeys: [], dqTeamKeys: []),
+                blue: MatchAlliance(score: -1, teamKeys: [], surrogateTeamKeys: [], dqTeamKeys: [])
+            ),
+            winningAlliance: ._empty_,
+            eventKey: "2026miket",
+            time: time,
+            actualTime: actualTime,
+            predictedTime: predictedTime,
+            videos: []
+        )
+    }
+
+}

--- a/TBAUnitTests/ViewModels/Match/MatchTimesViewModelTests.swift
+++ b/TBAUnitTests/ViewModels/Match/MatchTimesViewModelTests.swift
@@ -39,7 +39,7 @@ struct MatchTimesViewModelTests {
         #expect(viewModel.rows.isEmpty)
     }
 
-    @Test func rowsFollowTheEventClockByDefault() {
+    @Test func rowsFollowTheEventClockWhenNotShowingDeviceTime() {
         let viewModel = Self.makeViewModel(
             time: Self.scheduled,
             actualTime: Self.scheduled + 120,
@@ -56,7 +56,7 @@ struct MatchTimesViewModelTests {
         )
     }
 
-    @Test func toggleMovesRowsToTheDeviceClock() {
+    @Test func showingDeviceTimeMovesRowsToTheDeviceClock() {
         let viewModel = Self.makeViewModel(time: Self.scheduled, showsDeviceTimeZone: true)
         #expect(viewModel.rows.map(\.value) == ["Sat, Mar 7", Self.am("6:30")])
     }
@@ -87,17 +87,35 @@ struct MatchTimesViewModelTests {
 
     @Test func offScheduleWording() {
         let scheduled = Self.scheduled
-        #expect(MatchTimesViewModel.offSchedule(actual: scheduled, scheduled: scheduled) == "on time")
-        #expect(MatchTimesViewModel.offSchedule(actual: scheduled + 20, scheduled: scheduled) == "on time")
-        #expect(MatchTimesViewModel.offSchedule(actual: scheduled + 720, scheduled: scheduled) == "12m late")
-        #expect(MatchTimesViewModel.offSchedule(actual: scheduled - 720, scheduled: scheduled) == "12m early")
-        #expect(MatchTimesViewModel.offSchedule(actual: scheduled + 3600, scheduled: scheduled) == "1h late")
-        #expect(MatchTimesViewModel.offSchedule(actual: scheduled - 3900, scheduled: scheduled) == "1h 5m early")
+        #expect(
+            MatchTimesViewModel.offSchedule(actual: scheduled, scheduled: scheduled) == "on time"
+        )
+        #expect(
+            MatchTimesViewModel.offSchedule(actual: scheduled + 20, scheduled: scheduled)
+                == "on time"
+        )
+        #expect(
+            MatchTimesViewModel.offSchedule(actual: scheduled + 720, scheduled: scheduled)
+                == "12m late"
+        )
+        #expect(
+            MatchTimesViewModel.offSchedule(actual: scheduled - 720, scheduled: scheduled)
+                == "12m early"
+        )
+        #expect(
+            MatchTimesViewModel.offSchedule(actual: scheduled + 3600, scheduled: scheduled)
+                == "1h late"
+        )
+        #expect(
+            MatchTimesViewModel.offSchedule(actual: scheduled - 3900, scheduled: scheduled)
+                == "1h 5m early"
+        )
     }
 
     // MARK: - Test helpers
 
-    private static func makeMatch(time: Int64?, actualTime: Int64?, predictedTime: Int64?) -> Match {
+    private static func makeMatch(time: Int64?, actualTime: Int64?, predictedTime: Int64?) -> Match
+    {
         Match(
             key: "2026miket_qm1",
             compLevel: .qm,

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,3 +1,3 @@
-Hey y'all - this release is mostly under the hood: the app has been rebuilt for Swift 6. The myTBA sign-in screen got a refresh, and signing out of myTBA now reliably stops push notifications on that device.
+Hey y'all - this release is mostly under the hood: the app has been rebuilt for Swift 6. The myTBA sign-in screen got a refresh, match pages now show scheduled, predicted, and actual start times, and signing out of myTBA now reliably stops push notifications on that device.
 
 The Blue Alliance is built and maintained by volunteers - help us build The Blue Alliance for iOS at https://github.com/the-blue-alliance

--- a/fastlane/release_notes/beta.md
+++ b/fastlane/release_notes/beta.md
@@ -2,6 +2,7 @@ The Blue Alliance v3.6.0
 
 What's new:
 - The myTBA sign-in screen has been rebuilt, with matching Google and Apple buttons that follow light/dark appearance
+- A match's Info tab now shows its date and its actual, scheduled, and predicted start times, with how far off schedule it ran. Times are in the event's timezone, with a switch to show them in yours
 
 Bug fixes:
 - Signing out of myTBA now guarantees this device stops receiving push notifications, even if the TBA API is unreachable — if the device is fully offline, sign-out says so and leaves you signed in rather than leaving notifications on
@@ -9,6 +10,7 @@ Bug fixes:
 - Changing the cache policy in Settings while a screen is refreshing no longer races the in-flight request
 
 Please poke at:
+- Match → Info on a played match: the Match Times section, and the "Show in my timezone" switch on an event outside your timezone
 - Sign in with Google and with Apple; sign out; force-quit and relaunch and confirm the session restores
 - Airplane mode, then Sign Out — expect a clear error and to still be signed in
 - Tap a push notification and confirm it opens the right screen — this is the one runtime path the Swift 6 move changes

--- a/fastlane/release_notes/beta.md
+++ b/fastlane/release_notes/beta.md
@@ -2,7 +2,7 @@ The Blue Alliance v3.6.0
 
 What's new:
 - The myTBA sign-in screen has been rebuilt, with matching Google and Apple buttons that follow light/dark appearance
-- A match's Info tab now shows its date and its actual, scheduled, and predicted start times, with how far off schedule it ran. Times are in your timezone, with a switch to show them in the event's instead
+- A match's Info tab now shows its date and its actual, scheduled, and predicted start times, with how far off schedule it ran. Times are in the event's timezone, with a switch to show them in yours
 
 Bug fixes:
 - Signing out of myTBA now guarantees this device stops receiving push notifications, even if the TBA API is unreachable — if the device is fully offline, sign-out says so and leaves you signed in rather than leaving notifications on
@@ -10,7 +10,7 @@ Bug fixes:
 - Changing the cache policy in Settings while a screen is refreshing no longer races the in-flight request
 
 Please poke at:
-- Match → Info on a played match: the Match Times section, and the "Show in my timezone" switch on an event outside your timezone. It starts on, so turning it off should shift every time to the event's clock
+- Match → Info on a played match: the Match Times section, and the "Show in my timezone" switch on an event outside your timezone
 - Sign in with Google and with Apple; sign out; force-quit and relaunch and confirm the session restores
 - Airplane mode, then Sign Out — expect a clear error and to still be signed in
 - Tap a push notification and confirm it opens the right screen — this is the one runtime path the Swift 6 move changes

--- a/fastlane/release_notes/beta.md
+++ b/fastlane/release_notes/beta.md
@@ -2,7 +2,7 @@ The Blue Alliance v3.6.0
 
 What's new:
 - The myTBA sign-in screen has been rebuilt, with matching Google and Apple buttons that follow light/dark appearance
-- A match's Info tab now shows its date and its actual, scheduled, and predicted start times, with how far off schedule it ran. Times are in the event's timezone, with a switch to show them in yours
+- A match's Info tab now shows its date and its actual, scheduled, and predicted start times, with how far off schedule it ran. Times are in your timezone, with a switch to show them in the event's instead
 
 Bug fixes:
 - Signing out of myTBA now guarantees this device stops receiving push notifications, even if the TBA API is unreachable — if the device is fully offline, sign-out says so and leaves you signed in rather than leaving notifications on
@@ -10,7 +10,7 @@ Bug fixes:
 - Changing the cache policy in Settings while a screen is refreshing no longer races the in-flight request
 
 Please poke at:
-- Match → Info on a played match: the Match Times section, and the "Show in my timezone" switch on an event outside your timezone
+- Match → Info on a played match: the Match Times section, and the "Show in my timezone" switch on an event outside your timezone. It starts on, so turning it off should shift every time to the event's clock
 - Sign in with Google and with Apple; sign out; force-quit and relaunch and confirm the session restores
 - Airplane mode, then Sign Out — expect a clear error and to still be signed in
 - Tap a push notification and confirm it opens the right screen — this is the one runtime path the Swift 6 move changes

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		92AA7A072F0100000007AAAA /* SessionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA7A062F0100000006AAAA /* SessionMocks.swift */; };
 		92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */; };
 		5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000001 /* EventSectionTests.swift */; };
+		5EC0D41A2C26091000000006 /* MatchTimesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26091000000005 /* MatchTimesViewModelTests.swift */; };
 		5EC0D41A2C26060100000004 /* WeekEventsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */; };
 		5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000001 /* DependenciesMocks.swift */; };
 		5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */; };
@@ -140,6 +141,7 @@
 		92B55631215FDA9000C1D9A3 /* BasicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B55630215FDA9000C1D9A3 /* BasicTableViewCell.swift */; };
 		92B55633215FDB5300C1D9A3 /* BasicCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B55632215FDB5300C1D9A3 /* BasicCollectionViewCell.swift */; };
 		92B5565E21601D9000C1D9A3 /* MatchSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B5565D21601D9000C1D9A3 /* MatchSummaryView.swift */; };
+		5EC0D41A2C26091000000004 /* MatchTimesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26091000000003 /* MatchTimesView.swift */; };
 		92B5566021601D9B00C1D9A3 /* MatchSummaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 92B5565F21601D9B00C1D9A3 /* MatchSummaryView.xib */; };
 		92BB8B64214F17440035AF28 /* URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BB8B63214F17440035AF28 /* URLOpener.swift */; };
 		92C079C723F99CA400AE2AFA /* EventInsightsConfigurator2020.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C079C623F99CA400AE2AFA /* EventInsightsConfigurator2020.swift */; };
@@ -202,6 +204,7 @@
 		3604CAAD303FEEBD00DC500B /* Offseason.icon in Resources */ = {isa = PBXBuildFile; fileRef = 3604CAA9303FEEBD00DC500B /* Offseason.icon */; };
 		AA00000000000000000AA003 /* MatchSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000AA004 /* MatchSection.swift */; };
 		AA00000000000000000AA007 /* AllianceLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000AA008 /* AllianceLookup.swift */; };
+		5EC0D41A2C26091000000002 /* MatchTimesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26091000000001 /* MatchTimesViewModel.swift */; };
 		AA00000000000000000AA009 /* AllianceBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000AA00A /* AllianceBadgeView.swift */; };
 		BA0000000000000000000002 /* EventSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0000000000000000000001 /* EventSection.swift */; };
 		D105BC4723E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift in Sources */ = {isa = PBXBuildFile; fileRef = D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */; };
@@ -245,6 +248,7 @@
 		92AA7A062F0100000006AAAA /* SessionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/SessionMocks.swift"; sourceTree = "<group>"; };
 		92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Services/MyTBASessionServiceTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000001 /* EventSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModels/Event/EventSectionTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26091000000005 /* MatchTimesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModels/Match/MatchTimesViewModelTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Events/WeekEventsViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000001 /* DependenciesMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/DependenciesMocks.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Match/MatchBreakdownViewControllerTests.swift"; sourceTree = "<group>"; };
@@ -345,6 +349,7 @@
 		92B55630215FDA9000C1D9A3 /* BasicTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTableViewCell.swift; sourceTree = "<group>"; };
 		92B55632215FDB5300C1D9A3 /* BasicCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicCollectionViewCell.swift; sourceTree = "<group>"; };
 		92B5565D21601D9000C1D9A3 /* MatchSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchSummaryView.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26091000000003 /* MatchTimesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchTimesView.swift; sourceTree = "<group>"; };
 		92B5565F21601D9B00C1D9A3 /* MatchSummaryView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MatchSummaryView.xib; sourceTree = "<group>"; };
 		92BB8B63214F17440035AF28 /* URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLOpener.swift; sourceTree = "<group>"; };
 		92C079C623F99CA400AE2AFA /* EventInsightsConfigurator2020.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventInsightsConfigurator2020.swift; sourceTree = "<group>"; };
@@ -404,6 +409,7 @@
 		3604CAA9303FEEBD00DC500B /* Offseason.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = Offseason.icon; sourceTree = "<group>"; };
 		AA00000000000000000AA004 /* MatchSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchSection.swift; sourceTree = "<group>"; };
 		AA00000000000000000AA008 /* AllianceLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllianceLookup.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26091000000001 /* MatchTimesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchTimesViewModel.swift; sourceTree = "<group>"; };
 		AA00000000000000000AA00A /* AllianceBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllianceBadgeView.swift; sourceTree = "<group>"; };
 		BA0000000000000000000001 /* EventSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSection.swift; sourceTree = "<group>"; };
 		D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2020.swift; sourceTree = "<group>"; };
@@ -470,6 +476,7 @@
 			children = (
 				92B5565F21601D9B00C1D9A3 /* MatchSummaryView.xib */,
 				92B5565D21601D9000C1D9A3 /* MatchSummaryView.swift */,
+				5EC0D41A2C26091000000003 /* MatchTimesView.swift */,
 				145C57B61ED378E2004955B2 /* MatchTableViewCell.xib */,
 				145C57B41ED377EB004955B2 /* MatchTableViewCell.swift */,
 				1479693F215E9A580075AF4E /* MatchViewModel.swift */,
@@ -609,6 +616,7 @@
 				92AA7A062F0100000006AAAA /* SessionMocks.swift */,
 				92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */,
 				5EC0D41A2C26060100000001 /* EventSectionTests.swift */,
+				5EC0D41A2C26091000000005 /* MatchTimesViewModelTests.swift */,
 				5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */,
 				5EC0D41A2C26070100000001 /* DependenciesMocks.swift */,
 				5EC0D41A2C26070100000003 /* MatchBreakdownViewControllerTests.swift */,
@@ -1046,6 +1054,7 @@
 			isa = PBXGroup;
 			children = (
 				AA00000000000000000AA008 /* AllianceLookup.swift */,
+				5EC0D41A2C26091000000001 /* MatchTimesViewModel.swift */,
 			);
 			path = Match;
 			sourceTree = "<group>";
@@ -1293,6 +1302,7 @@
 				92AA7A072F0100000007AAAA /* SessionMocks.swift in Sources */,
 				92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */,
 				5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */,
+				5EC0D41A2C26091000000006 /* MatchTimesViewModelTests.swift in Sources */,
 				5EC0D41A2C26060100000004 /* WeekEventsViewControllerTests.swift in Sources */,
 				5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */,
 				5EC0D41A2C26070100000004 /* MatchBreakdownViewControllerTests.swift in Sources */,
@@ -1323,6 +1333,7 @@
 				BA0000000000000000000002 /* EventSection.swift in Sources */,
 				AA00000000000000000AA003 /* MatchSection.swift in Sources */,
 				AA00000000000000000AA007 /* AllianceLookup.swift in Sources */,
+				5EC0D41A2C26091000000002 /* MatchTimesViewModel.swift in Sources */,
 				AA00000000000000000AA009 /* AllianceBadgeView.swift in Sources */,
 				92A5E5DD21A22D550025CC85 /* Int16+Suffix.swift in Sources */,
 				514C2EF52F8F0D5F00C674A9 /* MatchBreakdownConfigurator2026.swift in Sources */,
@@ -1368,6 +1379,7 @@
 				9280B54523CEBDE70021FEBE /* MatchBreakdownConfigurator2015.swift in Sources */,
 				92C9BD3B2096BBA5007FB9C8 /* MyTBATableViewController.swift in Sources */,
 				92B5565E21601D9000C1D9A3 /* MatchSummaryView.swift in Sources */,
+				5EC0D41A2C26091000000004 /* MatchTimesView.swift in Sources */,
 				9280B54923CEBFA00021FEBE /* MatchBreakdownConfigurator2016.swift in Sources */,
 				92FF111821A61B37003BC5C4 /* DistrictBreakdownViewController.swift in Sources */,
 				14796946215EB0B90075AF4E /* RankingCellViewModel.swift in Sources */,

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -9,7 +9,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     private let teamKey: String?
 
     private var event: Event?
-    private var showsDeviceTimeZone = false
+    private var showsDeviceTimeZone = true
 
     // MARK: - UI
 
@@ -194,6 +194,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
             showsDeviceTimeZone: showsDeviceTimeZone
         )
         matchTimesView.viewModel = viewModel
+        matchTimesView.timeZoneSwitch.isOn = showsDeviceTimeZone
         matchTimesView.isHidden = viewModel.isEmpty
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -9,6 +9,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     private let teamKey: String?
 
     private var event: Event?
+    private var showsDeviceTimeZone = false
 
     // MARK: - UI
 
@@ -56,6 +57,19 @@ class MatchInfoViewController: TBAViewController, Refreshable {
         return matchStackView
     }()
 
+    private lazy var matchTimesView: MatchTimesView = {
+        let matchTimesView = MatchTimesView()
+        matchTimesView.timeZoneSwitch.addAction(
+            UIAction { [weak self] action in
+                guard let self, let timeZoneSwitch = action.sender as? UISwitch else { return }
+                self.showsDeviceTimeZone = timeZoneSwitch.isOn
+                self.updateMatchTimes()
+            },
+            for: .valueChanged
+        )
+        return matchTimesView
+    }()
+
     private let videoStackView: UIStackView = {
         let videoStackView = UIStackView(forAutoLayout: ())
         videoStackView.axis = .vertical
@@ -64,6 +78,16 @@ class MatchInfoViewController: TBAViewController, Refreshable {
         videoStackView.spacing = 10
         videoStackView.translatesAutoresizingMaskIntoConstraints = false
         return videoStackView
+    }()
+
+    // A stack view so the times section collapses when it has nothing to show.
+    private lazy var contentStackView: UIStackView = {
+        let contentStackView = UIStackView(arrangedSubviews: [
+            matchStackView, matchTimesView, videoStackView,
+        ])
+        contentStackView.axis = .vertical
+        contentStackView.spacing = 8
+        return contentStackView
     }()
 
     var matchSummaryDelegate: (any MatchSummaryViewDelegate)? {
@@ -108,12 +132,13 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     // MARK: Interface Methods
 
     func styleInterface() {
-        scrollView.addSubview(matchStackView)
-        matchStackView.autoSetDimension(.height, toSize: 90)
-        matchStackView.autoPinEdge(.top, to: .top, of: scrollView, withOffset: 8)
-        matchStackView.autoPinEdge(toSuperviewSafeArea: .leading, withInset: 16)
-        matchStackView.autoPinEdge(toSuperviewSafeArea: .trailing, withInset: 16)
+        scrollView.addSubview(contentStackView)
+        contentStackView.autoPinEdge(.top, to: .top, of: scrollView, withOffset: 8)
+        contentStackView.autoPinEdge(toSuperviewSafeArea: .leading, withInset: 16)
+        contentStackView.autoPinEdge(toSuperviewSafeArea: .trailing, withInset: 16)
+        contentStackView.autoPinEdge(toSuperviewEdge: .bottom)
 
+        matchStackView.autoSetDimension(.height, toSize: 90)
         infoStackView.autoMatch(
             .height,
             to: .height,
@@ -131,18 +156,13 @@ class MatchInfoViewController: TBAViewController, Refreshable {
             withMultiplier: 0.25
         )
 
-        scrollView.addSubview(videoStackView)
-        videoStackView.autoPinEdge(.top, to: .bottom, of: matchStackView, withOffset: 8)
-        videoStackView.autoPinEdge(toSuperviewSafeArea: .leading, withInset: 16)
-        videoStackView.autoPinEdge(toSuperviewSafeArea: .trailing, withInset: 16)
-        videoStackView.autoPinEdge(toSuperviewEdge: .bottom)
-
         // Override our default background color to be white
         view.backgroundColor = .systemBackground
     }
 
     func updateInterface() {
         updateMatchSummaryView()
+        updateMatchTimes()
         updateMatchVideos()
     }
 
@@ -161,6 +181,20 @@ class MatchInfoViewController: TBAViewController, Refreshable {
         matchSummaryView.viewModel = viewModel
 
         scoreTitleLabel.text = viewModel.hasScores ? "Score" : "Time"
+    }
+
+    func updateMatchTimes() {
+        guard let match = state.match else {
+            matchTimesView.isHidden = true
+            return
+        }
+        let viewModel = MatchTimesViewModel(
+            match: match,
+            eventTimeZone: event?.timeZone,
+            showsDeviceTimeZone: showsDeviceTimeZone
+        )
+        matchTimesView.viewModel = viewModel
+        matchTimesView.isHidden = viewModel.isEmpty
     }
 
     func updateMatchVideos() {

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -9,7 +9,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     private let teamKey: String?
 
     private var event: Event?
-    private var showsDeviceTimeZone = true
+    private var showsDeviceTimeZone = false
 
     // MARK: - UI
 

--- a/the-blue-alliance-ios/ViewElements/Match/MatchTimesView.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchTimesView.swift
@@ -1,0 +1,138 @@
+import PureLayout
+import UIKit
+
+class MatchTimesView: UIView {
+
+    var viewModel: MatchTimesViewModel? {
+        didSet {
+            configureView()
+        }
+    }
+
+    let timeZoneSwitch = UISwitch()
+
+    private static let rowFont = UIFontMetrics(forTextStyle: .body).scaledFont(
+        for: UIFont.systemFont(ofSize: 14)
+    )
+    private static let valueFont = UIFontMetrics(forTextStyle: .body).scaledFont(
+        for: UIFont.systemFont(ofSize: 14, weight: .medium)
+    )
+
+    private let headerLabel: UILabel = {
+        let label = UILabel(forAutoLayout: ())
+        label.text = "Match Times"
+        label.font = UIFontMetrics(forTextStyle: .body).scaledFont(
+            for: UIFont.systemFont(ofSize: 16, weight: .medium)
+        )
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var headerView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [headerLabel])
+        stackView.backgroundColor = UIColor.systemFill
+        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        return stackView
+    }()
+
+    private let rowsStackView: UIStackView = {
+        let stackView = UIStackView(forAutoLayout: ())
+        stackView.axis = .vertical
+        stackView.spacing = 4
+        return stackView
+    }()
+
+    private lazy var timeZoneRow: UIStackView = {
+        let label = UILabel(forAutoLayout: ())
+        label.text = "Show in my timezone"
+        label.font = Self.rowFont
+        label.adjustsFontForContentSizeCategory = true
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        let stackView = UIStackView(arrangedSubviews: [label, Self.spacerView(), timeZoneSwitch])
+        stackView.alignment = .center
+        stackView.spacing = 8
+        return stackView
+    }()
+
+    // MARK: - Init
+
+    init() {
+        super.init(frame: .zero)
+
+        let contentStackView = UIStackView(arrangedSubviews: [rowsStackView, timeZoneRow])
+        contentStackView.axis = .vertical
+        contentStackView.spacing = 8
+        contentStackView.layoutMargins = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+        contentStackView.isLayoutMarginsRelativeArrangement = true
+
+        let stackView = UIStackView(arrangedSubviews: [headerView, contentStackView])
+        stackView.axis = .vertical
+        addSubview(stackView)
+        stackView.autoPinEdgesToSuperviewEdges()
+
+        headerView.autoSetDimension(.height, toSize: 30)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Private Methods
+
+    private func configureView() {
+        for view in rowsStackView.arrangedSubviews {
+            rowsStackView.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+        guard let viewModel else { return }
+
+        for row in viewModel.rows {
+            rowsStackView.addArrangedSubview(Self.rowView(for: row))
+        }
+        timeZoneRow.isHidden = !viewModel.canToggleTimeZone
+    }
+
+    private static func rowView(for row: MatchTimesViewModel.Row) -> UIView {
+        let titleLabel = UILabel(forAutoLayout: ())
+        titleLabel.text = row.title
+        titleLabel.font = rowFont
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.textColor = UIColor.secondaryLabel
+
+        let valueLabel = UILabel(forAutoLayout: ())
+        valueLabel.text = row.value
+        valueLabel.font = valueFont
+        valueLabel.adjustsFontForContentSizeCategory = true
+
+        var trailingLabels: [UILabel] = []
+        if let detail = row.detail {
+            let detailLabel = UILabel(forAutoLayout: ())
+            detailLabel.text = "(\(detail))"
+            detailLabel.font = rowFont
+            detailLabel.adjustsFontForContentSizeCategory = true
+            detailLabel.textColor = UIColor.secondaryLabel
+            trailingLabels.append(detailLabel)
+        }
+        trailingLabels.append(valueLabel)
+
+        for label in [titleLabel] + trailingLabels {
+            label.setContentHuggingPriority(.required, for: .horizontal)
+        }
+
+        let stackView = UIStackView(
+            arrangedSubviews: [titleLabel, spacerView()] + trailingLabels
+        )
+        stackView.spacing = 4
+        return stackView
+    }
+
+    // Low compression resistance so the gap closes before a label truncates.
+    private static func spacerView() -> UIView {
+        let spacer = UIView(forAutoLayout: ())
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return spacer
+    }
+
+}

--- a/the-blue-alliance-ios/ViewModels/Match/MatchTimesViewModel.swift
+++ b/the-blue-alliance-ios/ViewModels/Match/MatchTimesViewModel.swift
@@ -1,0 +1,108 @@
+import Foundation
+import TBAAPI
+
+struct MatchTimesViewModel: Equatable {
+
+    struct Row: Equatable {
+        let title: String
+        let value: String
+        // How far off schedule the actual start was.
+        let detail: String?
+    }
+
+    let rows: [Row]
+    let canToggleTimeZone: Bool
+
+    var isEmpty: Bool { rows.isEmpty }
+
+    init(
+        match: Match,
+        eventTimeZone: TimeZone?,
+        showsDeviceTimeZone: Bool,
+        deviceTimeZone: TimeZone = .current,
+        locale: Locale = .current
+    ) {
+        let reference = match.actualTime ?? match.time ?? match.predictedTime
+        let referenceDate = reference.map(Self.date)
+
+        canToggleTimeZone = Self.clocksDiffer(
+            eventTimeZone,
+            deviceTimeZone,
+            at: referenceDate ?? Date()
+        )
+        // Without an event timezone there's nothing to translate from, so
+        // stay on the device's clock like the match list does.
+        let timeZone: TimeZone
+        if let eventTimeZone, canToggleTimeZone, !showsDeviceTimeZone {
+            timeZone = eventTimeZone
+        } else {
+            timeZone = deviceTimeZone
+        }
+
+        let dateStyle = Date.FormatStyle(locale: locale, timeZone: timeZone)
+            .weekday(.abbreviated).month(.abbreviated).day()
+        let timeStyle = Date.FormatStyle(locale: locale, timeZone: timeZone).hour().minute()
+
+        var rows: [Row] = []
+        if let referenceDate {
+            rows.append(Row(title: "Date", value: referenceDate.formatted(dateStyle), detail: nil))
+        }
+        if let actual = match.actualTime {
+            let detail = match.time.map { Self.offSchedule(actual: actual, scheduled: $0) }
+            rows.append(
+                Row(title: "Actual", value: Self.date(actual).formatted(timeStyle), detail: detail)
+            )
+        }
+        if let scheduled = match.time {
+            rows.append(
+                Row(
+                    title: "Scheduled",
+                    value: Self.date(scheduled).formatted(timeStyle),
+                    detail: nil
+                )
+            )
+        }
+        if let predicted = match.predictedTime {
+            rows.append(
+                Row(
+                    title: "Predicted",
+                    value: Self.date(predicted).formatted(timeStyle),
+                    detail: nil
+                )
+            )
+        }
+        self.rows = rows
+    }
+
+    private static func date(_ unixSeconds: Int64) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(unixSeconds))
+    }
+
+    // Compares offsets rather than identifiers so Detroit and New York, which
+    // keep the same clock, don't offer a toggle that changes nothing.
+    private static func clocksDiffer(_ event: TimeZone?, _ device: TimeZone, at date: Date) -> Bool
+    {
+        guard let event else { return false }
+        return event.secondsFromGMT(for: date) != device.secondsFromGMT(for: date)
+    }
+
+    static func offSchedule(actual: Int64, scheduled: Int64) -> String {
+        let minutes = Int((Double(actual - scheduled) / 60).rounded())
+        if minutes == 0 {
+            return "on time"
+        }
+        let magnitude = abs(minutes)
+        let hours = magnitude / 60
+        let remainder = magnitude % 60
+        let duration: String
+        if hours == 0 {
+            duration = "\(magnitude)m"
+        } else if remainder == 0 {
+            duration = "\(hours)h"
+        } else {
+            duration = "\(hours)h \(remainder)m"
+        }
+        return "\(duration) \(minutes > 0 ? "late" : "early")"
+    }
+
+}


### PR DESCRIPTION
Fixes #1103.

Adds a Match Times section to a match's Info tab, between the summary and the videos, mirroring the PWA's match details. It lists the date and whichever of the actual, scheduled, and predicted start times the API has, and notes how far off schedule the match ran.

Times render in the event's timezone. When the event's clock differs from the device's, a "Show in my timezone" switch appears, off by default, matching how the PWA's match details behaves. Offsets are compared rather than timezone identifiers, so an event in a different zone on the same clock does not offer a switch that changes nothing. A match with no times at all hides the section.

One deliberate difference from the PWA: when an event has no timezone at all, the PWA falls back to UTC, while this falls back to the device's clock, matching how the match list already shows times. Showing everyone UTC seemed worse than showing them their own clock.

Rows put the title on the leading edge and the time on the trailing edge, so the times line up down the column.

New `MatchTimesViewModel` holds the row and timezone rules and is covered by unit tests: row selection, both clocks, the two no-toggle cases, and the off-schedule wording.

## Screenshots

Verified in the simulator against 2026 Central Valley finals 1, a Pacific event on an Eastern device.

| | Date | Actual | Scheduled | Predicted |
| --- | --- | --- | --- | --- |
| Default, event's clock | Sun, Mar 29 | 4:59 PM (1h 5m late) | 3:54 PM | 4:51 PM |
| Switch on, viewer's clock | Sun, Mar 29 | 7:59 PM (1h 5m late) | 6:54 PM | 7:51 PM |

## Check out locally

```
git fetch origin
git worktree add ../tba-ios-times origin/zach/match-times
cd ../tba-ios-times
ln -s ../../../../the-blue-alliance-ios/Secrets.plist the-blue-alliance-ios/Secrets.plist
open the-blue-alliance-ios.xcodeproj
```

Clean up with `git worktree remove ../tba-ios-times`.

## Test plan

- Match → Info on a played match. Expect Date, Actual, Scheduled, Predicted, with a late or early note on Actual.
- A match at an event outside your timezone. Expect the "Show in my timezone" switch off, and every time to shift to your clock when you turn it on.
- A match at an event in your own timezone. Expect no switch.
- An unplayed match with only a scheduled or predicted time. Expect just those rows and no delay note.
- A 2014 or older match with no times. Expect no Match Times section at all.