### PR TITLE
Show event divisions on the Event Info tab

### DIFF
--- a/TBAUnitTests/ViewModels/Event/EventDivisionsViewModelTests.swift
+++ b/TBAUnitTests/ViewModels/Event/EventDivisionsViewModelTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import TBAAPI
+import Testing
+
+@testable import The_Blue_Alliance
+
+@MainActor
+struct EventDivisionsViewModelTests {
+
+    private static let championshipKey = "2026cmptx"
+    private static let divisionKeys = ["2026arc", "2026cur", "2026joh"]
+
+    private static func makeAPI() -> MockTBAAPI {
+        let api = MockTBAAPI()
+        api.eventsByKey[championshipKey] = event(
+            key: championshipKey,
+            name: "Einstein Field",
+            shortName: "Einstein",
+            divisionKeys: divisionKeys
+        )
+        for key in divisionKeys {
+            api.eventsByKey[key] = event(
+                key: key,
+                name: "\(key.dropFirst(4).capitalized) Division",
+                shortName: String(key.dropFirst(4)).capitalized,
+                parentEventKey: championshipKey
+            )
+        }
+        return api
+    }
+
+    @Test func championshipListsItsOwnDivisions() async {
+        let api = Self.makeAPI()
+        let viewModel = await EventDivisionsViewModel.load(
+            for: api.eventsByKey[Self.championshipKey]!,
+            api: api
+        )
+        #expect(viewModel.others.map(\.key) == Self.divisionKeys)
+        #expect(viewModel.parent == nil)
+        #expect(viewModel.menuTitle == "Event Divisions")
+    }
+
+    @Test func divisionListsItsSiblingsAndItsParent() async {
+        let api = Self.makeAPI()
+        let viewModel = await EventDivisionsViewModel.load(
+            for: api.eventsByKey["2026arc"]!,
+            api: api
+        )
+        // Siblings come from the parent, and the division itself is excluded.
+        #expect(viewModel.others.map(\.key) == ["2026cur", "2026joh"])
+        #expect(viewModel.parent?.key == Self.championshipKey)
+        #expect(viewModel.menuTitle == "Other Divisions")
+    }
+
+    @Test func menuUsesShortNamesAndTheRowUsesFullNames() async {
+        let api = Self.makeAPI()
+        let viewModel = await EventDivisionsViewModel.load(
+            for: api.eventsByKey["2026arc"]!,
+            api: api
+        )
+        #expect(viewModel.others.map(\.shortName) == ["Cur", "Joh"])
+        #expect(viewModel.parent?.name == "Einstein Field")
+    }
+
+    @Test func eventWithNeitherDivisionsNorParentHasNothingToShow() async {
+        let api = MockTBAAPI()
+        let regional = Self.event(key: "2026caclv", name: "CA District Central Valley Event")
+        let viewModel = await EventDivisionsViewModel.load(for: regional, api: api)
+        #expect(viewModel.isEmpty)
+        #expect(viewModel.menuTitle == nil)
+    }
+
+    @Test func aDivisionThatFailsToLoadIsSkippedRatherThanFailingTheRest() async {
+        let api = Self.makeAPI()
+        api.eventsByKey["2026cur"] = nil
+        let viewModel = await EventDivisionsViewModel.load(
+            for: api.eventsByKey[Self.championshipKey]!,
+            api: api
+        )
+        #expect(viewModel.others.map(\.key) == ["2026arc", "2026joh"])
+    }
+
+    @Test func aDivisionWhoseParentFailsToLoadShowsNothing() async {
+        let api = Self.makeAPI()
+        let division = api.eventsByKey["2026arc"]!
+        api.eventsByKey[Self.championshipKey] = nil
+        let viewModel = await EventDivisionsViewModel.load(for: division, api: api)
+        #expect(viewModel.isEmpty)
+        #expect(viewModel.menuTitle == nil)
+    }
+
+    // MARK: - Test helpers
+
+    private static func event(
+        key: String,
+        name: String,
+        shortName: String? = nil,
+        divisionKeys: [String] = [],
+        parentEventKey: String? = nil
+    ) -> Event {
+        Event(
+            key: key,
+            name: name,
+            eventCode: String(key.dropFirst(4)),
+            eventType: ._0,
+            startDate: "2026-04-29",
+            endDate: "2026-05-02",
+            year: 2026,
+            shortName: shortName,
+            eventTypeString: "",
+            week: nil,
+            webcasts: [],
+            divisionKeys: divisionKeys,
+            parentEventKey: parentEventKey
+        )
+    }
+
+}

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		92AA7A072F0100000007AAAA /* SessionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA7A062F0100000006AAAA /* SessionMocks.swift */; };
 		92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */; };
 		5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000001 /* EventSectionTests.swift */; };
+		5EC0D41A2C26091100000004 /* EventDivisionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26091100000003 /* EventDivisionsViewModelTests.swift */; };
 		5EC0D41A2C26091000000006 /* MatchTimesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26091000000005 /* MatchTimesViewModelTests.swift */; };
 		5EC0D41A2C26060100000004 /* WeekEventsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */; };
 		5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26070100000001 /* DependenciesMocks.swift */; };
@@ -207,6 +208,7 @@
 		5EC0D41A2C26091000000002 /* MatchTimesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26091000000001 /* MatchTimesViewModel.swift */; };
 		AA00000000000000000AA009 /* AllianceBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000AA00A /* AllianceBadgeView.swift */; };
 		BA0000000000000000000002 /* EventSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0000000000000000000001 /* EventSection.swift */; };
+		5EC0D41A2C26091100000002 /* EventDivisionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26091100000001 /* EventDivisionsViewModel.swift */; };
 		D105BC4723E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift in Sources */ = {isa = PBXBuildFile; fileRef = D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */; };
 		5EC0D41A2C26090100000002 /* FeatureFlagsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090100000001 /* FeatureFlagsStore.swift */; };
 		5EC0D41A2C26090200000002 /* DashboardContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26090200000001 /* DashboardContainerViewController.swift */; };
@@ -248,6 +250,7 @@
 		92AA7A062F0100000006AAAA /* SessionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/SessionMocks.swift"; sourceTree = "<group>"; };
 		92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Services/MyTBASessionServiceTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000001 /* EventSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModels/Event/EventSectionTests.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26091100000003 /* EventDivisionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModels/Event/EventDivisionsViewModelTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26091000000005 /* MatchTimesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModels/Match/MatchTimesViewModelTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewControllers/Events/WeekEventsViewControllerTests.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26070100000001 /* DependenciesMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mocks/DependenciesMocks.swift"; sourceTree = "<group>"; };
@@ -412,6 +415,7 @@
 		5EC0D41A2C26091000000001 /* MatchTimesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchTimesViewModel.swift; sourceTree = "<group>"; };
 		AA00000000000000000AA00A /* AllianceBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllianceBadgeView.swift; sourceTree = "<group>"; };
 		BA0000000000000000000001 /* EventSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSection.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26091100000001 /* EventDivisionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDivisionsViewModel.swift; sourceTree = "<group>"; };
 		D105BC4623E5BF1E00378CB5 /* MatchBreakdownConfigurator2020.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2020.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26090100000001 /* FeatureFlagsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsStore.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26090200000001 /* DashboardContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardContainerViewController.swift; sourceTree = "<group>"; };
@@ -616,6 +620,7 @@
 				92AA7A062F0100000006AAAA /* SessionMocks.swift */,
 				92AA7A082F0100000008AAAA /* MyTBASessionServiceTests.swift */,
 				5EC0D41A2C26060100000001 /* EventSectionTests.swift */,
+				5EC0D41A2C26091100000003 /* EventDivisionsViewModelTests.swift */,
 				5EC0D41A2C26091000000005 /* MatchTimesViewModelTests.swift */,
 				5EC0D41A2C26060100000003 /* WeekEventsViewControllerTests.swift */,
 				5EC0D41A2C26070100000001 /* DependenciesMocks.swift */,
@@ -728,6 +733,7 @@
 			isa = PBXGroup;
 			children = (
 				BA0000000000000000000001 /* EventSection.swift */,
+				5EC0D41A2C26091100000001 /* EventDivisionsViewModel.swift */,
 				5EC0D41A2C26041700000003 /* WeekEventsGrouping.swift */,
 			);
 			path = Event;
@@ -1302,6 +1308,7 @@
 				92AA7A072F0100000007AAAA /* SessionMocks.swift in Sources */,
 				92AA7A092F0100000009AAAA /* MyTBASessionServiceTests.swift in Sources */,
 				5EC0D41A2C26060100000002 /* EventSectionTests.swift in Sources */,
+				5EC0D41A2C26091100000004 /* EventDivisionsViewModelTests.swift in Sources */,
 				5EC0D41A2C26091000000006 /* MatchTimesViewModelTests.swift in Sources */,
 				5EC0D41A2C26060100000004 /* WeekEventsViewControllerTests.swift in Sources */,
 				5EC0D41A2C26070100000002 /* DependenciesMocks.swift in Sources */,
@@ -1331,6 +1338,7 @@
 				5EC0D41A2C26041700000004 /* WeekEventsGrouping.swift in Sources */,
 				5EC0D41A2C26041700000006 /* EventsListViewController.swift in Sources */,
 				BA0000000000000000000002 /* EventSection.swift in Sources */,
+				5EC0D41A2C26091100000002 /* EventDivisionsViewModel.swift in Sources */,
 				AA00000000000000000AA003 /* MatchSection.swift in Sources */,
 				AA00000000000000000AA007 /* AllianceLookup.swift in Sources */,
 				5EC0D41A2C26091000000002 /* MatchTimesViewModel.swift in Sources */,

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PureLayout
 import TBAAPI
 import UIKit
 
@@ -8,6 +9,7 @@ protocol EventInfoViewControllerDelegate: AnyObject {
     func showDistrictPoints()
     func showInsights()
     func showPitMap()
+    func showEvent(key: String, name: String?)
 }
 
 nonisolated private enum EventInfoSection: Int {
@@ -26,6 +28,7 @@ nonisolated private enum EventInfoItem: Hashable {
     case insights
     case awards
     case website
+    case advancesTo(EventDivision)
 }
 
 class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
@@ -39,6 +42,32 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
     weak var delegate: (any EventInfoViewControllerDelegate)?
 
     private var hasPitMap = false
+    private var divisions = EventDivisionsViewModel()
+
+    private lazy var divisionsButton: UIButton = {
+        var configuration = UIButton.Configuration.tinted()
+        configuration.baseBackgroundColor = UIColor.primaryBlue
+        configuration.baseForegroundColor = UIColor.primaryBlue
+        configuration.image = UIImage(systemName: "chevron.down")
+        configuration.imagePlacement = .trailing
+        configuration.imagePadding = 6
+        configuration.cornerStyle = .capsule
+        configuration.buttonSize = .small
+
+        let button = UIButton(configuration: configuration)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.showsMenuAsPrimaryAction = true
+        return button
+    }()
+
+    private lazy var divisionsHeaderView: UIView = {
+        let headerView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 44))
+        headerView.autoresizingMask = .flexibleWidth
+        headerView.addSubview(divisionsButton)
+        divisionsButton.autoPinEdge(toSuperviewMargin: .trailing)
+        divisionsButton.autoAlignAxis(toSuperviewAxis: .horizontal)
+        return headerView
+    }()
 
     // MARK: - Init
 
@@ -68,6 +97,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
 
         tableView.sectionFooterHeight = 0
         tableView.registerReusableCell(InfoTableViewCell.self)
+        tableView.registerReusableCell(ReverseSubtitleTableViewCell.self)
 
         tableView.dataSource = dataSource
 
@@ -129,6 +159,15 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
                     let cell = self.tableView(tableView, detailCellForRowAtIndexPath: indexPath)
                     cell.textLabel?.text = "View event's website"
                     return cell
+                case .advancesTo(let parent):
+                    let cell =
+                        tableView.dequeueReusableCell(indexPath: indexPath)
+                        as ReverseSubtitleTableViewCell
+                    cell.titleLabel.text = "Winners advance to"
+                    cell.subtitleLabel.text = parent.name
+                    cell.selectionStyle = .default
+                    cell.accessoryType = .disclosureIndicator
+                    return cell
                 }
             }
         )
@@ -141,6 +180,9 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
 
         snapshot.appendSections([.title])
         var titleItems: [EventInfoItem] = [.title]
+        if let parent = divisions.parent {
+            titleItems.append(.advancesTo(parent))
+        }
         if hasPitMap {
             titleItems.append(.pitMap)
         }
@@ -179,7 +221,20 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
             snapshot.appendItems([.website], toSection: .link)
         }
 
+        updateDivisionsHeader()
         dataSource.applySnapshotUsingReloadData(snapshot)
+    }
+
+    private func updateDivisionsHeader() {
+        guard let title = divisions.menuTitle, let menu = divisionsMenu() else {
+            tableView.tableHeaderView = nil
+            return
+        }
+        divisionsButton.configuration?.title = title
+        divisionsButton.menu = menu
+        if tableView.tableHeaderView !== divisionsHeaderView {
+            tableView.tableHeaderView = divisionsHeaderView
+        }
     }
 
     // MARK: - Table View Methods
@@ -236,6 +291,8 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
             urlString = webcast.urlString
         case .website:
             urlString = state.event?.website
+        case .advancesTo(let parent):
+            delegate?.showEvent(key: parent.key, name: parent.name)
         default:
             break
         }
@@ -259,7 +316,23 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
             await probeHandle.value
             self.state = .event(event)
             self.updateEventInfo()
+
+            self.divisions = await EventDivisionsViewModel.load(for: event, api: self.api)
+            self.updateEventInfo()
         }
+    }
+
+    // MARK: - Divisions
+
+    private func divisionsMenu() -> UIMenu? {
+        guard !divisions.others.isEmpty else { return nil }
+        return UIMenu(
+            children: divisions.others.map { division in
+                UIAction(title: division.shortName) { [weak self] _ in
+                    self?.delegate?.showEvent(key: division.key, name: division.name)
+                }
+            }
+        )
     }
 
     // MARK: - Stateful

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -148,6 +148,15 @@ private struct EventSubscribable: MyTBASubscribable {
 
 extension EventViewController: EventInfoViewControllerDelegate {
 
+    func showEvent(key: String, name: String?) {
+        let eventViewController = EventViewController(
+            eventKey: key,
+            name: name,
+            dependencies: dependencies
+        )
+        self.navigationController?.pushViewController(eventViewController, animated: true)
+    }
+
     func showAlliances() {
         guard let event = state.event else { return }
         let eventAlliancesViewController = EventAlliancesContainerViewController(

--- a/the-blue-alliance-ios/ViewModels/Event/EventDivisionsViewModel.swift
+++ b/the-blue-alliance-ios/ViewModels/Event/EventDivisionsViewModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+import TBAAPI
+
+nonisolated struct EventDivision: Hashable {
+    let key: String
+    let name: String
+    let shortName: String
+
+    init(event: Event) {
+        key = event.key
+        name = event.name
+        shortName = event.safeShortName
+    }
+
+    init(key: String, name: String, shortName: String) {
+        self.key = key
+        self.name = name
+        self.shortName = shortName
+    }
+}
+
+/// The events reachable sideways from an event: a championship's own divisions,
+/// or for a division, its siblings and the event its winners advance to.
+nonisolated struct EventDivisionsViewModel: Hashable {
+
+    let others: [EventDivision]
+    let parent: EventDivision?
+
+    var isEmpty: Bool { others.isEmpty && parent == nil }
+
+    /// Titles the picker the way the web does. Only a division has a parent,
+    /// so that alone distinguishes "the rest of them" from "this event's".
+    var menuTitle: String? {
+        guard !others.isEmpty else { return nil }
+        return parent == nil ? "Event Divisions" : "Other Divisions"
+    }
+
+    init(others: [EventDivision] = [], parent: EventDivision? = nil) {
+        self.others = others
+        self.parent = parent
+    }
+
+    static func load(for event: Event, api: any TBAAPIProtocol) async -> EventDivisionsViewModel {
+        var siblingKeys = event.divisionKeys
+        var parentEvent: Event?
+
+        // A division knows its parent but not its siblings, so the parent is
+        // what holds the full list.
+        if siblingKeys.isEmpty, let parentEventKey = event.parentEventKey {
+            parentEvent = try? await api.event(key: parentEventKey)
+            siblingKeys = parentEvent?.divisionKeys ?? []
+        }
+
+        // Task handles rather than a task group, see issue #996.
+        let handles =
+            siblingKeys
+            .filter { $0 != event.key }
+            .map { key in Task { try? await api.event(key: key) } }
+
+        var others: [EventDivision] = []
+        for handle in handles {
+            guard let division = await handle.value else { continue }
+            others.append(EventDivision(event: division))
+        }
+
+        return EventDivisionsViewModel(
+            others: others,
+            parent: parentEvent.map(EventDivision.init(event:))
+        )
+    }
+
+}


### PR DESCRIPTION
Fixes #735.

| Division | Championship | Division (dark) |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/73e02e63-ae4f-415a-86c9-3c9bff2db4b0" width="260"> | <img src="https://github.com/user-attachments/assets/cd83ffe4-7af7-405a-adda-627297e08467" width="260"> | <img src="https://github.com/user-attachments/assets/31a87adb-398c-4c70-b026-ed29e3cd55aa" width="260"> |

A championship's Info tab gets an "Event Divisions" pill in the table header that opens a menu of its divisions. A division gets "Other Divisions" listing the rest of them, plus a "Winners advance to" row under the event info linking to the championship. Both mirror how the web renders it. Events with neither are unchanged.

Division names come from the parent, since a division only knows its parent key and not its siblings. Those fetches run as task handles rather than a task group, per #996.

`EventDivisionsViewModel` holds the loading and naming rules so they're testable. This is the first view model backing a view controller rather than a cell, and the first in `ViewModels/` that fetches; existing types there are pure transforms over data the view controller already has.